### PR TITLE
Add macOS Docker tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ At its heart is a single principle:
 | `commands/restart-target.sh` | Restart a service specified in feedback |
 | `systemd/fountain-dispatcher.service` | Autostarts dispatcher on VPS boot |
 | `docs/dispatcher_v2.md` | Detailed dispatcher v2 documentation |
+| `docs/mac_docker_tutorial.md` | Run the dispatcher locally on macOS with Docker |
 
 ---
 


### PR DESCRIPTION
## Summary
- document how to run codex-deployer locally with Docker on macOS
- reference the new tutorial from the README

## Testing
- `python3 -m py_compile deploy/dispatcher_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_6871f1dbb6ac83258e16d775fcb469d1