### PR TITLE
Replace ViewFactory repo with Teatro

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ At its heart is a single principle:
     ├── fountainai/          ← Swift + Python services
     ├── kong-codex/          ← Gateway config & plugins
     ├── typesense-codex/     ← Schema definitions + indexing logic
-    ├── view-factory/        ← SwiftUI view templates
+    ├── teatro/              ← Teatro view engine
     └── deploy/
          ├── dispatcher_v2.py   ← Daemonized build + feedback loop
          ├── logs/
@@ -71,7 +71,7 @@ At its heart is a single principle:
 | ✅ No runners required | Runs 100% on your VPS |
 | ✅ Semantic feedback loop | Codex writes JSON to `/feedback/`, patches are applied |
 | ✅ Daemon architecture | One Python loop drives the whole system |
-| ✅ Multi-repo awareness | Supports FountainAI, Kong, Typesense, ViewFactory clones in one loop |
+| ✅ Multi-repo awareness | Supports FountainAI, Kong, Typesense, Teatro clones in one loop |
 | ✅ Developer-agnostic | Works whether code was committed by a human or Codex |
 | ✅ GitHub sync | Build logs and applied patches automatically pushed |
 | ✅ Log rotation | Each cycle writes `build-YYYYMMDD-HHMMSS.log` for history |

--- a/agent.md
+++ b/agent.md
@@ -41,7 +41,7 @@ The agent pulls and manages the following GitHub repositories:
 | `kong-codex`        | Gateway configuration and plugin definitions |
 | `typesense-codex`   | Typesense indexing schemas and bootstrapping logic |
 | `codex-deployer`    | This repo — hosts the dispatcher, feedback, and loop logic |
-| `view-factory`      | Shared SwiftUI views and composition helpers |
+| `teatro`            | Teatro view engine and rendering framework |
 
 > **Note**: `fountainai` refers to the GitHub repo
 > [`Fountain-Coach/swift-codex-openapi-kernel`](https://github.com/Fountain-Coach/swift-codex-openapi-kernel).
@@ -70,7 +70,7 @@ Accepted values for `"repo"`:
 - `"kong-codex"` → API routes and plugins
 - `"typesense-codex"` → schema or search logic
 - `"codex-deployer"` → dispatcher logic or system config
-- `"view-factory"` → shared SwiftUI components
+- `"teatro"` → Teatro components
 
 ---
 
@@ -81,7 +81,7 @@ Accepted values for `"repo"`:
 | `/srv/fountainai/` | FountainAI services cloned from Git |
 | `/srv/kong-codex/` | Kong gateway config + plugins |
 | `/srv/typesense-codex/` | Typesense indexing definitions |
-| `/srv/view-factory/` | Shared SwiftUI views |
+| `/srv/teatro/` | Teatro view engine |
 | `/srv/deploy/` | Contains `dispatcher_v2.py`, `repo_config.py`, and runtime control logic |
 | `/srv/deploy/logs/` | Build logs from `swift build` and other commands |
 | `/srv/deploy/feedback/` | Codex-pushed semantic patches |

--- a/deploy/repo_config.py
+++ b/deploy/repo_config.py
@@ -2,11 +2,11 @@ REPOS = {
     "fountainai": "https://github.com/Fountain-Coach/swift-codex-openapi-kernel.git",
     "kong-codex": "https://github.com/fountain-coach/kong-codex.git",
     "typesense-codex": "https://github.com/fountain-coach/typesense-codex.git",
-    "view-factory": "https://github.com/Fountain-Coach/SwiftUI-View-Factory.git",
+    "teatro": "https://github.com/Fountain-Coach/teatro.git",
 }
 
 # Mapping of legacy names to the canonical repository names.
 ALIASES = {
     "fountainai": "swift-codex-openapi-kernel",
-    "view-factory": "SwiftUI-View-Factory",
+    "teatro": "teatro",
 }


### PR DESCRIPTION
## Summary
- switch repo_config to use `teatro`
- update documentation to reference Teatro repository

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872db4f5c448325b8f1a69e8a7e780f