### PR TITLE
Add PR workflow doc and bump dispatcher to v2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ At its heart is a single principle:
 
 | File | Purpose |
 |------|---------|
-| `dispatcher_v2.py` | The daemon loop (v2.2): pulls repos, builds services, checks for Codex feedback |
+| `dispatcher_v2.py` | The daemon loop (v2.3): pulls repos, builds services, checks for Codex feedback |
 | `logs/latest.log` | Most recent Swift build/test output |
 | `logs/build-*.log` | Historical logs for each dispatcher cycle |
 | `feedback/` | Codex inbox – write here to apply changes or fix builds |

--- a/deploy/dispatcher_v2.py
+++ b/deploy/dispatcher_v2.py
@@ -1,7 +1,7 @@
-"""Dispatcher v2.2
+"""Dispatcher v2.3
 ===================
 
-An improved deployment dispatcher for Codex. Version 2.2 adds
+An improved deployment dispatcher for Codex. Version 2.3 adds
 basic build result checking, log rotation, automatic patch
 application, and granular service restarts. It remains backward
 compatible with the original :mod:`dispatcher` but exposes a new
@@ -18,7 +18,7 @@ import sys
 
 from repo_config import REPOS, ALIASES
 
-__version__ = "2.2"
+__version__ = "2.3"
 
 LOG_DIR = "/srv/deploy/logs"
 FEEDBACK_DIR = "/srv/deploy/feedback"

--- a/docs/dispatcher_v2.md
+++ b/docs/dispatcher_v2.md
@@ -1,7 +1,7 @@
-# Dispatcher v2.2
+# Dispatcher v2.3
 
 `dispatcher_v2.py` is the second major iteration of the Codex deployment loop.
-Version 2.2 extends the previous release with build result checks, log rotation,
+Version 2.3 extends the previous release with build result checks, log rotation,
 automatic patch application, and platform-aware compilation.
 
 ## Key Changes
@@ -28,3 +28,4 @@ ExecStart=/usr/bin/python3 /srv/deploy/dispatcher_v2.py
 
 See the repository [README](../README.md) for setup details and an overview of
 the dispatcher's role in the deployment architecture.
+\nFor teams that prefer code review via pull requests, see [pull_request_workflow.md](pull_request_workflow.md) for a conceptual guide on extending the dispatcher.

--- a/docs/mac_docker_tutorial.md
+++ b/docs/mac_docker_tutorial.md
@@ -64,7 +64,7 @@ Press `Ctrl-C` in the terminal running the container to stop the dispatcher.
 
 ## 6. Cross-platform compilation
 
-Version 2.2 of the dispatcher detects when it is running on macOS and invokes
+Version 2.3 of the dispatcher detects when it is running on macOS and invokes
 `xcrun swift` so that the Apple SDKs are available. On Linux or other
 environments the open source `swift` toolchain is used. You can experiment with
 cross compiling by mounting additional volumes that contain the target SDKs and

--- a/docs/pull_request_workflow.md
+++ b/docs/pull_request_workflow.md
@@ -1,0 +1,13 @@
+# Pull Request Workflow Concept
+
+The default dispatcher pushes commits directly to the repository branch it manages. This keeps the deployment loop simple but may be too permissive for some teams.
+
+If you would rather have Codex propose changes through pull requests, modify `dispatcher_v2.py` so that it:
+
+1. **Creates a branch** when applying patches or log updates.
+2. **Pushes that branch** to GitHub instead of committing to `main`.
+3. **Opens a pull request** from the new branch to the target branch using the GitHub API or `gh` CLI.
+4. **Waits for merge**. The dispatcher should poll for the PR status and only continue once it has been merged.
+5. **Pulls the updated branch** and resumes its normal build cycle.
+
+This approach allows human code review while still keeping the automation centralized. The dispatcher does not implement this behavior by default—it's an optional extension you can layer on top of version 2.3.


### PR DESCRIPTION
## Summary
- document how to adapt dispatcher for a pull request workflow
- bump dispatcher version from 2.2 to 2.3
- update docs and README for v2.3 reference

## Testing
- `python3 -m py_compile deploy/dispatcher_v2.py deploy/dispatcher.py deploy/repo_config.py`

------
https://chatgpt.com/codex/tasks/task_e_6872261a9ce88325b6f8be695e445340