### PR TITLE
Fix FunctionCallerClient integration test

### DIFF
--- a/repos/fountainai/Tests/IntegrationTests/ServicesIntegrationTests.swift
+++ b/repos/fountainai/Tests/IntegrationTests/ServicesIntegrationTests.swift
@@ -188,9 +188,13 @@ final class ServicesIntegrationTests: XCTestCase {
         let (server, port) = try await startServer(with: kernel)
         addTeardownBlock { try? await server.stop() }
 
-        let client = FunctionCallerClient.APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
-        let data = try await client.sendRaw(FunctionCallerClient.list_functions())
-        let items = try JSONDecoder().decode([FunctionCallerClient.FunctionInfo].self, from: data)
+        // The Swift OpenAPI generator exposes the client types at the module
+        // root. Reference them directly without the `FunctionCallerClient`
+        // prefix to avoid clashes with the server-side helper struct of the
+        // same name.
+        let client = APIClient(baseURL: URL(string: "http://127.0.0.1:\(port)")!)
+        let data = try await client.sendRaw(list_functions())
+        let items = try JSONDecoder().decode([FunctionInfo].self, from: data)
         XCTAssertEqual(items.first?.function_id, "f1")
     }
 


### PR DESCRIPTION
## Summary
- tweak FunctionCallerClient test to reference top-level API client types

## Testing
- `swift test --package-path repos/fountainai --list-tests` *(fails: no such member 'APIClient')*

------
https://chatgpt.com/codex/tasks/task_e_68768fb67abc8325819f89cf73b7d3b9