### PR TITLE
Add mac local testing tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ At its heart is a single principle:
 | `docs/environment_variables.md` | Reference for all environment variables |
 | `docs/managing_environment_variables.md` | Step-by-step variable setup |
 | `docs/mac_docker_tutorial.md` | Run the dispatcher locally on macOS with Docker |
+| `docs/mac_local_testing.md` | Test services locally on macOS |
 | `docs/what_is_git.md` | Intro to Git with history and flow |
 | `docs/design_patterns.md` | Evaluation of client/server, plugin, and declarative patterns |
 

--- a/docs/mac_local_testing.md
+++ b/docs/mac_local_testing.md
@@ -1,0 +1,69 @@
+# Local Testing on macOS
+
+This guide shows how to run the Codex deployer on a Mac so you can execute service tests locally.
+It builds a small Docker image and starts `dispatcher_v2.py` with environment variables exported from `dispatcher.env`.
+See [environment_variables.md](environment_variables.md) for the full list of variables.
+
+## 1. Prerequisites
+
+- macOS with [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed
+- Git command line tools
+
+## 2. Clone the repository
+
+```bash
+git clone https://github.com/fountain-coach/codex-deployer.git
+cd codex-deployer
+```
+
+Copy the sample env file and fill in your tokens:
+
+```bash
+cp systemd/dispatcher.env dispatcher.env
+# edit dispatcher.env with values like GITHUB_TOKEN and OPENAI_API_KEY
+```
+
+Follow [managing_environment_variables.md](managing_environment_variables.md) for detailed instructions.
+
+## 3. Build the Docker image
+
+```bash
+docker build -t codex-deployer-local .
+```
+
+The Dockerfile installs Python, Git and Swift then copies the repository into `/srv/deploy` so the dispatcher runs just like on a server.
+
+## 4. Run the dispatcher with tests
+
+Export the variables and start the container with `DISPATCHER_RUN_E2E=1` to run integration tests:
+
+```bash
+export $(grep -v '^#' dispatcher.env | xargs)
+docker run --rm -it -v $(pwd):/srv/deploy \
+  -e GITHUB_TOKEN -e OPENAI_API_KEY \
+  -e DISPATCHER_RUN_E2E=1 \
+  -e GIT_USER_NAME -e GIT_USER_EMAIL \
+  codex-deployer-local \
+  python3 /srv/deploy/deploy/dispatcher_v2.py
+```
+
+The dispatcher runs inside the container, clones the service repositories and executes their build and test commands. Logs appear under `deploy/logs` and are also committed back to GitHub.
+
+## 5. Viewing logs
+
+On your host machine you can inspect the build output:
+
+```bash
+ls deploy/logs
+cat deploy/logs/build.log
+```
+
+## 6. Stopping
+
+Press `Ctrl-C` in the terminal running the container to stop the dispatcher.
+
+## 7. Further reading
+
+- [mac_docker_tutorial.md](mac_docker_tutorial.md) – more details on running the dispatcher locally
+- [environment_variables.md](environment_variables.md) – complete variable reference
+- [managing_environment_variables.md](managing_environment_variables.md) – step‑by‑step setup guide


### PR DESCRIPTION
## Summary
- add `docs/mac_local_testing.md` with steps to run dispatcher tests on macOS
- document the new file in README

## Testing
- `python3 -m py_compile deploy/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68763b40e9d48325a3a371014c6f6e1b