### PR TITLE
Fix Git remote token handling

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -43,8 +43,11 @@ permissions. See GitHub's
 for instructions and follow
 [managing_environment_variables.md](managing_environment_variables.md) for a
 step-by-step walk-through of adding it to `dispatcher.env`.
+
 The token is used for cloning repositories, pushing commits, and pulling
 updates after pull requests merge so that Git never prompts for a username.
+The dispatcher also rewrites the ``origin`` remote with this token before any
+push, pull, or PR creation to ensure non-interactive authentication.
 
 ## Using GitHub Secrets
 


### PR DESCRIPTION
## Summary
- inject GITHUB_TOKEN into remote URL before git operations
- document automatic remote rewriting in environment variables docs

## Testing
- `python3 -m py_compile deploy/dispatcher_v2.py`

------
https://chatgpt.com/codex/tasks/task_e_68766617f5048325a33f9c490b32a51c