### PR TITLE
Configure env file loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ At its heart is a single principle:
 git clone https://github.com/fountain-coach/codex-deployer /srv/deploy
 cd /srv/deploy
 sudo cp systemd/fountain-dispatcher.service /etc/systemd/system/
+sudo cp systemd/dispatcher.env /srv/deploy/dispatcher.env
+sudo nano /srv/deploy/dispatcher.env  # edit values or source secrets
 sudo systemctl daemon-reexec
 sudo systemctl enable fountain-dispatcher
 sudo systemctl start fountain-dispatcher
@@ -110,7 +112,8 @@ sudo systemctl start fountain-dispatcher
 
 Make sure `/srv/` is writable and owned by the system user running the daemon.
 See [docs/environment_variables.md](docs/environment_variables.md) for required
-environment variables and GitHub secret configuration.
+environment variables and GitHub secret configuration. Update
+`/srv/deploy/dispatcher.env` with those values before starting the service.
 
 ---
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,6 +15,9 @@ chmod +x /srv/deploy/commands/restart-target.sh
 
 echo "[BOOTSTRAP] Copying systemd unit file..."
 cp /srv/deploy/systemd/fountain-dispatcher.service /etc/systemd/system/
+cp /srv/deploy/systemd/dispatcher.env /srv/deploy/dispatcher.env
+
+echo "[BOOTSTRAP] Reminder: edit /srv/deploy/dispatcher.env with your secrets"
 
 echo "[BOOTSTRAP] Enabling and starting dispatcher service..."
 systemctl daemon-reexec

--- a/deploy/codex_changelog.py
+++ b/deploy/codex_changelog.py
@@ -1,4 +1,5 @@
 import os
+# OPENAI_API_KEY is documented in docs/environment_variables.md
 import subprocess
 from datetime import datetime
 

--- a/deploy/dispatcher_v2.py
+++ b/deploy/dispatcher_v2.py
@@ -31,6 +31,7 @@ FEEDBACK_DIR = "/srv/deploy/feedback"
 # to ``LOG_LATEST`` for backwards compatibility.
 LOG_LATEST = os.path.join(LOG_DIR, "build.log")
 LOG_FILE = LOG_LATEST
+# See docs/environment_variables.md for details on these variables
 LOOP_INTERVAL = int(os.environ.get("DISPATCHER_INTERVAL", "60"))
 USE_PRS = os.environ.get("DISPATCHER_USE_PRS", "1").lower() not in {"0", "false", "no"}
 

--- a/docs/dispatcher_v2.md
+++ b/docs/dispatcher_v2.md
@@ -32,5 +32,6 @@ the dispatcher's role in the deployment architecture.
 
 The pull request process is documented in [pull_request_workflow.md](pull_request_workflow.md). Set `DISPATCHER_USE_PRS=0` to revert to direct push mode.
 Refer to [environment_variables.md](environment_variables.md) for details on
-required environment variables and how to set them using GitHub secrets.
+required environment variables and how to set them using GitHub secrets. The
+systemd unit reads values from `/srv/deploy/dispatcher.env`.
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -26,3 +26,9 @@ export OPENAI_API_KEY="${{ secrets.OPENAI_API_KEY }}"
 
 The dispatcher reads these variables at startup, so ensure they are exported
 before launching the service (e.g. inside your systemd unit file).
+
+## dispatcher.env
+
+The systemd unit loads variables from `/srv/deploy/dispatcher.env`. Copy the
+sample from `systemd/dispatcher.env` and edit the values or source your GitHub
+secrets there.

--- a/docs/mac_docker_tutorial.md
+++ b/docs/mac_docker_tutorial.md
@@ -6,6 +6,8 @@ This tutorial demonstrates how to start the deployment loop on a Mac using Docke
 
 - macOS with [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed
 - Git command line tools
+- Review [environment_variables.md](environment_variables.md) for required
+  variables like `GITHUB_TOKEN`.
 
 ## 1. Clone the repository
 
@@ -38,7 +40,11 @@ The image copies the repository into `/srv/deploy` so the dispatcher can run as 
 Launch the container and run `dispatcher_v2.py`:
 
 ```bash
-docker run --rm -it -v $(pwd):/srv/deploy codex-deployer-local \
+export GITHUB_TOKEN=yourtoken
+export OPENAI_API_KEY=yourapikey  # optional
+docker run --rm -it -v $(pwd):/srv/deploy \
+  -e GITHUB_TOKEN -e OPENAI_API_KEY \
+  codex-deployer-local \
   python3 /srv/deploy/deploy/dispatcher_v2.py
 ```
 

--- a/systemd/dispatcher.env
+++ b/systemd/dispatcher.env
@@ -1,0 +1,7 @@
+# Environment variables for fountain-dispatcher.service
+# See docs/environment_variables.md for details on each variable.
+DISPATCHER_INTERVAL=60
+DISPATCHER_USE_PRS=1
+# Set tokens below or source them from secure storage
+GITHUB_TOKEN=
+OPENAI_API_KEY=

--- a/systemd/fountain-dispatcher.service
+++ b/systemd/fountain-dispatcher.service
@@ -3,6 +3,7 @@ Description=Codex FountainAI Deployment Dispatcher
 After=network.target
 
 [Service]
+EnvironmentFile=/srv/deploy/dispatcher.env
 ExecStart=/usr/bin/python3 /srv/deploy/dispatcher_v2.py
 WorkingDirectory=/srv/deploy
 Restart=always


### PR DESCRIPTION
## Summary
- load environment variables from `/srv/deploy/dispatcher.env`
- document the new env file and update setup instructions
- mention env variables in code comments and Docker tutorial
- bootstrap script copies the sample env file

## Testing
- `python3 -m py_compile deploy/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6872888336e483259ce07dbd6e02707a