### PR TITLE
Clarify Docker requirements for integration tests

### DIFF
--- a/deploy/dispatcher_v2.py
+++ b/deploy/dispatcher_v2.py
@@ -38,6 +38,7 @@ LOG_FILE = LOG_LATEST
 LOOP_INTERVAL = int(os.environ.get("DISPATCHER_INTERVAL", "60"))
 USE_PRS = os.environ.get("DISPATCHER_USE_PRS", "1").lower() not in {"0", "false", "no"}
 BUILD_DOCKER = os.environ.get("DISPATCHER_BUILD_DOCKER", "0").lower() not in {"0", "false", "no"}
+# docker and docker compose must be available inside the container when running integration tests
 RUN_E2E = os.environ.get("DISPATCHER_RUN_E2E", "0").lower() not in {"0", "false", "no"}
 
 # Defaults for git identity when environment variables are missing.

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -17,6 +17,7 @@ This document lists the environment variables used by the Codex deployer.
 | `GIT_USER_EMAIL` | `mail@benedikt-eickhoff.de` | Used to configure `git config --global user.email`. |
 | `DISPATCHER_BUILD_DOCKER` | `0` | Set to `1` to build Docker images for repos containing a `Dockerfile`. |
 | `DISPATCHER_RUN_E2E` | `0` | Set to `1` to run `docker compose` integration tests when available. |
+| | | Docker is not included in the default image – install it or mount the host Docker socket. |
 | `SWIFTPM_NUM_JOBS` | `2` | Number of build jobs used by `swift test`. Helps limit CI runner concurrency. |
 | `SECRETS_API_URL` | _(none)_ | Endpoint for retrieving secrets at startup. |
 | `SECRETS_API_TOKEN` | _(none)_ | Authentication token for the secrets service. |

--- a/docs/mac_docker_tutorial.md
+++ b/docs/mac_docker_tutorial.md
@@ -52,6 +52,8 @@ docker run --rm -it -v $(pwd):/srv/deploy \
   python3 /srv/deploy/deploy/dispatcher_v2.py
 ```
 
+Set `DISPATCHER_RUN_E2E=1` to run `docker compose` integration tests. Docker and `docker compose` must be installed inside the container or the host's Docker socket mounted. See [environment_variables.md](environment_variables.md) for the variable description.
+
 `GITHUB_TOKEN` must be a personal access token with access to your private
 repositories. See [managing_environment_variables.md](managing_environment_variables.md)
 for instructions and links to GitHub's token documentation.

--- a/docs/mac_local_testing.md
+++ b/docs/mac_local_testing.md
@@ -35,7 +35,7 @@ The Dockerfile installs Python, Git and Swift then copies the repository into `/
 
 ## 4. Run the dispatcher with tests
 
-Export the variables and start the container with `DISPATCHER_RUN_E2E=1` to run integration tests:
+Export the variables and start the container with `DISPATCHER_RUN_E2E=1` to run integration tests. `docker` and `docker compose` must be available inside the container, so either install Docker in your image or mount the host's socket. See [environment_variables.md](environment_variables.md) for details:
 
 ```bash
 export $(grep -v '^#' dispatcher.env | xargs)


### PR DESCRIPTION
## Summary
- document need for Docker when running integration tests
- add integration test note in macOS docs
- note Docker requirement for `DISPATCHER_RUN_E2E`
- document docker compose requirement in dispatcher script

## Testing
- `python3 -m py_compile deploy/dispatcher_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_68765a8c7fbc83259cf5707682536241