### PR TITLE
Add post-commit build hooks

### DIFF
--- a/docs/dispatcher_v2.md
+++ b/docs/dispatcher_v2.md
@@ -37,6 +37,6 @@ variables and see
 [managing_environment_variables.md](managing_environment_variables.md) for a
 step-by-step setup guide, including GitHub token creation. The systemd unit reads values from
 `/srv/deploy/dispatcher.env`. Set
-`DISPATCHER_BUILD_DOCKER=1` and `DISPATCHER_RUN_E2E=1` to enable cross-repo
-container builds and integration tests.
+`DISPATCHER_BUILD_DOCKER=1` and `DISPATCHER_RUN_E2E=1` to trigger Docker builds
+and integration tests after each successful commit or PR merge.
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -15,8 +15,8 @@ This document lists the environment variables used by the Codex deployer.
 | `FUNCTION_CALLER_URL` | _(none)_ | Base URL for the Function Caller service invoked by the Planner. |
 | `GIT_USER_NAME` | `Contexter` | Used to configure `git config --global user.name`. |
 | `GIT_USER_EMAIL` | `mail@benedikt-eickhoff.de` | Used to configure `git config --global user.email`. |
-| `DISPATCHER_BUILD_DOCKER` | `0` | Set to `1` to build Docker images for repos containing a `Dockerfile`. |
-| `DISPATCHER_RUN_E2E` | `0` | Set to `1` to run `docker compose` integration tests when available. |
+| `DISPATCHER_BUILD_DOCKER` | `0` | Set to `1` to build Docker images for repos containing a `Dockerfile` after each commit. |
+| `DISPATCHER_RUN_E2E` | `0` | Set to `1` to run `docker compose` integration tests after each commit when available. |
 | | | The Docker CLI is installed in the image. Mount the host's Docker socket so `docker compose` commands can run. |
 | `SWIFTPM_NUM_JOBS` | `2` | Number of build jobs used by `swift test`. Helps limit CI runner concurrency. |
 | `SECRETS_API_URL` | _(none)_ | Endpoint for retrieving secrets at startup. |


### PR DESCRIPTION
## Summary
- run optional Docker build and integration tests after committing
- log actions for Docker builds and tests
- document updated environment variable behaviour

## Testing
- `python3 -m py_compile deploy/dispatcher_v2.py`


------
https://chatgpt.com/codex/tasks/task_e_68766ceadeb88325b20b3dd507e66af0