### PR TITLE
Add env var token instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ At its heart is a single principle:
 | `systemd/fountain-dispatcher.service` | Autostarts dispatcher on VPS boot |
 | `docs/dispatcher_v2.md` | Detailed dispatcher v2 documentation |
 | `docs/environment_variables.md` | Reference for all environment variables |
+| `docs/managing_environment_variables.md` | Step-by-step variable setup |
 | `docs/mac_docker_tutorial.md` | Run the dispatcher locally on macOS with Docker |
 | `docs/what_is_git.md` | Intro to Git with history and flow |
 | `docs/design_patterns.md` | Evaluation of client/server, plugin, and declarative patterns |
@@ -115,8 +116,11 @@ sudo systemctl start fountain-dispatcher
 
 Make sure `/srv/` is writable and owned by the system user running the daemon.
 See [docs/environment_variables.md](docs/environment_variables.md) for required
-environment variables and GitHub secret configuration. Update
-`/srv/deploy/dispatcher.env` with those values before starting the service.
+environment variables and GitHub secret configuration. For a detailed token
+setup walk-through, including how to create `GITHUB_TOKEN`, consult
+[docs/managing_environment_variables.md](docs/managing_environment_variables.md).
+Update `/srv/deploy/dispatcher.env` with those values before starting the
+service.
 
 ---
 

--- a/docs/dispatcher_v2.md
+++ b/docs/dispatcher_v2.md
@@ -32,9 +32,11 @@ See the repository [README](../README.md) for setup details and an overview of
 the dispatcher's role in the deployment architecture.
 
 The pull request process is documented in [pull_request_workflow.md](pull_request_workflow.md). Set `DISPATCHER_USE_PRS=0` to revert to direct push mode.
-Refer to [environment_variables.md](environment_variables.md) for details on
-required environment variables and how to set them using GitHub secrets. The
-systemd unit reads values from `/srv/deploy/dispatcher.env`. Set
+Refer to [environment_variables.md](environment_variables.md) for a list of
+variables and see
+[managing_environment_variables.md](managing_environment_variables.md) for a
+step-by-step setup guide, including GitHub token creation. The systemd unit reads values from
+`/srv/deploy/dispatcher.env`. Set
 `DISPATCHER_BUILD_DOCKER=1` and `DISPATCHER_RUN_E2E=1` to enable cross-repo
 container builds and integration tests.
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -15,6 +15,13 @@ Variables without defaults are optional but enable additional functionality.
 The dispatcher logs a warning at startup if any variable is missing, allowing
 you to verify configuration before the main loop begins.
 
