### PR TITLE
Introduce dispatcher v2 and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ At its heart is a single principle:
     ├── kong-codex/          ← Gateway config & plugins
     ├── typesense-codex/     ← Schema definitions + indexing logic
     └── deploy/
-         ├── dispatcher.py   ← Daemonized build + feedback loop
+         ├── dispatcher_v2.py   ← Daemonized build + feedback loop
          ├── logs/
          │    └── build.log  ← Swift compiler output
          ├── feedback/
@@ -79,11 +79,12 @@ At its heart is a single principle:
 
 | File | Purpose |
 |------|---------|
-| `dispatcher.py` | The daemon loop: pulls repos, builds services, checks for Codex feedback |
+| `dispatcher_v2.py` | The daemon loop: pulls repos, builds services, checks for Codex feedback |
 | `logs/build.log` | Canonical Swift compiler output for semantic introspection |
 | `feedback/` | Codex inbox – write here to apply changes or fix builds |
 | `commands/restart-services.sh` | Optional system command triggered by semantic feedback |
 | `systemd/fountain-dispatcher.service` | Autostarts dispatcher on VPS boot |
+| `docs/dispatcher_v2.md` | Detailed dispatcher v2 documentation |
 
 ---
 

--- a/agent.md
+++ b/agent.md
@@ -79,7 +79,7 @@ Accepted values for `"repo"`:
 | `/srv/fountainai/` | FountainAI services cloned from Git |
 | `/srv/kong-codex/` | Kong gateway config + plugins |
 | `/srv/typesense-codex/` | Typesense indexing definitions |
-| `/srv/deploy/` | Contains `dispatcher.py`, `repo_config.py`, and runtime control logic |
+| `/srv/deploy/` | Contains `dispatcher_v2.py`, `repo_config.py`, and runtime control logic |
 | `/srv/deploy/logs/` | Build logs from `swift build` and other commands |
 | `/srv/deploy/feedback/` | Codex-pushed semantic patches |
 | `/srv/deploy/commands/` | Optional system hooks (restart, reindex, etc) |

