### PR TITLE
Use GitHub token for repo cloning

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -6,7 +6,7 @@ This document lists the environment variables used by the Codex deployer.
 |----------|---------|---------|
 | `DISPATCHER_INTERVAL` | `60` | Interval in seconds between dispatcher loops. |
 | `DISPATCHER_USE_PRS` | `1` | When set to `0` disables the pull request workflow and pushes directly to `main`. |
-| `GITHUB_TOKEN` | _(none)_ | Personal access token used to open pull requests when PR mode is active. |
+| `GITHUB_TOKEN` | _(none)_ | Personal access token used to clone private repositories and open pull requests when PR mode is active. |
 | `OPENAI_API_KEY` | _(none)_ | Enables AI-generated commit messages when set. |
 | `DISPATCHER_BUILD_DOCKER` | `0` | Set to `1` to build Docker images for repos containing a `Dockerfile`. |
 | `DISPATCHER_RUN_E2E` | `0` | Set to `1` to run `docker-compose` integration tests when available. |


### PR DESCRIPTION
## Summary
- use GITHUB_TOKEN when cloning repos so git doesn't prompt for credentials
- document the new behavior in environment_variables.md

## Testing
- `python3 -m py_compile deploy/dispatcher_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_6874838d6c3083258081ca8463792ecd