### PR TITLE
Switch to docker compose CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A daemonized, Git-native deployment loop designed for FountainAI infrastructure 
 
 This repo defines a fully autonomous deployment system where Codex:
 - Pulls repositories directly via `git`
-- Triggers service builds (e.g. `swift build`, `docker-compose up`)
+- Triggers service builds (e.g. `swift build`, `docker compose up`)
 - Parses compiler and runtime logs
 - Writes structured feedback into a semantic inbox
 - Iterates on patches based on the build outcome

--- a/deploy/dispatcher_v2.py
+++ b/deploy/dispatcher_v2.py
@@ -322,7 +322,7 @@ def build_docker_images() -> None:
 
 
 def run_e2e_tests() -> None:
-    """Run docker-compose integration tests if a compose file is present."""
+    """Run docker compose integration tests if a compose file is present."""
     if not RUN_E2E:
         return
     with open(LOG_FILE, "a") as fh:
@@ -332,13 +332,14 @@ def run_e2e_tests() -> None:
             if os.path.exists(compose_file):
                 fh.write(f"\n[{timestamp()}] Running integration tests for {alias}...\n")
                 result = subprocess.run(
-                    ["docker-compose", "up", "--build", "--abort-on-container-exit"],
+                    ["docker", "compose", "up", "--build", "--abort-on-container-exit"],
                     cwd=repo_path,
                     stdout=fh,
                     stderr=subprocess.STDOUT,
                 )
                 subprocess.run([
-                    "docker-compose",
+                    "docker",
+                    "compose",
                     "down",
                     "--remove-orphans",
                 ], cwd=repo_path, stdout=fh, stderr=subprocess.STDOUT)

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -16,7 +16,7 @@ This document lists the environment variables used by the Codex deployer.
 | `GIT_USER_NAME` | `Contexter` | Used to configure `git config --global user.name`. |
 | `GIT_USER_EMAIL` | `mail@benedikt-eickhoff.de` | Used to configure `git config --global user.email`. |
 | `DISPATCHER_BUILD_DOCKER` | `0` | Set to `1` to build Docker images for repos containing a `Dockerfile`. |
-| `DISPATCHER_RUN_E2E` | `0` | Set to `1` to run `docker-compose` integration tests when available. |
+| `DISPATCHER_RUN_E2E` | `0` | Set to `1` to run `docker compose` integration tests when available. |
 | `SWIFTPM_NUM_JOBS` | `2` | Number of build jobs used by `swift test`. Helps limit CI runner concurrency. |
 | `SECRETS_API_URL` | _(none)_ | Endpoint for retrieving secrets at startup. |
 | `SECRETS_API_TOKEN` | _(none)_ | Authentication token for the secrets service. |

--- a/repos/fountainai/Docs/StatusQuo/Reports/deployment.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/deployment.md
@@ -9,7 +9,7 @@ Each generated server already contains a `Dockerfile`. The root `docker-compose.
 Run the following command at the repository root:
 
 ```bash
-docker-compose build
+docker compose build
 ```
 
 This compiles each service into a minimal Swift container.
@@ -21,7 +21,7 @@ Before running the containers configure the environment variables described in [
 To start all containers:
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 The services start minimal Swift HTTP servers that handle simple JSON requests. Persistence uses an in-memory `TypesenseClient`.
@@ -48,7 +48,7 @@ curl http://localhost:8080/health
 Press `Ctrl+C` to stop the running services, then remove containers with:
 
 ```bash
-docker-compose down
+docker compose down
 ```
 
 This workflow lets you run the microservices locally. Future updates will add full networking and durable persistence.

--- a/repos/fountainai/README.md
+++ b/repos/fountainai/README.md
@@ -137,8 +137,8 @@ See [deployment.md](Docs/StatusQuo/Reports/deployment.md) for more details.
 ### Docker Compose
 To build and run all services together:
 ```bash
-docker-compose build
-docker-compose up
+docker compose build
+docker compose up
 ```
 
 ### Docker Compose Integration Tests

--- a/repos/fountainai/run-compose-e2e.sh
+++ b/repos/fountainai/run-compose-e2e.sh
@@ -6,10 +6,10 @@ COMPOSE_FILE="$SCRIPT_DIR/Docs/Compose/function-caller-tools.yml"
 
 cd "$SCRIPT_DIR"
 
-docker-compose -f "$COMPOSE_FILE" build
+docker compose -f "$COMPOSE_FILE" build
 
-docker-compose -f "$COMPOSE_FILE" up -d
-trap 'docker-compose -f "$COMPOSE_FILE" down -v' EXIT
+docker compose -f "$COMPOSE_FILE" up -d
+trap 'docker compose -f "$COMPOSE_FILE" down -v' EXIT
 
 # wait for function caller to be up
 for i in {1..30}; do

--- a/repos/kong-codex/README.md
+++ b/repos/kong-codex/README.md
@@ -17,7 +17,7 @@ on these variables.
 3. Start the stack:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 Kong's admin API will be available on `http://localhost:8001` and the proxy


### PR DESCRIPTION
## Summary
- use `docker compose` CLI in docs, scripts and dispatcher
- document integration test variable using `docker compose`

## Testing
- `swift test -v` *(failed: build too resource-intensive)*

------
https://chatgpt.com/codex/tasks/task_e_687656b8f1fc83258416b1815132b4b6