### PR TITLE
Upgrade dispatcher to support build, test, and run

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ At its heart is a single principle:
 | Capability | Description |
 |------------|-------------|
 | ✅ Git-native | Codex pulls from `main` and reads current state |
-| ✅ Swift compiler integration | Full `swift build` and `swift test` output is captured |
+| ✅ Swift compiler integration | Full `swift build`, `swift test`, and `swift run` output is captured |
 | ✅ No runners required | Runs 100% on your VPS |
 | ✅ Semantic feedback loop | Codex writes JSON to `/feedback/`, patches are applied |
 | ✅ Daemon architecture | One Python loop drives the whole system |


### PR DESCRIPTION
## Summary
- expand dispatcher.py with functions for running tests and executing a Swift target
- log `swift build`, `swift test`, and `swift run` sections
- update the dispatch loop order
- document full Swift lifecycle in README

## Testing
- `python3 -m py_compile deploy/dispatcher.py`


------
https://chatgpt.com/codex/tasks/task_e_687096d3d9b88325a0c02fc978e9f824