### PR TITLE
Update Swift environment to 6.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:5.8
+FROM swift:6.1.2-jammy
 RUN apt-get update && \
     apt-get install -y git python3 python3-pip docker.io docker-compose-v2 && \
     rm -rf /var/lib/apt/lists/*

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,7 +3,10 @@
 set -e
 
 echo "[BOOTSTRAP] Updating and installing system dependencies..."
-apt update && apt install -y git python3 python3-pip swift curl unzip
+apt update && apt install -y git python3 python3-pip curl unzip
+# Install Swift using swiftly to ensure a modern toolchain
+curl -L https://github.com/swift-server/swiftly/releases/download/1.0.1/swiftly-linux-amd64.tar.gz | tar -xz -C /usr/local/bin
+/usr/local/bin/swiftly install 6.1.2
 
 echo "[BOOTSTRAP] Cloning codex-deployer repo into /srv/deploy..."
 mkdir -p /srv && cd /srv

--- a/docs/mac_docker_tutorial.md
+++ b/docs/mac_docker_tutorial.md
@@ -25,7 +25,7 @@ Create a small Docker image that includes Python, Git and Swift:
 
 ```bash
 cat > Dockerfile <<'DOCKER'
-FROM swift:5.8
+FROM swift:6.1.2-jammy
 RUN apt-get update && apt-get install -y git python3 python3-pip \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /srv/deploy


### PR DESCRIPTION
## Summary
- use Swift 6.1.2 image for the dispatcher container
- install Swift 6.1.2 via swiftly during bootstrap
- update the Docker tutorial docs to show the new base image

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_687675a433e88325829bb6db103eeede