### PR TITLE
Fix missing imports for FountainAI servers

### DIFF
--- a/repos/fountainai/Generated/Server/baseline-awareness/HTTPServer.swift
+++ b/repos/fountainai/Generated/Server/baseline-awareness/HTTPServer.swift
@@ -1,4 +1,6 @@
 import Foundation
+import FoundationNetworking
+import BaselineAwarenessService
 
 public class HTTPServer: URLProtocol {
     static var kernel: HTTPKernel?

--- a/repos/fountainai/Generated/Server/baseline-awareness/main.swift
+++ b/repos/fountainai/Generated/Server/baseline-awareness/main.swift
@@ -6,7 +6,9 @@ import Glibc
 import Darwin
 #endif
 
-final class SimpleHTTPRuntime {
+import BaselineAwarenessService
+
+final class SimpleHTTPRuntime: @unchecked Sendable {
     enum RuntimeError: Error { case socket, bind, listen }
     let kernel: HTTPKernel
     let port: Int32

--- a/repos/fountainai/Generated/Server/bootstrap/main.swift
+++ b/repos/fountainai/Generated/Server/bootstrap/main.swift
@@ -6,7 +6,9 @@ import Glibc
 import Darwin
 #endif
 
-final class SimpleHTTPRuntime {
+import BootstrapService
+
+final class SimpleHTTPRuntime: @unchecked Sendable {
     enum RuntimeError: Error { case socket, bind, listen }
     let kernel: HTTPKernel
     let port: Int32

--- a/repos/fountainai/Generated/Server/function-caller/main.swift
+++ b/repos/fountainai/Generated/Server/function-caller/main.swift
@@ -6,7 +6,9 @@ import Glibc
 import Darwin
 #endif
 
-final class SimpleHTTPRuntime {
+import FunctionCallerService
+
+final class SimpleHTTPRuntime: @unchecked Sendable {
     enum RuntimeError: Error { case socket, bind, listen }
     let kernel: HTTPKernel
     let port: Int32

--- a/repos/fountainai/Generated/Server/llm-gateway/main.swift
+++ b/repos/fountainai/Generated/Server/llm-gateway/main.swift
@@ -6,7 +6,9 @@ import Glibc
 import Darwin
 #endif
 
-final class SimpleHTTPRuntime {
+import LLMGatewayService
+
+final class SimpleHTTPRuntime: @unchecked Sendable {
     enum RuntimeError: Error { case socket, bind, listen }
     let kernel: HTTPKernel
     let port: Int32

--- a/repos/fountainai/Generated/Server/persist/main.swift
+++ b/repos/fountainai/Generated/Server/persist/main.swift
@@ -6,7 +6,9 @@ import Glibc
 import Darwin
 #endif
 
-final class SimpleHTTPRuntime {
+import PersistService
+
+final class SimpleHTTPRuntime: @unchecked Sendable {
     enum RuntimeError: Error { case socket, bind, listen }
     let kernel: HTTPKernel
     let port: Int32

--- a/repos/fountainai/Generated/Server/planner/main.swift
+++ b/repos/fountainai/Generated/Server/planner/main.swift
@@ -6,7 +6,9 @@ import Glibc
 import Darwin
 #endif
 
-final class SimpleHTTPRuntime {
+import PlannerService
+
+final class SimpleHTTPRuntime: @unchecked Sendable {
     enum RuntimeError: Error { case socket, bind, listen }
     let kernel: HTTPKernel
     let port: Int32

--- a/repos/fountainai/Generated/Server/tools-factory/main.swift
+++ b/repos/fountainai/Generated/Server/tools-factory/main.swift
@@ -6,7 +6,9 @@ import Glibc
 import Darwin
 #endif
 
-final class SimpleHTTPRuntime {
+import ToolsFactoryService
+
+final class SimpleHTTPRuntime: @unchecked Sendable {
     enum RuntimeError: Error { case socket, bind, listen }
     let kernel: HTTPKernel
     let port: Int32


### PR DESCRIPTION
## Summary
- include required service modules in each generated server `main.swift`
- import FoundationNetworking and service module for BaselineAwareness `HTTPServer`
- mark `SimpleHTTPRuntime` classes as `@unchecked Sendable` to satisfy Sendable checks

## Testing
- `swift build` *(fails: Build output exceeds environment limits)*
- `swift test -v` *(fails: Build output exceeds environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6876ad35392883258b4756e96ff913c0