### PR TITLE
Allow dispatcher container to access host Docker daemon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM swift:5.8
-RUN apt-get update && apt-get install -y git python3 python3-pip \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y git python3 python3-pip docker.io docker-compose-v2 && \
+    rm -rf /var/lib/apt/lists/*
 WORKDIR /srv/deploy
 COPY . /srv/deploy

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -17,7 +17,7 @@ This document lists the environment variables used by the Codex deployer.
 | `GIT_USER_EMAIL` | `mail@benedikt-eickhoff.de` | Used to configure `git config --global user.email`. |
 | `DISPATCHER_BUILD_DOCKER` | `0` | Set to `1` to build Docker images for repos containing a `Dockerfile`. |
 | `DISPATCHER_RUN_E2E` | `0` | Set to `1` to run `docker compose` integration tests when available. |
-| | | Docker is not included in the default image – install it or mount the host Docker socket. |
+| | | The Docker CLI is installed in the image. Mount the host's Docker socket so `docker compose` commands can run. |
 | `SWIFTPM_NUM_JOBS` | `2` | Number of build jobs used by `swift test`. Helps limit CI runner concurrency. |
 | `SECRETS_API_URL` | _(none)_ | Endpoint for retrieving secrets at startup. |
 | `SECRETS_API_TOKEN` | _(none)_ | Authentication token for the secrets service. |

--- a/docs/mac_docker_tutorial.md
+++ b/docs/mac_docker_tutorial.md
@@ -46,13 +46,15 @@ export GITHUB_TOKEN=yourtoken
 export OPENAI_API_KEY=yourapikey  # optional
 export GIT_USER_NAME="Contexter"
 export GIT_USER_EMAIL=mail@benedikt-eickhoff.de
-docker run --rm -it -v $(pwd):/srv/deploy \
+docker run --rm -it \
+  -v $(pwd):/srv/deploy \
+  -v /var/run/docker.sock:/var/run/docker.sock \
   -e GITHUB_TOKEN -e OPENAI_API_KEY -e GIT_USER_NAME -e GIT_USER_EMAIL \
   codex-deployer-local \
   python3 /srv/deploy/deploy/dispatcher_v2.py
 ```
 
-Set `DISPATCHER_RUN_E2E=1` to run `docker compose` integration tests. Docker and `docker compose` must be installed inside the container or the host's Docker socket mounted. See [environment_variables.md](environment_variables.md) for the variable description.
+Set `DISPATCHER_RUN_E2E=1` to run `docker compose` integration tests. The image already includes the Docker CLI; mount `/var/run/docker.sock` so the container can talk to the host daemon. See [environment_variables.md](environment_variables.md) for the variable description.
 
 `GITHUB_TOKEN` must be a personal access token with access to your private
 repositories. See [managing_environment_variables.md](managing_environment_variables.md)

--- a/docs/mac_local_testing.md
+++ b/docs/mac_local_testing.md
@@ -34,12 +34,13 @@ docker build -t codex-deployer-local .
 The Dockerfile installs Python, Git and Swift then copies the repository into `/srv/deploy` so the dispatcher runs just like on a server.
 
 ## 4. Run the dispatcher with tests
-
-Export the variables and start the container with `DISPATCHER_RUN_E2E=1` to run integration tests. `docker` and `docker compose` must be available inside the container, so either install Docker in your image or mount the host's socket. See [environment_variables.md](environment_variables.md) for details:
+Export the variables and start the container with `DISPATCHER_RUN_E2E=1` to run integration tests. The Docker CLI is installed in the image, but the container needs access to the host daemon. Mount `/var/run/docker.sock` so `docker compose` commands work. See [environment_variables.md](environment_variables.md) for details:
 
 ```bash
 export $(grep -v '^#' dispatcher.env | xargs)
-docker run --rm -it -v $(pwd):/srv/deploy \
+docker run --rm -it \
+  -v $(pwd):/srv/deploy \
+  -v /var/run/docker.sock:/var/run/docker.sock \
   -e GITHUB_TOKEN -e OPENAI_API_KEY \
   -e DISPATCHER_RUN_E2E=1 \
   -e GIT_USER_NAME -e GIT_USER_EMAIL \

--- a/docs/managing_environment_variables.md
+++ b/docs/managing_environment_variables.md
@@ -66,11 +66,13 @@ The `set -a` command marks all variables for export so that `python3` inherits t
 
 ## 5. Running inside Docker
 
-Mount your project directory and pass the variables to Docker:
+Mount your project directory and pass the variables to Docker. The image includes
+the Docker CLI, so mount `/var/run/docker.sock` to connect to the host daemon:
 
 ```bash
 export $(grep -v '^#' dispatcher.env)
 docker run --rm -it -v $(pwd):/srv/deploy \
+  -v /var/run/docker.sock:/var/run/docker.sock \
   -e GITHUB_TOKEN -e OPENAI_API_KEY \
   codex-deployer-local \
   python3 /srv/deploy/deploy/dispatcher_v2.py


### PR DESCRIPTION
## Summary
- install docker CLI & compose plugin in the Dockerfile
- document mounting `/var/run/docker.sock` for integration tests
- update local testing, docker tutorial and env management docs
- clarify DISPATCHER_RUN_E2E row about Docker availability

## Testing
- `docker compose version | head`


------
https://chatgpt.com/codex/tasks/task_e_687662e8c46c8325a4eea1476b5043dd