### PR TITLE
Implement tools factory improvements

### DIFF
--- a/repos/fountainai/Docs/StatusQuo/Reports/tools-factory-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/tools-factory-status.md
@@ -11,9 +11,10 @@ Spec path: `FountainAi/openAPI/v1/tools-factory.yml` (version 1.0.0).
 - Server persists tools via `TypesenseClient`
 - Client decodes typed models
 - When `TYPESENSE_URL` is configured the service will persist tool definitions remotely
-- See [environment_variables.md](../../../../../../docs/environment_variables.md) for configuration options
+- See [environment_variables.md](../../../../../docs/environment_variables.md) for configuration options
 - Integration tests cover registration and listing flows
 - Authentication middleware checks the `TOOLS_FACTORY_AUTH_TOKEN` environment variable
+- Production Typesense collections can be bootstrapped using `typesense-codex/scripts/bootstrap_typesense.py`
 
 ### Example Usage
 
@@ -26,8 +27,8 @@ curl -X POST \
 curl http://tools-factory.fountain.coach/api/v1/tools
 ```
 
-Invalid documents return `400` with an `ErrorResponse`.
+Invalid documents return `422` with an `ErrorResponse`.
 
 ## Next Steps toward Production
-- Harden validation rules and error reporting
-- Add persistence migrations for production databases
+- **Completed**: Validation rules now detect duplicate `operationId` values and missing path parameters, returning detailed `ErrorResponse` messages.
+- **Completed**: `typesense-codex/scripts/bootstrap_typesense.py` creates required collections for production Typesense instances.

--- a/repos/typesense-codex/schemas/functions.schema.json
+++ b/repos/typesense-codex/schemas/functions.schema.json
@@ -1,4 +1,11 @@
 {
   "name": "functions",
-  "fields": []
+  "fields": [
+    {"name": "functionId", "type": "string"},
+    {"name": "name", "type": "string"},
+    {"name": "description", "type": "string"},
+    {"name": "httpMethod", "type": "string"},
+    {"name": "httpPath", "type": "string"}
+  ],
+  "default_sorting_field": "functionId"
 }

--- a/repos/typesense-codex/scripts/bootstrap_typesense.py
+++ b/repos/typesense-codex/scripts/bootstrap_typesense.py
@@ -1,1 +1,22 @@
-# Script to create Typesense collections
+#!/usr/bin/env python3
+"""Create required Typesense collections for FountainAI services."""
+
+import os
+import json
+import requests
+
+TYPESENSE_URL = os.environ.get("TYPESENSE_URL")
+API_KEY = os.environ.get("TYPESENSE_API_KEY", "")
+
+if not TYPESENSE_URL:
+    raise SystemExit("TYPESENSE_URL not set")
+
+SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "../schemas/functions.schema.json")
+with open(SCHEMA_PATH) as f:
+    schema = json.load(f)
+
+headers = {"X-API-Key": API_KEY, "Content-Type": "application/json"}
+resp = requests.post(f"{TYPESENSE_URL.rstrip('/')}/collections", headers=headers, json=schema)
+if resp.status_code not in (200, 201):
+    raise SystemExit(f"failed to create collection: {resp.status_code} {resp.text}")
+print("Created collection", schema["name"])


### PR DESCRIPTION
## Summary
- validate unique operation IDs and path parameters in `SpecValidator`
- return detailed `ErrorResponse` from tools factory service
- add Typesense bootstrap script and schema
- update tools factory status report with new info
- test validation logic

## Testing
- `swift test -c debug --enable-test-discovery` *(fails: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_e_6875d3aac7d48325b0626fe412be7f89