### PR TITLE
Fix compile error by importing FoundationNetworking

### DIFF
--- a/repos/fountainai/Generated/Server/planner/LLMGatewayClient.swift
+++ b/repos/fountainai/Generated/Server/planner/LLMGatewayClient.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Client for the LLM Gateway. When `LLM_GATEWAY_URL` is unset it returns
 /// a stubbed response for offline tests. See `docs/environment_variables.md`.


### PR DESCRIPTION
## Summary
- fix missing URLSession by adding conditional FoundationNetworking import to LLMGatewayClient

## Testing
- `swift test -v` *(fails: compilation requires large dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_e_6876800760bc8325bc367872ae6ae256