### PR TITLE
Improve Swift CI test runner

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -95,6 +95,30 @@ Accepted values for `"repo"`:
 
 ---
 
+## 🚦 Test Economization
+
+The CI runners sometimes hit CPU or memory limits when executing `swift test`.
+To keep tests green on limited runners, the agent economizes test runs using a
+progressive fallback sequence:
+
+1. **No parallelism** – run `swift test --parallel false`.
+2. **Cap concurrency** – retry with `--jobs 2` or the `SWIFTPM_NUM_JOBS`
+   environment variable (see
+   [docs/environment_variables.md](docs/environment_variables.md)).
+3. **Split targets** – loop over `swift test --filter <Target>` for each test
+   module so heavy modules run in isolation.
+4. **Skip heavy cases** – retry with `-DSKIP_SLOW_TESTS` to omit the slowest
+   tests when resources are scarce.
+5. **Prefer fast tags** – if the suite has tagged tests, run `FastTests` first
+   and postpone `SlowTests` to later jobs.
+6. **Persist build artifacts** – keep the `.build` directory between runs so
+   subsequent retries compile faster.
+7. **Fallback runner** – after two failed attempts on the default
+   GitHub runner, dispatch the job to a self-hosted runner labeled
+   `large-memory`.
+
+---
+
 ## 🛡️ Security Notes
 
 - Initial bootstrap requires SSH access so the server can clone repos and install dependencies.

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -15,6 +15,7 @@ This document lists the environment variables used by the Codex deployer.
 | `GIT_USER_EMAIL` | `mail@benedikt-eickhoff.de` | Used to configure `git config --global user.email`. |
 | `DISPATCHER_BUILD_DOCKER` | `0` | Set to `1` to build Docker images for repos containing a `Dockerfile`. |
 | `DISPATCHER_RUN_E2E` | `0` | Set to `1` to run `docker-compose` integration tests when available. |
+| `SWIFTPM_NUM_JOBS` | `2` | Number of build jobs used by `swift test`. Helps limit CI runner concurrency. |
 | `SECRETS_API_URL` | _(none)_ | Endpoint for retrieving secrets at startup. |
 | `SECRETS_API_TOKEN` | _(none)_ | Authentication token for the secrets service. |
 | `BOOTSTRAP_AUTH_TOKEN` | _(none)_ | Optional bearer token required by the Bootstrap service. |

--- a/docs/managing_environment_variables.md
+++ b/docs/managing_environment_variables.md
@@ -21,6 +21,7 @@ DISPATCHER_INTERVAL=60            # Seconds between loops
 DISPATCHER_USE_PRS=1              # Set to 0 for direct pushes
 GIT_USER_NAME="Contexter"         # Name used for git commits
 GIT_USER_EMAIL=mail@benedikt-eickhoff.de  # Email used for git commits
+SWIFTPM_NUM_JOBS=2                # Concurrency for swift test (see environment_variables.md)
 ```
 
 Refer to [environment_variables.md](environment_variables.md) for all available variables and their meanings.

--- a/repos/fountainai/.github/workflows/ci.yml
+++ b/repos/fountainai/.github/workflows/ci.yml
@@ -13,10 +13,39 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: .build
+          key: ${{ runner.os }}-swift-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-
       - uses: swift-actions/setup-swift@v1
         with:
           swift-version: '6.1'
       - name: Build
         run: swift build -v
       - name: Test
-        run: swift test -v
+        run: ./run-tests.sh
+        env:
+          SWIFTPM_NUM_JOBS: 2
+  fallback:
+    needs: build-and-test
+    if: failure() && github.run_attempt > 2
+    runs-on: [self-hosted, large-memory]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: .build
+          key: ${{ runner.os }}-swift-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-
+      - uses: swift-actions/setup-swift@v1
+        with:
+          swift-version: '6.1'
+      - name: Build
+        run: swift build -v
+      - name: Test
+        run: ./run-tests.sh
+        env:
+          SWIFTPM_NUM_JOBS: 2

--- a/repos/fountainai/run-tests.sh
+++ b/repos/fountainai/run-tests.sh
@@ -1,3 +1,38 @@
 #!/bin/bash
-# Wraps `swift test -v` to limit line lengths for Codex
-swift test -v 2>&1 | fold -sw 160
+# Adaptive wrapper for `swift test` to cope with CI resource limits.
+# Uses SWIFTPM_NUM_JOBS (see ../../docs/environment_variables.md) to control concurrency.
+set -euo pipefail
+
+run() {
+  echo "Running: $*"
+  "$@"
+}
+
+# Attempt 1: disable parallelism
+if run swift test -v --parallel false; then
+  exit 0
+fi
+
+echo "Retry with limited concurrency"
+# Attempt 2: limit job count
+if SWIFTPM_NUM_JOBS=${SWIFTPM_NUM_JOBS:-2} run swift test -v --parallel false --jobs 2; then
+  exit 0
+fi
+
+echo "Retry per test target"
+# Attempt 3: run each test target separately
+targets=$(swift test --list-tests | awk -F/ '{print $1}' | sort -u)
+if [ -n "$targets" ]; then
+  for t in $targets; do
+    echo "Running target $t"
+    if ! SWIFTPM_NUM_JOBS=${SWIFTPM_NUM_JOBS:-2} run swift test -v --parallel false --jobs 2 --filter "$t"; then
+      echo "Target $t failed"
+      exit 1
+    fi
+  done
+  exit 0
+fi
+
+echo "Retry skipping slow tests"
+# Attempt 4: skip heavy tests
+SWIFTPM_NUM_JOBS=${SWIFTPM_NUM_JOBS:-2} run swift test -v --parallel false --jobs 2 -Xswiftc -DSKIP_SLOW_TESTS


### PR DESCRIPTION
## Summary
- add adaptive `run-tests.sh` script for Swift testing
- cache build artifacts and add fallback runner in CI
- document new `SWIFTPM_NUM_JOBS` variable
- mention `SWIFTPM_NUM_JOBS` in setup docs
- outline CI test fallback sequence in `agent.md`
- expand test economization docs

## Testing
- `./repos/fountainai/run-tests.sh` *(fails: aborted due to lengthy build)*

------
https://chatgpt.com/codex/tasks/task_e_6875d7efafd083258b09888fd9b708e1