### PR TITLE
Fix docker builds and update Mac instructions

### DIFF
--- a/docs/mac_docker_tutorial.md
+++ b/docs/mac_docker_tutorial.md
@@ -79,6 +79,7 @@ Press `Ctrl-C` in the terminal running the container to stop the dispatcher.
 
 - Map additional volumes if you want the cloned service repositories (like `fountainai`) to persist outside the container.
 - Edit files on your host; the container sees changes immediately because the project directory is mounted.
+- On macOS ensure the repository directory is listed under Docker Desktop > Settings > Resources > File Sharing, otherwise integration tests fail with "mounts denied" errors.
 
 ## 6. Cross-platform compilation
 

--- a/repos/fountainai/Generated/Server/baseline-awareness/Dockerfile
+++ b/repos/fountainai/Generated/Server/baseline-awareness/Dockerfile
@@ -1,9 +1,11 @@
 # baseline-awareness server container
 FROM swift:6.1-jammy AS build
 WORKDIR /src
-COPY ./ .
-RUN swiftc -O HTTPKernel.swift HTTPRequest.swift HTTPResponse.swift Router.swift Handlers.swift Models.swift main.swift -o /server
+COPY Generated/Server/Shared ./Shared
+COPY Generated/Server/baseline-awareness ./app
+WORKDIR /src/app
+RUN swiftc -emit-library -emit-module -module-name ServiceShared ../Shared/*.swift -o ../libServiceShared.so &&     swiftc -O -I .. -L .. -lServiceShared *.swift -o /server
 
 FROM ubuntu:22.04
-COPY --from=build /server /server
+COPY --from=build /src/app/server /server
 CMD ["/server"]

--- a/repos/fountainai/Generated/Server/bootstrap/Dockerfile
+++ b/repos/fountainai/Generated/Server/bootstrap/Dockerfile
@@ -1,9 +1,11 @@
 # bootstrap server container
 FROM swift:6.1-jammy AS build
 WORKDIR /src
-COPY ./ .
-RUN swiftc -O HTTPKernel.swift HTTPRequest.swift HTTPResponse.swift Router.swift Handlers.swift Models.swift main.swift -o /server
+COPY Generated/Server/Shared ./Shared
+COPY Generated/Server/bootstrap ./app
+WORKDIR /src/app
+RUN swiftc -emit-library -emit-module -module-name ServiceShared ../Shared/*.swift -o ../libServiceShared.so &&     swiftc -O -I .. -L .. -lServiceShared *.swift -o /server
 
 FROM ubuntu:22.04
-COPY --from=build /server /server
+COPY --from=build /src/app/server /server
 CMD ["/server"]

--- a/repos/fountainai/Generated/Server/function-caller/Dockerfile
+++ b/repos/fountainai/Generated/Server/function-caller/Dockerfile
@@ -1,9 +1,11 @@
 # function-caller server container
 FROM swift:6.1-jammy AS build
 WORKDIR /src
-COPY ./ .
-RUN swiftc -O HTTPKernel.swift HTTPRequest.swift HTTPResponse.swift Router.swift Handlers.swift Models.swift main.swift -o /server
+COPY Generated/Server/Shared ./Shared
+COPY Generated/Server/function-caller ./app
+WORKDIR /src/app
+RUN swiftc -emit-library -emit-module -module-name ServiceShared ../Shared/*.swift -o ../libServiceShared.so &&     swiftc -O -I .. -L .. -lServiceShared *.swift -o /server
 
 FROM ubuntu:22.04
-COPY --from=build /server /server
+COPY --from=build /src/app/server /server
 CMD ["/server"]

--- a/repos/fountainai/Generated/Server/llm-gateway/Dockerfile
+++ b/repos/fountainai/Generated/Server/llm-gateway/Dockerfile
@@ -1,9 +1,11 @@
 # llm-gateway server container
 FROM swift:6.1-jammy AS build
 WORKDIR /src
-COPY ./ .
-RUN swiftc -O HTTPKernel.swift HTTPRequest.swift HTTPResponse.swift Router.swift Handlers.swift Models.swift main.swift -o /server
+COPY Generated/Server/Shared ./Shared
+COPY Generated/Server/llm-gateway ./app
+WORKDIR /src/app
+RUN swiftc -emit-library -emit-module -module-name ServiceShared ../Shared/*.swift -o ../libServiceShared.so &&     swiftc -O -I .. -L .. -lServiceShared *.swift -o /server
 
 FROM ubuntu:22.04
-COPY --from=build /server /server
+COPY --from=build /src/app/server /server
 CMD ["/server"]

--- a/repos/fountainai/Generated/Server/persist/Dockerfile
+++ b/repos/fountainai/Generated/Server/persist/Dockerfile
@@ -1,9 +1,11 @@
 # persist server container
 FROM swift:6.1-jammy AS build
 WORKDIR /src
-COPY ./ .
-RUN swiftc -O HTTPKernel.swift HTTPRequest.swift HTTPResponse.swift Router.swift Handlers.swift Models.swift main.swift -o /server
+COPY Generated/Server/Shared ./Shared
+COPY Generated/Server/persist ./app
+WORKDIR /src/app
+RUN swiftc -emit-library -emit-module -module-name ServiceShared ../Shared/*.swift -o ../libServiceShared.so &&     swiftc -O -I .. -L .. -lServiceShared *.swift -o /server
 
 FROM ubuntu:22.04
-COPY --from=build /server /server
+COPY --from=build /src/app/server /server
 CMD ["/server"]

--- a/repos/fountainai/Generated/Server/planner/Dockerfile
+++ b/repos/fountainai/Generated/Server/planner/Dockerfile
@@ -1,9 +1,11 @@
 # planner server container
 FROM swift:6.1-jammy AS build
 WORKDIR /src
-COPY ./ .
-RUN swiftc -O HTTPKernel.swift HTTPRequest.swift HTTPResponse.swift Router.swift Handlers.swift Models.swift main.swift -o /server
+COPY Generated/Server/Shared ./Shared
+COPY Generated/Server/planner ./app
+WORKDIR /src/app
+RUN swiftc -emit-library -emit-module -module-name ServiceShared ../Shared/*.swift -o ../libServiceShared.so &&     swiftc -O -I .. -L .. -lServiceShared *.swift -o /server
 
 FROM ubuntu:22.04
-COPY --from=build /server /server
+COPY --from=build /src/app/server /server
 CMD ["/server"]

--- a/repos/fountainai/Generated/Server/tools-factory/Dockerfile
+++ b/repos/fountainai/Generated/Server/tools-factory/Dockerfile
@@ -1,9 +1,11 @@
 # tools-factory server container
 FROM swift:6.1-jammy AS build
 WORKDIR /src
-COPY ./ .
-RUN swiftc -O HTTPKernel.swift HTTPRequest.swift HTTPResponse.swift Router.swift Handlers.swift Models.swift main.swift -o /server
+COPY Generated/Server/Shared ./Shared
+COPY Generated/Server/tools-factory ./app
+WORKDIR /src/app
+RUN swiftc -emit-library -emit-module -module-name ServiceShared ../Shared/*.swift -o ../libServiceShared.so &&     swiftc -O -I .. -L .. -lServiceShared *.swift -o /server
 
 FROM ubuntu:22.04
-COPY --from=build /server /server
+COPY --from=build /src/app/server /server
 CMD ["/server"]

--- a/repos/fountainai/docker-compose.yml
+++ b/repos/fountainai/docker-compose.yml
@@ -1,16 +1,30 @@
 version: '3.9'
 services:
   baseline-awareness:
-    build: ./Generated/Server/baseline-awareness
+    build:
+      context: .
+      dockerfile: Generated/Server/baseline-awareness/Dockerfile
   bootstrap:
-    build: ./Generated/Server/bootstrap
+    build:
+      context: .
+      dockerfile: Generated/Server/bootstrap/Dockerfile
   function-caller:
-    build: ./Generated/Server/function-caller
+    build:
+      context: .
+      dockerfile: Generated/Server/function-caller/Dockerfile
   llm-gateway:
-    build: ./Generated/Server/llm-gateway
+    build:
+      context: .
+      dockerfile: Generated/Server/llm-gateway/Dockerfile
   planner:
-    build: ./Generated/Server/planner
+    build:
+      context: .
+      dockerfile: Generated/Server/planner/Dockerfile
   persist:
-    build: ./Generated/Server/persist
+    build:
+      context: .
+      dockerfile: Generated/Server/persist/Dockerfile
   tools-factory:
-    build: ./Generated/Server/tools-factory
+    build:
+      context: .
+      dockerfile: Generated/Server/tools-factory/Dockerfile


### PR DESCRIPTION
## Summary
- update service Dockerfiles to compile ServiceShared before building each service
- change `docker-compose.yml` to use repository root as build context
- add note about Docker Desktop file sharing to Mac tutorial

## Testing
- `swift test -v` *(failed: posix_spawn error)*

------
https://chatgpt.com/codex/tasks/task_e_6876875ccabc8325a783b2b60ee58399