+`GITHUB_TOKEN` should be a personal access token with `repo` and `workflow`
+permissions. See GitHub's
+[official guide](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+for instructions and follow
+[managing_environment_variables.md](managing_environment_variables.md) for a
+step-by-step walk-through of adding it to `dispatcher.env`.
+
 ## Using GitHub Secrets
 
 Environment variables can be managed using **GitHub Secrets** so that sensitive
@@ -33,4 +40,6 @@ before launching the service (e.g. inside your systemd unit file).
 
 The systemd unit loads variables from `/srv/deploy/dispatcher.env`. Copy the
 sample from `systemd/dispatcher.env` and edit the values or source your GitHub
-secrets there.
+secrets there. See
+[managing_environment_variables.md](managing_environment_variables.md) for a
+step-by-step walkthrough of the setup process.

--- a/docs/mac_docker_tutorial.md
+++ b/docs/mac_docker_tutorial.md
@@ -6,8 +6,9 @@ This tutorial demonstrates how to start the deployment loop on a Mac using Docke
 
 - macOS with [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed
 - Git command line tools
-- Review [environment_variables.md](environment_variables.md) for required
-  variables like `GITHUB_TOKEN`.
+- Review [environment_variables.md](environment_variables.md) and
+  [managing_environment_variables.md](managing_environment_variables.md)
+  for required variables like `GITHUB_TOKEN`.
 
 ## 1. Clone the repository
 
@@ -47,6 +48,10 @@ docker run --rm -it -v $(pwd):/srv/deploy \
   codex-deployer-local \
   python3 /srv/deploy/deploy/dispatcher_v2.py
 ```
+
+`GITHUB_TOKEN` must be a personal access token with access to your private
+repositories. See [managing_environment_variables.md](managing_environment_variables.md)
+for instructions and links to GitHub's token documentation.
 
 The first run will clone the other repositories defined in `repo_config.py` and write logs under `/srv/deploy/logs` inside the container.
 

--- a/docs/managing_environment_variables.md
+++ b/docs/managing_environment_variables.md
@@ -1,0 +1,82 @@
+# Managing Environment Variables
+
+This guide explains how to configure the environment variables required by `dispatcher_v2.py`.
+It complements [environment_variables.md](environment_variables.md) with step‑by‑step setup instructions.
+
+## 1. Create `dispatcher.env`
+
+Copy the sample file from `systemd/dispatcher.env` to `/srv/deploy/dispatcher.env`.
+This file is loaded by the systemd unit or can be sourced manually when running the dispatcher in Docker.
+
+```bash
+cp systemd/dispatcher.env dispatcher.env
+```
+
+Edit `dispatcher.env` and fill in your secrets:
+
+```bash
+GITHUB_TOKEN=ghp_xxx              # Personal access token for private repos and PRs
+OPENAI_API_KEY=sk-xxx             # Optional, enables AI commit messages
+DISPATCHER_INTERVAL=60            # Seconds between loops
+DISPATCHER_USE_PRS=1              # Set to 0 for direct pushes
+```
+
+Refer to [environment_variables.md](environment_variables.md) for all available variables and their meanings.
+
+## 2. Generate a GitHub personal access token
+
+1. Sign in to GitHub and open the token settings page:
+   [github.com/settings/tokens](https://github.com/settings/tokens) (classic) or
+   [github.com/settings/personal-access-tokens](https://github.com/settings/personal-access-tokens)
+   for the new interface.
+2. Choose **Generate new token** and select *classic* if prompted.
+3. Select at least the `repo` and `workflow` scopes so the dispatcher can clone
+   private repositories and open pull requests.
+4. Click **Generate token** and copy the value.
+
+GitHub provides a walkthrough at their
+["Create a personal access token" guide](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+Paste the token into `dispatcher.env`:
+
+```bash
+GITHUB_TOKEN=ghp_xxx
+```
+
+## 3. Obtain an OpenAI API key
+
+Visit [OpenAI's API key page](https://platform.openai.com/account/api-keys) and
+create a new key if you haven't already. Add it to `dispatcher.env` as
+`OPENAI_API_KEY`. This value is optional but enables AI-generated commit
+messages.
+
+## 4. Export the variables
+
+Before launching `dispatcher_v2.py`, export the variables from the file:
+
+```bash
+set -a
+source dispatcher.env
+set +a
+```
+
+The `set -a` command marks all variables for export so that `python3` inherits them.
+
+## 5. Running inside Docker
+
+Mount your project directory and pass the variables to Docker:
+
+```bash
+export $(grep -v '^#' dispatcher.env)
+docker run --rm -it -v $(pwd):/srv/deploy \
+  -e GITHUB_TOKEN -e OPENAI_API_KEY \
+  codex-deployer-local \
+  python3 /srv/deploy/deploy/dispatcher_v2.py
+```
+
+Using a token avoids interactive Git prompts when cloning private repositories.
+
+## Further Reading
+
+- [environment_variables.md](environment_variables.md) – complete variable reference
+- [mac_docker_tutorial.md](mac_docker_tutorial.md) – full walkthrough for macOS
+


### PR DESCRIPTION
## Summary
- add personal access token steps to managing guide
- reference token setup from environment variable docs
- link token info in README, Docker tutorial, and dispatcher docs

## Testing
- `python3 -m py_compile deploy/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6874735435008325a5b134cdfd55132f