### PR TITLE
Implement planner auth token

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -22,6 +22,7 @@ This document lists the environment variables used by the Codex deployer.
 | `BASELINE_AUTH_TOKEN` | _(none)_ | Optional bearer token required by the Baseline Awareness service. |
 | `FUNCTION_CALLER_AUTH_TOKEN` | _(none)_ | Optional bearer token required by the Function Caller service. |
 | `TOOLS_FACTORY_AUTH_TOKEN` | _(none)_ | Optional bearer token required by the Tools Factory service. |
+| `PLANNER_AUTH_TOKEN` | _(none)_ | Optional bearer token required by the Planner service. |
 
 Variables without defaults are optional but enable additional functionality.
 The dispatcher logs a warning at startup if any variable is missing, allowing

--- a/repos/fountainai/Docs/StatusQuo/Reports/planner-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/planner-status.md
@@ -11,6 +11,7 @@ Spec path: `FountainAi/openAPI/v0/planner.yml` (version 0.1.0).
 - Router and handlers integrate with `LLMGatewayClient` and `TypesenseClient` to reason over objectives and invoke registered functions
 - Integration tests cover the `planner_list_corpora` endpoint
 - Prometheus metrics exposed at `/metrics`
+- Authentication middleware checks the `PLANNER_AUTH_TOKEN` environment variable
 
 ## Next Steps toward Production
 - Upgrade the API to stable v1 once semantics are finalized

--- a/repos/fountainai/Generated/Server/planner/HTTPKernel.swift
+++ b/repos/fountainai/Generated/Server/planner/HTTPKernel.swift
@@ -1,6 +1,8 @@
 import Foundation
 import ServiceShared
 
+/// Planner service kernel. Requires a bearer token when
+/// `PLANNER_AUTH_TOKEN` is set. See `docs/environment_variables.md`.
 public struct HTTPKernel {
     let router: Router
 
@@ -9,6 +11,12 @@ public struct HTTPKernel {
     }
 
     public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
+        if let token = ProcessInfo.processInfo.environment["PLANNER_AUTH_TOKEN"] {
+            let expected = "Bearer \(token)"
+            if request.headers["Authorization"] != expected {
+                return HTTPResponse(status: 401)
+            }
+        }
         let resp = try await router.route(request)
         await PrometheusAdapter.shared.record(service: "planner", path: request.path)
         return resp


### PR DESCRIPTION
## Summary
- enforce `PLANNER_AUTH_TOKEN` in planner server
- document the new variable in environment variable guide
- note authentication middleware in planner status doc

## Testing
- `swift test -v` *(failed: environment constraints)*

------
https://chatgpt.com/codex/tasks/task_e_6875e2ce927883259bc225bf7afa8cd6