### PR TITLE
Update security notes for dispatcher docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ At its heart is a single principle:
 | ✅ Daemon architecture | One Python loop drives the whole system |
 | ✅ Multi-repo awareness | Supports FountainAI, Kong, Typesense clones in one loop |
 | ✅ Developer-agnostic | Works whether code was committed by a human or Codex |
+| ✅ GitHub sync | Build logs and applied patches automatically pushed |
 
 ---
 
@@ -117,7 +118,7 @@ Codex can:
 ```
 
 - On next loop, the dispatcher reads and applies it
-- Optional: patches are committed back via `git`
+- Applied patches and the latest build log are committed and pushed to GitHub
 
 ---
 

--- a/agent.md
+++ b/agent.md
@@ -27,7 +27,7 @@ Codex interacts with this agent via:
 
 Codex does **not** use GitHub runners or CI pipelines. It communicates entirely through Git clones and semantic feedback.
 
-Codex does **not** push directly to GitHub. All feedback is local — Codex may submit improvements as `.json` files or, optionally, as PRs.
+Build logs and applied feedback patches are automatically pushed back to GitHub for traceability.
 
 ---
 
@@ -95,10 +95,11 @@ Accepted values for `"repo"`:
 
 ## 🛡️ Security Notes
 
-- Agent expects secure SSH access to the VPS
-- All Git operations are pull-only unless explicitly patched by Codex
-- Feedback files must be vetted and logged
-- `agent.md` is the source of truth for Codex behavior understanding
+- Initial bootstrap requires SSH access so the server can clone repos and install dependencies.
+- Once running, the dispatcher operates autonomously via `systemd` and interacts with GitHub over HTTPS.
+- All Git operations are pull-only unless Codex submits a feedback patch.
+- Feedback files must be vetted and logged.
+- `agent.md` defines the expected behavior and should remain under version control.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify SSH requirement in agent security notes
- confirm logs and patches are auto-pushed

## Testing
- `python3 -m py_compile deploy/dispatcher.py`
- `bash -n bootstrap.sh`
- `bash -n deploy/commands/restart-services.sh`
- `python3 -m py_compile deploy/repo_config.py`


------
https://chatgpt.com/codex/tasks/task_e_68700c8097008325829361c7e27fc04d