### PR TITLE
Add FountainAI repo alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ This repo defines a fully autonomous deployment system where Codex:
 
 No CI runners. No pipelines. Just an always-on deployment brain powered by Codex.
 
+> **Repo Alias**: References to `fountainai` actually point to
+> [`Fountain-Coach/swift-codex-openapi-kernel`](https://github.com/Fountain-Coach/swift-codex-openapi-kernel).
+> The dispatcher clones it under `/srv/fountainai/` for compatibility until the
+> rename is complete.
+
 ---
 
 ## 🧠 What is the Codex-Powered Operating System?

--- a/agent.md
+++ b/agent.md
@@ -37,10 +37,14 @@ The agent pulls and manages the following GitHub repositories:
 
 | Repo               | Purpose                                 |
 |--------------------|------------------------------------------|
-| `fountainai`        | Swift + Python services (main logic layer) |
+| `fountainai` (alias for `swift-codex-openapi-kernel`) | Swift + Python services (main logic layer) |
 | `kong-codex`        | Gateway configuration and plugin definitions |
 | `typesense-codex`   | Typesense indexing schemas and bootstrapping logic |
 | `codex-deployer`    | This repo — hosts the dispatcher, feedback, and loop logic |
+
+> **Note**: `fountainai` refers to the GitHub repo
+> [`Fountain-Coach/swift-codex-openapi-kernel`](https://github.com/Fountain-Coach/swift-codex-openapi-kernel).
+> The agent clones it under `/srv/fountainai/` until the rename is finalized.
 
 These repos are cloned directly — they are **not submodules**. Paths and build logic are mapped semantically in `repo_config.py`.
 

--- a/deploy/dispatcher.py
+++ b/deploy/dispatcher.py
@@ -1,10 +1,6 @@
 import subprocess, os, time, datetime
 
-REPOS = {
-    "fountainai": "https://github.com/fountain-coach/fountainai.git",
-    "kong-codex": "https://github.com/fountain-coach/kong-codex.git",
-    "typesense-codex": "https://github.com/fountain-coach/typesense-codex.git"
-}
+from repo_config import REPOS, ALIASES
 
 LOG_FILE = "/srv/deploy/logs/build.log"
 FEEDBACK_DIR = "/srv/deploy/feedback/"
@@ -17,14 +13,15 @@ def log(msg):
         f.write(f"[{timestamp()}] {msg}\n")
 
 def pull_repos():
-    for name, url in REPOS.items():
-        path = f"/srv/{name}"
+    for alias, url in REPOS.items():
+        path = f"/srv/{alias}"
+        canonical = ALIASES.get(alias, alias)
         if not os.path.exists(path):
             subprocess.run(["git", "clone", url, path])
-            log(f"Cloned {name}")
+            log(f"Cloned {alias} -> {canonical}")
         else:
             subprocess.run(["git", "-C", path, "pull"])
-            log(f"Pulled latest {name}")
+            log(f"Pulled latest {alias} -> {canonical}")
 
 def build_swift():
     with open(LOG_FILE, "a") as f:

--- a/deploy/repo_config.py
+++ b/deploy/repo_config.py
@@ -1,0 +1,10 @@
+REPOS = {
+    "fountainai": "https://github.com/Fountain-Coach/swift-codex-openapi-kernel.git",
+    "kong-codex": "https://github.com/fountain-coach/kong-codex.git",
+    "typesense-codex": "https://github.com/fountain-coach/typesense-codex.git"
+}
+
+# Mapping of legacy names to the canonical repository names.
+ALIASES = {
+    "fountainai": "swift-codex-openapi-kernel"
+}


### PR DESCRIPTION
## Summary
- introduce `repo_config.py` with FountainAI alias to `swift-codex-openapi-kernel`
- use the new config in `dispatcher.py`
- document the alias in `README.md` and `agent.md`

## Testing
- `python3 -m py_compile deploy/dispatcher.py deploy/repo_config.py`

------
https://chatgpt.com/codex/tasks/task_e_686fd2466b908325a98316c001b3f304