### PR TITLE
Fix documentation links and update function caller next steps

### DIFF
--- a/repos/fountainai/Docs/StatusQuo/Reports/baseline-awareness-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/baseline-awareness-status.md
@@ -19,7 +19,7 @@ Spec path: `FountainAi/openAPI/v1/baseline-awareness.yml` (version 1.0.0).
 - Integration tests run the NIO-based server on both Linux and macOS for cross-platform coverage
 - Production analytics compute corpus history breakdown via `TypesenseClient`
 - Authentication middleware checks the `BASELINE_AUTH_TOKEN` environment variable
-- For a full list of configuration options see [environment_variables.md](../../../../../../docs/environment_variables.md)
+- For a full list of configuration options see [environment_variables.md](../../../../../docs/environment_variables.md)
 - Prometheus metrics track request counts and durations
 - Analytics can also be streamed via SSE at `/corpus/history/stream`
 ## Recent Updates

--- a/repos/fountainai/Docs/StatusQuo/Reports/bootstrap-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/bootstrap-status.md
@@ -10,7 +10,7 @@ Spec path: `FountainAi/openAPI/v1/bootstrap.yml` (version 1.0.0).
 - Generated server kernel at `Generated/Server/bootstrap` persists via `BaselineStore`
 - Reflection promotion registers new GPT roles via `BaselineStore`
 - `/bootstrap/baseline` streams drift and patterns analytics using SSE
-- Token-based auth checks `BOOTSTRAP_AUTH_TOKEN`; see [environment_variables.md](../../../../docs/environment_variables.md)
+- Token-based auth checks `BOOTSTRAP_AUTH_TOKEN`; see [environment_variables.md](../../../../../docs/environment_variables.md)
 - Prometheus metrics available at `/metrics`
 - Integration tests cover role seeding, corpus initialization and promotion
 - A `Dockerfile` exists for building the service container

--- a/repos/fountainai/Docs/StatusQuo/Reports/deployment.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/deployment.md
@@ -24,7 +24,7 @@ docker-compose up
 
 The services start minimal Swift HTTP servers that handle simple JSON requests. Persistence uses an in-memory `TypesenseClient`.
 Set environment variables like `TYPESENSE_URL`, `TYPESENSE_API_KEY`, `OPENAI_API_KEY` and optionally `OPENAI_API_BASE` before starting containers so services can connect to external dependencies.
-Refer to [environment_variables.md](../../../../../../docs/environment_variables.md) for details on these variables.
+Refer to [environment_variables.md](../../../../../docs/environment_variables.md) for details on these variables.
 
 ### Running a Single Service
 

--- a/repos/fountainai/Docs/StatusQuo/Reports/function-caller-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/function-caller-status.md
@@ -11,7 +11,7 @@ Spec path: `FountainAi/openAPI/v1/function-caller.yml` (version 1.0.0).
 - Handlers dispatch registered functions via ``FunctionDispatcher`` using ``TypesenseClient``
 - Client decodes typed models for all endpoints
 - When `TYPESENSE_URL` is set the dispatcher looks up functions from the external Typesense service
-- See [environment_variables.md](../../../../../../docs/environment_variables.md) for required configuration.
+- See [environment_variables.md](../../../../../docs/environment_variables.md) for required configuration.
 - Authentication middleware checks the `FUNCTION_CALLER_AUTH_TOKEN` environment variable
 - Integration tests verify the `list_functions` endpoint and invocation flows
 - Tools Factory integration allows dynamic registration via `/tools/register`
@@ -24,8 +24,11 @@ Spec path: `FountainAi/openAPI/v1/function-caller.yml` (version 1.0.0).
 - Docker Compose example at `Docs/Compose/function-caller-tools.yml`
 
 ## Recent Updates
-- Log aggregation setup documented in [log_aggregation.md](../../../../../../docs/log_aggregation.md)
+- Log aggregation setup documented in [log_aggregation.md](../../../../../docs/log_aggregation.md)
 
 ## Next Steps toward Production
 - Harden cache invalidation and error handling
 - Expand integration tests for the Compose workflow
+- Persist registered functions using Typesense so definitions survive restarts
+- Record metrics for invocation success and failures
+- Document Kubernetes deployment examples

--- a/repos/fountainai/Docs/StatusQuo/Reports/llm-gateway-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/llm-gateway-status.md
@@ -11,7 +11,7 @@ Spec path: `FountainAi/openAPI/v2/llm-gateway.yml` (version 2.0.0).
 - Minimal socket runtime handles requests; metrics endpoint returns Prometheus data
 - Client decodes typed models
 - Requests to OpenAI use `OPENAI_API_KEY` for authentication and can be routed through `OPENAI_API_BASE`
-- Environment variables are documented in [environment_variables.md](../../../../../../docs/environment_variables.md)
+- Environment variables are documented in [environment_variables.md](../../../../../docs/environment_variables.md)
 - Integration tests verify the `/metrics` endpoint
 
 ## Next Steps toward Production

--- a/repos/fountainai/Docs/StatusQuo/Reports/next-steps.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/next-steps.md
@@ -10,6 +10,6 @@ To move the project toward a stable production release:
 4. **Add authentication** – ✅ All services enforce bearer tokens and validate inputs.
 5. **Harden testing** – grow the integration tests to cover more scenarios and enable CI metrics.
 6. **Finalize deployment assets** – refine the Docker images, document environment variables, and provide examples for Kubernetes.
-   See [environment_variables.md](../../../../../../docs/environment_variables.md) for the latest list.
+   See [environment_variables.md](../../../../../docs/environment_variables.md) for the latest list.
 
 Following these steps will transition the FountainAI suite from generated stubs to fully functional, deployable microservices.

--- a/repos/fountainai/Docs/StatusQuo/Reports/persistence-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/persistence-status.md
@@ -11,7 +11,7 @@ Spec path: `FountainAi/openAPI/v1/persist.yml` (version 1.0.0).
 - Server uses an in-memory ``TypesenseClient`` for persistence during tests
 - Client decodes typed models for all endpoints
 - When `TYPESENSE_URL` and `TYPESENSE_API_KEY` are provided the service persists data to a remote Typesense instance
-- Configuration variables are listed in [environment_variables.md](../../../../../../docs/environment_variables.md)
+- Configuration variables are listed in [environment_variables.md](../../../../../docs/environment_variables.md)
 - Integration tests verify corpus listing and basic storage
 - Prometheus metrics exposed at `/metrics` for monitoring
 


### PR DESCRIPTION
## Summary
- fix relative links to environment variables documentation
- correct log aggregation link in function caller report
- add additional production steps for the function caller service

## Testing
- `swift test -v` *(failed to finish due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6875f7fa3ca08325a73f4752008195b3