### PR TITLE
Default git identity for dispatcher

### DIFF
--- a/deploy/dispatcher_v2.py
+++ b/deploy/dispatcher_v2.py
@@ -37,25 +37,22 @@ USE_PRS = os.environ.get("DISPATCHER_USE_PRS", "1").lower() not in {"0", "false"
 BUILD_DOCKER = os.environ.get("DISPATCHER_BUILD_DOCKER", "0").lower() not in {"0", "false", "no"}
 RUN_E2E = os.environ.get("DISPATCHER_RUN_E2E", "0").lower() not in {"0", "false", "no"}
 
+# Defaults for git identity when environment variables are missing.
+# See docs/environment_variables.md for details.
+DEFAULT_GIT_NAME = "Contexter"
+DEFAULT_GIT_EMAIL = "mail@benedikt-eickhoff.de"
+
 
 def configure_git() -> None:
-    """Set global git identity from environment variables."""
-    name = os.environ.get("GIT_USER_NAME")
-    email = os.environ.get("GIT_USER_EMAIL")
-    if name:
-        subprocess.run(["git", "config", "--global", "user.name", name], check=False)
-    else:
-        log("GIT_USER_NAME not set; using existing git user.name")
-    if email:
-        subprocess.run([
-            "git",
-            "config",
-            "--global",
-            "user.email",
-            email,
-        ], check=False)
-    else:
-        log("GIT_USER_EMAIL not set; using existing git user.email")
+    """Set global git identity, falling back to defaults."""
+    name = os.environ.get("GIT_USER_NAME", DEFAULT_GIT_NAME)
+    email = os.environ.get("GIT_USER_EMAIL", DEFAULT_GIT_EMAIL)
+    subprocess.run(["git", "config", "--global", "user.name", name], check=False)
+    subprocess.run(["git", "config", "--global", "user.email", email], check=False)
+    if os.environ.get("GIT_USER_NAME") is None:
+        log(f"GIT_USER_NAME not set; defaulting to {name}")
+    if os.environ.get("GIT_USER_EMAIL") is None:
+        log(f"GIT_USER_EMAIL not set; defaulting to {email}")
 
 
 def check_env() -> None:

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -8,8 +8,8 @@ This document lists the environment variables used by the Codex deployer.
 | `DISPATCHER_USE_PRS` | `1` | When set to `0` disables the pull request workflow and pushes directly to `main`. |
 | `GITHUB_TOKEN` | _(none)_ | Personal access token used to clone private repositories and open pull requests when PR mode is active. |
 | `OPENAI_API_KEY` | _(none)_ | Enables AI-generated commit messages when set. |
-| `GIT_USER_NAME` | _(none)_ | Used to configure `git config --global user.name`. |
-| `GIT_USER_EMAIL` | _(none)_ | Used to configure `git config --global user.email`. |
+| `GIT_USER_NAME` | `Contexter` | Used to configure `git config --global user.name`. |
+| `GIT_USER_EMAIL` | `mail@benedikt-eickhoff.de` | Used to configure `git config --global user.email`. |
 | `DISPATCHER_BUILD_DOCKER` | `0` | Set to `1` to build Docker images for repos containing a `Dockerfile`. |
 | `DISPATCHER_RUN_E2E` | `0` | Set to `1` to run `docker-compose` integration tests when available. |
 | `SECRETS_API_URL` | _(none)_ | Endpoint for retrieving secrets at startup. |
@@ -21,6 +21,8 @@ you to verify configuration before the main loop begins.
 
 Set `GIT_USER_NAME` and `GIT_USER_EMAIL` to configure the commit identity used
 by `git`. This prevents interactive prompts when the dispatcher performs commits.
+If these variables are omitted, the dispatcher uses `Contexter` and
+`mail@benedikt-eickhoff.de` as defaults.
 
 `GITHUB_TOKEN` should be a personal access token with `repo` and `workflow`
 permissions. See GitHub's

--- a/docs/mac_docker_tutorial.md
+++ b/docs/mac_docker_tutorial.md
@@ -43,8 +43,8 @@ Launch the container and run `dispatcher_v2.py`:
 ```bash
 export GITHUB_TOKEN=yourtoken
 export OPENAI_API_KEY=yourapikey  # optional
-export GIT_USER_NAME="Codex Bot"
-export GIT_USER_EMAIL=codex@example.com
+export GIT_USER_NAME="Contexter"
+export GIT_USER_EMAIL=mail@benedikt-eickhoff.de
 docker run --rm -it -v $(pwd):/srv/deploy \
   -e GITHUB_TOKEN -e OPENAI_API_KEY -e GIT_USER_NAME -e GIT_USER_EMAIL \
   codex-deployer-local \

--- a/docs/managing_environment_variables.md
+++ b/docs/managing_environment_variables.md
@@ -19,8 +19,8 @@ GITHUB_TOKEN=ghp_xxx              # Personal access token for private repos and 
 OPENAI_API_KEY=sk-xxx             # Optional, enables AI commit messages
 DISPATCHER_INTERVAL=60            # Seconds between loops
 DISPATCHER_USE_PRS=1              # Set to 0 for direct pushes
-GIT_USER_NAME="Codex Bot"         # Name used for git commits
-GIT_USER_EMAIL=codex@example.com  # Email used for git commits
+GIT_USER_NAME="Contexter"         # Name used for git commits
+GIT_USER_EMAIL=mail@benedikt-eickhoff.de  # Email used for git commits
 ```
 
 Refer to [environment_variables.md](environment_variables.md) for all available variables and their meanings.

--- a/systemd/dispatcher.env
+++ b/systemd/dispatcher.env
@@ -8,6 +8,6 @@ DISPATCHER_RUN_E2E=0
 # Set tokens below or source them from secure storage
 GITHUB_TOKEN=
 OPENAI_API_KEY=
-# Git identity for commits
+# Git identity for commits (defaults used if empty)
 GIT_USER_NAME=
 GIT_USER_EMAIL=


### PR DESCRIPTION
## Summary
- default git username and email if none provided
- document default git identity in environment variables guide
- update setup docs and sample configs

## Testing
- `python3 -m py_compile deploy/dispatcher_v2.py`
- `python3 -m py_compile deploy/codex_changelog.py deploy/dispatcher.py deploy/repo_config.py`

------
https://chatgpt.com/codex/tasks/task_e_68748edb5ed88325b2c659bf40b7da3d