### PR TITLE
Configure git identity via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ setup walk-through, including how to create `GITHUB_TOKEN`, consult
 [docs/managing_environment_variables.md](docs/managing_environment_variables.md).
 Update `/srv/deploy/dispatcher.env` with those values before starting the
 service.
+Set `GIT_USER_NAME` and `GIT_USER_EMAIL` there to configure the identity used
+for commits and avoid interactive Git prompts.
 
 The repository's `.gitignore` excludes `dispatcher.env` and other `*.env` files
 to keep secrets out of version control. When building images, `.dockerignore`

--- a/deploy/dispatcher_v2.py
+++ b/deploy/dispatcher_v2.py
@@ -38,6 +38,26 @@ BUILD_DOCKER = os.environ.get("DISPATCHER_BUILD_DOCKER", "0").lower() not in {"0
 RUN_E2E = os.environ.get("DISPATCHER_RUN_E2E", "0").lower() not in {"0", "false", "no"}
 
 
+def configure_git() -> None:
+    """Set global git identity from environment variables."""
+    name = os.environ.get("GIT_USER_NAME")
+    email = os.environ.get("GIT_USER_EMAIL")
+    if name:
+        subprocess.run(["git", "config", "--global", "user.name", name], check=False)
+    else:
+        log("GIT_USER_NAME not set; using existing git user.name")
+    if email:
+        subprocess.run([
+            "git",
+            "config",
+            "--global",
+            "user.email",
+            email,
+        ], check=False)
+    else:
+        log("GIT_USER_EMAIL not set; using existing git user.email")
+
+
 def check_env() -> None:
     """Log the availability of environment variables."""
     if "DISPATCHER_INTERVAL" not in os.environ:
@@ -403,6 +423,7 @@ def loop() -> None:
     ensure_dirs()
     start_new_log()
     check_env()
+    configure_git()
     while True:
         log("=== New Cycle ===")
         pull_repos(REPOS)

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -8,12 +8,17 @@ This document lists the environment variables used by the Codex deployer.
 | `DISPATCHER_USE_PRS` | `1` | When set to `0` disables the pull request workflow and pushes directly to `main`. |
 | `GITHUB_TOKEN` | _(none)_ | Personal access token used to clone private repositories and open pull requests when PR mode is active. |
 | `OPENAI_API_KEY` | _(none)_ | Enables AI-generated commit messages when set. |
+| `GIT_USER_NAME` | _(none)_ | Used to configure `git config --global user.name`. |
+| `GIT_USER_EMAIL` | _(none)_ | Used to configure `git config --global user.email`. |
 | `DISPATCHER_BUILD_DOCKER` | `0` | Set to `1` to build Docker images for repos containing a `Dockerfile`. |
 | `DISPATCHER_RUN_E2E` | `0` | Set to `1` to run `docker-compose` integration tests when available. |
 
 Variables without defaults are optional but enable additional functionality.
 The dispatcher logs a warning at startup if any variable is missing, allowing
 you to verify configuration before the main loop begins.
+
+Set `GIT_USER_NAME` and `GIT_USER_EMAIL` to configure the commit identity used
+by `git`. This prevents interactive prompts when the dispatcher performs commits.
 
 `GITHUB_TOKEN` should be a personal access token with `repo` and `workflow`
 permissions. See GitHub's

--- a/docs/mac_docker_tutorial.md
+++ b/docs/mac_docker_tutorial.md
@@ -43,8 +43,10 @@ Launch the container and run `dispatcher_v2.py`:
 ```bash
 export GITHUB_TOKEN=yourtoken
 export OPENAI_API_KEY=yourapikey  # optional
+export GIT_USER_NAME="Codex Bot"
+export GIT_USER_EMAIL=codex@example.com
 docker run --rm -it -v $(pwd):/srv/deploy \
-  -e GITHUB_TOKEN -e OPENAI_API_KEY \
+  -e GITHUB_TOKEN -e OPENAI_API_KEY -e GIT_USER_NAME -e GIT_USER_EMAIL \
   codex-deployer-local \
   python3 /srv/deploy/deploy/dispatcher_v2.py
 ```

--- a/docs/managing_environment_variables.md
+++ b/docs/managing_environment_variables.md
@@ -19,6 +19,8 @@ GITHUB_TOKEN=ghp_xxx              # Personal access token for private repos and 
 OPENAI_API_KEY=sk-xxx             # Optional, enables AI commit messages
 DISPATCHER_INTERVAL=60            # Seconds between loops
 DISPATCHER_USE_PRS=1              # Set to 0 for direct pushes
+GIT_USER_NAME="Codex Bot"         # Name used for git commits
+GIT_USER_EMAIL=codex@example.com  # Email used for git commits
 ```
 
 Refer to [environment_variables.md](environment_variables.md) for all available variables and their meanings.

--- a/systemd/dispatcher.env
+++ b/systemd/dispatcher.env
@@ -8,3 +8,6 @@ DISPATCHER_RUN_E2E=0
 # Set tokens below or source them from secure storage
 GITHUB_TOKEN=
 OPENAI_API_KEY=
+# Git identity for commits
+GIT_USER_NAME=
+GIT_USER_EMAIL=


### PR DESCRIPTION
## Summary
- allow dispatcher to configure global git identity from env variables
- document `GIT_USER_NAME` and `GIT_USER_EMAIL`
- include sample config in systemd file and tutorials

## Testing
- `python3 -m py_compile deploy/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687485f40cbc8325afe4693b678f72d3