### PR TITLE
Update dispatcher path

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ At its heart is a single principle:
     │   ├── kong-codex/       ← Gateway config + local Typesense
     │   ├── typesense-codex/  ← Schema definitions + indexing logic
     │   └── teatro/           ← Teatro view engine
-    ├── dispatcher_v2.py   ← Daemonized build + feedback loop
+    ├── deploy/
+    │   └── dispatcher_v2.py   ← Daemonized build + feedback loop
     ├── logs/
     │    └── build.log  ← Swift compiler output
     ├── feedback/

--- a/agent.md
+++ b/agent.md
@@ -81,7 +81,7 @@ Accepted values for `"repo"`:
 | `/srv/deploy/repos/kong-codex/` | Kong gateway config + plugins |
 | `/srv/deploy/repos/typesense-codex/` | Typesense indexing definitions |
 | `/srv/deploy/repos/teatro/` | Teatro view engine |
-| `/srv/deploy/` | Contains `dispatcher_v2.py` and runtime control logic |
+| `/srv/deploy/deploy/` | Contains `dispatcher_v2.py` and runtime control logic |
 | `/srv/deploy/logs/` | Build logs from `swift build` and other commands |
 | `/srv/deploy/feedback/` | Codex-pushed semantic patches |
 | `/srv/deploy/commands/` | Optional system hooks (restart, reindex, etc) |

--- a/docs/dispatcher_v2.md
+++ b/docs/dispatcher_v2.md
@@ -25,7 +25,7 @@ service is built, logs are pushed to GitHub and feedback JSON files are applied.
 The systemd service has been updated to use this version by default:
 
 ```ini
-ExecStart=/usr/bin/python3 /srv/deploy/dispatcher_v2.py
+ExecStart=/usr/bin/python3 /srv/deploy/deploy/dispatcher_v2.py
 ```
 
 See the repository [README](../README.md) for setup details and an overview of

--- a/systemd/fountain-dispatcher.service
+++ b/systemd/fountain-dispatcher.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 EnvironmentFile=/srv/deploy/dispatcher.env
-ExecStart=/usr/bin/python3 /srv/deploy/dispatcher_v2.py
+ExecStart=/usr/bin/python3 /srv/deploy/deploy/dispatcher_v2.py
 WorkingDirectory=/srv/deploy
 Restart=always
 User=root


### PR DESCRIPTION
## Summary
- run dispatcher from /srv/deploy/deploy/dispatcher_v2.py
- document new path in dispatcher docs, agent guide, and README diagram

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68765a902de08325a661af19826b3c53