### PR TITLE
Add design pattern evaluation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ At its heart is a single principle:
 | `docs/environment_variables.md` | Reference for all environment variables |
 | `docs/mac_docker_tutorial.md` | Run the dispatcher locally on macOS with Docker |
 | `docs/what_is_git.md` | Intro to Git with history and flow |
+| `docs/design_patterns.md` | Evaluation of client/server, plugin, and declarative patterns |
 
 ---
 

--- a/docs/design_patterns.md
+++ b/docs/design_patterns.md
@@ -1,0 +1,53 @@
+# Design Pattern Evaluation
+
+This document summarizes the architectural patterns used across the Codex-powered deployment system.
+
+## Managed Repositories
+
+| Repository | Purpose |
+|------------|---------|
+| `fountainai` (alias for `swift-codex-openapi-kernel`) | Swift and Python services providing the main logic layer |
+| `kong-codex` | Gateway configuration and plugin definitions |
+| `typesense-codex` | Typesense indexing schemas and bootstrapping logic |
+| `codex-deployer` | Dispatcher loop, feedback handling, and deployment logic |
+| `teatro` | Teatro view engine and rendering framework |
+
+## Kernel – Client/Server Pattern
+
+The kernel repository exposes services that clients consume over API boundaries.
+
+**Strengths**
+- Clear separation between server implementations and clients
+- Scales horizontally as clients connect to a shared server
+
+**Weaknesses**
+- Each cross-service call adds network overhead
+- Requires careful API versioning to avoid tight coupling
+
+## Gateway – Plugin Pattern
+
+The Kong gateway relies on plugins to handle routing, authentication, and other gateway features.
+
+**Strengths**
+- Modular behavior that can be extended or removed without rewriting the gateway
+- Supports features like rate limiting and transformation through dedicated plugins
+
+**Weaknesses**
+- Managing many plugins can introduce complexity
+- Each plugin must remain compatible with the gateway version
+
+## View Engine – Declarative Style
+
+Teatro defines its UI purely through declarations.
+
+**Strengths**
+- Predictable rendering with minimal side effects
+- Easier to test individual view components
+
+**Weaknesses**
+- Highly dynamic interfaces can become verbose
+- Debugging layout issues may require specialized tooling
+
+## Overall Evaluation
+
+The combination of a client/server kernel, plugin-driven gateway, and declarative view engine offers clear separation of concerns. While each pattern introduces trade-offs, the design aligns with common best practices and provides a solid foundation for scaling the system.


### PR DESCRIPTION
## Summary
- document the design patterns used across codex repositories
- link to the new document from the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68739bce4b348325848f201f1a1d3519