### PR TITLE
Fix git pull authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ Update `/srv/deploy/dispatcher.env` with those values before starting the
 service.
 Set `GIT_USER_NAME` and `GIT_USER_EMAIL` there to configure the identity used
 for commits and avoid interactive Git prompts.
+Set `GITHUB_TOKEN` as well to authenticate `git pull` and `git push` commands
+without manual prompts. See [docs/environment_variables.md](docs/environment_variables.md)
+for details.
 
 The repository's `.gitignore` excludes `dispatcher.env` and other `*.env` files
 to keep secrets out of version control. When building images, `.dockerignore`

--- a/deploy/dispatcher_v2.py
+++ b/deploy/dispatcher_v2.py
@@ -226,7 +226,10 @@ def commit_and_push(repo_path: str, message: str, base: str = "main") -> None:
         pr = _create_pr(slug, branch, message, base)
         _wait_for_merge(slug, pr)
         subprocess.run(["git", "-C", repo_path, "checkout", base], check=False)
-        subprocess.run(["git", "-C", repo_path, "pull"], check=False)
+        pull_cmd = ["git", "-C", repo_path, "pull"]
+        if token:
+            pull_cmd.append(f"https://x-access-token:{token}@github.com/{slug}.git")
+        subprocess.run(pull_cmd, check=False)
     else:
         push_cmd = ["git", "-C", repo_path, "push"]
         if token:
@@ -271,7 +274,10 @@ def pull_repos(repos: Dict[str, str]) -> None:
                 subprocess.run(["git", "-C", path, "remote", "set-url", "origin", url], check=False)
             log(f"Cloned {alias} -> {canonical}")
         else:
-            subprocess.run(["git", "-C", path, "pull"], check=False)
+            pull_cmd = ["git", "-C", path, "pull"]
+            if token and url.startswith("https://"):
+                pull_cmd.append(url.replace("https://", f"https://x-access-token:{token}@"))
+            subprocess.run(pull_cmd, check=False)
             log(f"Pulled latest {alias} -> {canonical}")
 
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -30,6 +30,8 @@ permissions. See GitHub's
 for instructions and follow
 [managing_environment_variables.md](managing_environment_variables.md) for a
 step-by-step walk-through of adding it to `dispatcher.env`.
+The token is used for cloning repositories, pushing commits, and pulling
+updates after pull requests merge so that Git never prompts for a username.
 
 ## Using GitHub Secrets
 


### PR DESCRIPTION
## Summary
- avoid git credential prompts by using GITHUB_TOKEN for `git pull`
- mention that GITHUB_TOKEN is also used for pulls in docs
- clarify README setup instructions to set GITHUB_TOKEN

## Testing
- `python3 -m py_compile deploy/dispatcher_v2.py`


------
https://chatgpt.com/codex/tasks/task_e_6874b28e2d108325967794b7c67dca34