--- a/deploy/dispatcher_v2.py
+++ b/deploy/dispatcher_v2.py
@@ -1,0 +1,114 @@
+"""Dispatcher v2.0
+===================
+
+An improved deployment dispatcher for Codex. This version introduces
+structured logging, configurable loop intervals, and clearer function
+documentation. It remains backward compatible with the original
+:mod:`dispatcher` but exposes a new entry point.
+"""
+
+import os
+import subprocess
+import time
+from datetime import datetime
+from typing import Dict
+
+from repo_config import REPOS, ALIASES
+
+__version__ = "2.0"
+
+LOG_DIR = "/srv/deploy/logs"
+FEEDBACK_DIR = "/srv/deploy/feedback"
+LOG_FILE = os.path.join(LOG_DIR, "build.log")
+LOOP_INTERVAL = int(os.environ.get("DISPATCHER_INTERVAL", "60"))
+
+
+def ensure_dirs() -> None:
+    """Create required directories if they do not exist."""
+    os.makedirs(LOG_DIR, exist_ok=True)
+    os.makedirs(FEEDBACK_DIR, exist_ok=True)
+
+
+def timestamp() -> str:
+    """Return the current timestamp in ISO format."""
+    return datetime.utcnow().isoformat()
+
+
+def log(msg: str) -> None:
+    """Append a log message to ``LOG_FILE`` with a timestamp."""
+    with open(LOG_FILE, "a") as fh:
+        fh.write(f"[{timestamp()}] {msg}\n")
+
+
+def push_logs_to_github() -> None:
+    """Commit and push the latest build log to the ``codex-deployer`` repo."""
+    latest_log = os.path.join("/srv/deploy", "logs", "latest.log")
+    os.makedirs(os.path.dirname(latest_log), exist_ok=True)
+    subprocess.run(["cp", LOG_FILE, latest_log], check=False)
+    subprocess.run(["git", "-C", "/srv/deploy", "add", "logs/latest.log"], check=False)
+    subprocess.run(
+        ["git", "-C", "/srv/deploy", "commit", "-m", f"Update build log: {timestamp()}"] ,
+        check=False,
+    )
+    subprocess.run(["git", "-C", "/srv/deploy", "push"], check=False)
+
+
+def pull_repos(repos: Dict[str, str]) -> None:
+    """Clone or update all configured repositories."""
+    for alias, url in repos.items():
+        path = f"/srv/{alias}"
+        canonical = ALIASES.get(alias, alias)
+        if not os.path.exists(path):
+            subprocess.run(["git", "clone", url, path], check=False)
+            log(f"Cloned {alias} -> {canonical}")
+        else:
+            subprocess.run(["git", "-C", path, "pull"], check=False)
+            log(f"Pulled latest {alias} -> {canonical}")
+
+
+def build_swift() -> None:
+    """Run ``swift build`` inside the FountainAI repository."""
+    with open(LOG_FILE, "a") as fh:
+        fh.write(f"\n[{timestamp()}] Starting swift build...\n")
+        subprocess.run(
+            ["swift", "build"], cwd="/srv/fountainai", stdout=fh, stderr=subprocess.STDOUT, check=False
+        )
+
+
+def commit_applied_patch(fname: str) -> None:
+    """Mark a feedback JSON file as applied and push it upstream."""
+    patch_path = os.path.join(FEEDBACK_DIR, fname)
+    new_name = f"applied-{fname}"
+    new_path = os.path.join(FEEDBACK_DIR, new_name)
+    os.rename(patch_path, new_path)
+    subprocess.run(["git", "-C", "/srv/deploy", "add", f"feedback/{new_name}"], check=False)
+    subprocess.run(
+        ["git", "-C", "/srv/deploy", "commit", "-m", f"Applied patch: {fname}"], check=False
+    )
+    subprocess.run(["git", "-C", "/srv/deploy", "push"], check=False)
+
+
+def apply_codex_feedback() -> None:
+    """Consume any pending JSON feedback files from ``FEEDBACK_DIR``."""
+    for fname in os.listdir(FEEDBACK_DIR):
+        if fname.endswith(".json"):
+            log(f"Codex feedback detected: {fname}")
+            subprocess.run(["bash", "/srv/deploy/commands/restart-services.sh"], check=False)
+            commit_applied_patch(fname)
+
+
+def loop() -> None:
+    """Main dispatcher loop."""
+    ensure_dirs()
+    while True:
+        log("=== New Cycle ===")
+        pull_repos(REPOS)
+        build_swift()
+        push_logs_to_github()
+        apply_codex_feedback()
+        time.sleep(LOOP_INTERVAL)
+
+
+if __name__ == "__main__":
+    loop()
+

--- a/docs/dispatcher_v2.md
+++ b/docs/dispatcher_v2.md
@@ -1,0 +1,26 @@
+# Dispatcher v2.0
+
+`dispatcher_v2.py` is the second major iteration of the Codex deployment loop.
+It extends the original `dispatcher.py` with clearer documentation and a few
+quality of life improvements.
+
+## Key Changes
+
+- **Configurable loop interval** via the `DISPATCHER_INTERVAL` environment
+  variable.
+- **Structured logging** that timestamps every action.
+- **Explicit version tag** accessible via the `__version__` attribute.
+
+The overall workflow remains the same: repositories are pulled, the FountainAI
+service is built, logs are pushed to GitHub and feedback JSON files are applied.
+
+## Usage
+
+The systemd service has been updated to use this version by default:
+
+```ini
+ExecStart=/usr/bin/python3 /srv/deploy/dispatcher_v2.py
+```
+
+See the repository [README](../README.md) for setup details and an overview of
+the dispatcher's role in the deployment architecture.

--- a/systemd/fountain-dispatcher.service
+++ b/systemd/fountain-dispatcher.service
@@ -3,7 +3,7 @@ Description=Codex FountainAI Deployment Dispatcher
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/python3 /srv/deploy/dispatcher.py
+ExecStart=/usr/bin/python3 /srv/deploy/dispatcher_v2.py
 WorkingDirectory=/srv/deploy
 Restart=always
 User=root


### PR DESCRIPTION
## Summary
- add new `dispatcher_v2.py` with improved logging and configurable interval
- document dispatcher v2 in `docs/dispatcher_v2.md`
- update README and agent docs to reference dispatcher v2
- modify systemd service to run the new dispatcher

## Testing
- `python3 -m py_compile deploy/dispatcher_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_68708f39c6f08325ba8377f873d8d232