### PR TITLE
Fix missing curl dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM swift:5.8
-RUN apt-get update && apt-get install -y git python3 python3-pip
+RUN apt-get update && apt-get install -y git python3 python3-pip curl
 WORKDIR /srv/deploy
 COPY . /srv/deploy

--- a/docs/mac_docker_tutorial.md
+++ b/docs/mac_docker_tutorial.md
@@ -26,7 +26,7 @@ Create a small Docker image that includes Python, Git and Swift:
 ```bash
 cat > Dockerfile <<'DOCKER'
 FROM swift:5.8
-RUN apt-get update && apt-get install -y git python3 python3-pip
+RUN apt-get update && apt-get install -y git python3 python3-pip curl
 WORKDIR /srv/deploy
 COPY . /srv/deploy
 DOCKER


### PR DESCRIPTION
## Summary
- install `curl` in the Docker image
- update macOS tutorial snippet to install `curl`

## Testing
- `python3 -m py_compile deploy/dispatcher_v2.py`


------
https://chatgpt.com/codex/tasks/task_e_6874978c41c08325808d38ed70024b1b