### PR TITLE
Add Docker Compose integration tests

### DIFF
--- a/repos/fountainai/.github/workflows/ci.yml
+++ b/repos/fountainai/.github/workflows/ci.yml
@@ -49,3 +49,11 @@ jobs:
         run: ./run-tests.sh
         env:
           SWIFTPM_NUM_JOBS: 2
+
+  compose-integration:
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Docker Compose workflow
+        run: ./run-compose-e2e.sh

--- a/repos/fountainai/Docs/Compose/function-caller-tools.yml
+++ b/repos/fountainai/Docs/Compose/function-caller-tools.yml
@@ -11,6 +11,8 @@ services:
     environment:
       - TYPESENSE_URL=http://typesense:8108
       - TYPESENSE_API_KEY=xyz
+    ports:
+      - "8087:8080"
     depends_on:
       - typesense
   function-caller:
@@ -19,5 +21,7 @@ services:
       - TYPESENSE_URL=http://typesense:8108
       - TYPESENSE_API_KEY=xyz
       - FUNCTIONS_CACHE_PATH=functions-cache.json
+    ports:
+      - "8088:8080"
     depends_on:
       - typesense

--- a/repos/fountainai/README.md
+++ b/repos/fountainai/README.md
@@ -140,6 +140,16 @@ To build and run all services together:
 docker-compose build
 docker-compose up
 ```
+
+### Docker Compose Integration Tests
+Run the workflow defined in `Docs/Compose/function-caller-tools.yml` to test the
+Tools Factory and Function Caller services together. Ensure `TYPESENSE_URL` and
+`TYPESENSE_API_KEY` are configured as described in
+[environment_variables.md](../../docs/environment_variables.md).
+
+```bash
+./run-compose-e2e.sh
+```
 ## 🗓 Versioning & Changelog
 The service specifications follow Semantic Versioning. Major API revisions live in directories like `FountainAi/openAPI/v1`. All changes are recorded in [CHANGELOG.md](CHANGELOG.md); see [VERSIONING.md](VERSIONING.md) for policy details.
 ## 📚 Documentation Structure

--- a/repos/fountainai/run-compose-e2e.sh
+++ b/repos/fountainai/run-compose-e2e.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+COMPOSE_FILE="$SCRIPT_DIR/Docs/Compose/function-caller-tools.yml"
+
+cd "$SCRIPT_DIR"
+
+docker-compose -f "$COMPOSE_FILE" build
+
+docker-compose -f "$COMPOSE_FILE" up -d
+trap 'docker-compose -f "$COMPOSE_FILE" down -v' EXIT
+
+# wait for function caller to be up
+for i in {1..30}; do
+  if curl -s http://localhost:8088/functions | grep -q "\["; then
+    break
+  fi
+  sleep 2
+done
+
+# register a function that lists tools via tools-factory
+curl -s -X POST http://localhost:8087/tools/register \
+  -H 'Content-Type: application/json' \
+  -d '[{"function_id":"list","name":"list","description":"list","http_method":"GET","http_path":"http://tools-factory:8080/tools"}]'
+
+# invoke the function via Function Caller
+resp=$(curl -s -X POST http://localhost:8088/functions/list/invoke -H 'Content-Type: application/json' -d '{}')
+
+echo "Response: $resp"
+if echo "$resp" | grep -q "functions"; then
+  echo "Compose integration workflow succeeded"
+else
+  echo "Unexpected response from function caller" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add docker-compose integration workflow example
- document running docker compose integration tests in README
- automate compose workflow in CI

## Testing
- `swift test -v` *(fails: build output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_687611a0a4888325aba1b0628c48da4a