### PR TITLE
Fix Swift build issues

### DIFF
--- a/repos/fountainai/Generated/Server/planner/Handlers.swift
+++ b/repos/fountainai/Generated/Server/planner/Handlers.swift
@@ -7,7 +7,7 @@ import ServiceShared
 
 public struct Handlers {
     let llm = LLMGatewayClient()
-    let functions = FunctionCallerClient()
+    let functions = LocalFunctionCallerClient()
 
     public init() {}
 

--- a/repos/fountainai/Generated/Server/planner/LocalFunctionCallerClient.swift
+++ b/repos/fountainai/Generated/Server/planner/LocalFunctionCallerClient.swift
@@ -5,7 +5,7 @@ import ServiceShared
 /// Client for delegating executions to the Function Caller service. When
 /// `FUNCTION_CALLER_URL` is unset it falls back to the local dispatcher used
 /// during tests. See `docs/environment_variables.md`.
-struct FunctionCallerClient {
+struct LocalFunctionCallerClient {
     enum DispatchError: Error { case notFound }
 
     private let baseURL: URL?

--- a/repos/fountainai/Package.swift
+++ b/repos/fountainai/Package.swift
@@ -31,149 +31,160 @@ let package = Package(
         .target(
             name: "BaselineAwarenessService",
             dependencies: ["ServiceShared"],
-            path: "Generated/Server",
+            path: "Generated/Server/baseline-awareness",
+            exclude: ["main.swift", "HTTPServer.swift", "Dockerfile"],
             sources: [
-                "baseline-awareness/HTTPKernel.swift",
-                "baseline-awareness/Router.swift",
-                "baseline-awareness/Handlers.swift",
-                "baseline-awareness/Models.swift",
-                "baseline-awareness/HTTPRequest.swift",
-                "baseline-awareness/HTTPResponse.swift",
-                "baseline-awareness/BaselineStore.swift"
+                "HTTPKernel.swift",
+                "Router.swift",
+                "Handlers.swift",
+                "Models.swift",
+                "HTTPRequest.swift",
+                "HTTPResponse.swift",
+                "BaselineStore.swift"
             ]
         ),
         .executableTarget(
             name: "BaselineAwarenessServer",
             dependencies: ["BaselineAwarenessService"],
-            path: "Generated/Server",
-            sources: [
-                "baseline-awareness/main.swift",
-                "baseline-awareness/HTTPServer.swift"
-            ]
+            path: "Generated/Server/baseline-awareness",
+            exclude: ["HTTPKernel.swift", "Router.swift", "Handlers.swift", "Models.swift", "HTTPRequest.swift", "HTTPResponse.swift", "BaselineStore.swift", "Dockerfile"],
+            sources: ["main.swift", "HTTPServer.swift"]
         ),
         .target(name: "BaselineAwarenessClient", path: "Generated/Client/baseline-awareness"),
         .target(
             name: "BootstrapService",
             dependencies: ["ServiceShared", "BaselineAwarenessService"],
-            path: "Generated/Server",
+            path: "Generated/Server/bootstrap",
+            exclude: ["main.swift", "Dockerfile"],
             sources: [
-                "bootstrap/HTTPKernel.swift",
-                "bootstrap/Router.swift",
-                "bootstrap/Handlers.swift",
-                "bootstrap/Models.swift",
-                "bootstrap/HTTPRequest.swift",
-                "bootstrap/HTTPResponse.swift"
+                "HTTPKernel.swift",
+                "Router.swift",
+                "Handlers.swift",
+                "Models.swift",
+                "HTTPRequest.swift",
+                "HTTPResponse.swift"
             ]
         ),
         .executableTarget(
             name: "BootstrapServer",
             dependencies: ["BootstrapService"],
-            path: "Generated/Server",
-            sources: ["bootstrap/main.swift"]
+            path: "Generated/Server/bootstrap",
+            exclude: ["HTTPKernel.swift", "Router.swift", "Handlers.swift", "Models.swift", "HTTPRequest.swift", "HTTPResponse.swift", "Dockerfile"],
+            sources: ["main.swift"]
         ),
         .target(name: "BootstrapClient", path: "Generated/Client/bootstrap"),
         .target(
             name: "PersistService",
             dependencies: ["ServiceShared"],
-            path: "Generated/Server",
+            path: "Generated/Server/persist",
+            exclude: ["main.swift", "Dockerfile"],
             sources: [
-                "persist/HTTPKernel.swift",
-                "persist/Router.swift",
-                "persist/Handlers.swift",
-                "persist/Models.swift",
-                "persist/HTTPRequest.swift",
-                "persist/HTTPResponse.swift"
+                "HTTPKernel.swift",
+                "Router.swift",
+                "Handlers.swift",
+                "Models.swift",
+                "HTTPRequest.swift",
+                "HTTPResponse.swift"
             ]
         ),
         .executableTarget(
             name: "PersistServer",
             dependencies: ["PersistService"],
-            path: "Generated/Server",
-            sources: ["persist/main.swift"]
+            path: "Generated/Server/persist",
+            exclude: ["HTTPKernel.swift", "Router.swift", "Handlers.swift", "Models.swift", "HTTPRequest.swift", "HTTPResponse.swift", "Dockerfile"],
+            sources: ["main.swift"]
         ),
         .target(name: "PersistClient", path: "Generated/Client/persist"),
         .target(
             name: "FunctionCallerService",
             dependencies: ["ServiceShared", "Parser"],
-            path: "Generated/Server",
+            path: "Generated/Server/function-caller",
+            exclude: ["main.swift", "Dockerfile"],
             sources: [
-                "function-caller/HTTPKernel.swift",
-                "function-caller/Router.swift",
-                "function-caller/Handlers.swift",
-                "function-caller/Models.swift",
-                "function-caller/Dispatcher.swift",
-                "function-caller/HTTPRequest.swift",
-                "function-caller/HTTPResponse.swift",
-                "function-caller/Logger.swift"
+                "HTTPKernel.swift",
+                "Router.swift",
+                "Handlers.swift",
+                "Models.swift",
+                "Dispatcher.swift",
+                "HTTPRequest.swift",
+                "HTTPResponse.swift",
+                "Logger.swift"
             ]
         ),
         .executableTarget(
             name: "FunctionCallerServer",
             dependencies: ["FunctionCallerService"],
-            path: "Generated/Server",
-            sources: ["function-caller/main.swift"]
+            path: "Generated/Server/function-caller",
+            exclude: ["HTTPKernel.swift", "Router.swift", "Handlers.swift", "Models.swift", "Dispatcher.swift", "HTTPRequest.swift", "HTTPResponse.swift", "Logger.swift", "Dockerfile"],
+            sources: ["main.swift"]
         ),
         .target(name: "FunctionCallerClient", path: "Generated/Client/function-caller"),
         .target(
             name: "PlannerService",
             dependencies: ["ServiceShared"],
-            path: "Generated/Server",
+            path: "Generated/Server/planner",
+            exclude: ["main.swift", "Dockerfile"],
             sources: [
-                "planner/HTTPKernel.swift",
-                "planner/Router.swift",
-                "planner/Handlers.swift",
-                "planner/Models.swift",
-                "planner/LLMGatewayClient.swift",
-                "planner/FunctionCallerClient.swift",
-                "planner/HTTPRequest.swift",
-                "planner/HTTPResponse.swift"
+                "HTTPKernel.swift",
+                "Router.swift",
+                "Handlers.swift",
+                "Models.swift",
+                "LLMGatewayClient.swift",
+                "LocalFunctionCallerClient.swift",
+                "HTTPRequest.swift",
+                "HTTPResponse.swift"
             ]
         ),
         .executableTarget(
             name: "PlannerServer",
             dependencies: ["PlannerService"],
-            path: "Generated/Server",
-            sources: ["planner/main.swift"]
+            path: "Generated/Server/planner",
+            exclude: ["HTTPKernel.swift", "Router.swift", "Handlers.swift", "Models.swift", "LLMGatewayClient.swift", "LocalFunctionCallerClient.swift", "HTTPRequest.swift", "HTTPResponse.swift", "Dockerfile"],
+            sources: ["main.swift"]
         ),
         .target(name: "PlannerClient", path: "Generated/Client/planner"),
         .target(
             name: "ToolsFactoryService",
             dependencies: ["ServiceShared", "Parser"],
-            path: "Generated/Server",
+            path: "Generated/Server/tools-factory",
+            exclude: ["main.swift", "Dockerfile"],
             sources: [
-                "tools-factory/HTTPKernel.swift",
-                "tools-factory/Router.swift",
-                "tools-factory/Handlers.swift",
-                "tools-factory/Models.swift",
-                "tools-factory/HTTPRequest.swift",
-                "tools-factory/HTTPResponse.swift"
+                "HTTPKernel.swift",
+                "Router.swift",
+                "Handlers.swift",
+                "Models.swift",
+                "HTTPRequest.swift",
+                "HTTPResponse.swift"
             ]
         ),
         .executableTarget(
             name: "ToolsFactoryServer",
             dependencies: ["ToolsFactoryService"],
-            path: "Generated/Server",
-            sources: ["tools-factory/main.swift"]
+            path: "Generated/Server/tools-factory",
+            exclude: ["HTTPKernel.swift", "Router.swift", "Handlers.swift", "Models.swift", "HTTPRequest.swift", "HTTPResponse.swift", "Dockerfile"],
+            sources: ["main.swift"]
         ),
         .target(name: "ToolsFactoryClient", path: "Generated/Client/tools-factory"),
         .target(
             name: "LLMGatewayService",
             dependencies: ["ServiceShared"],
-            path: "Generated/Server",
+            path: "Generated/Server/llm-gateway",
+            exclude: ["main.swift", "Dockerfile"],
             sources: [
-                "llm-gateway/HTTPKernel.swift",
-                "llm-gateway/Router.swift",
-                "llm-gateway/Handlers.swift",
-                "llm-gateway/Models.swift",
-                "llm-gateway/HTTPRequest.swift",
-                "llm-gateway/HTTPResponse.swift"
+                "HTTPKernel.swift",
+                "Router.swift",
+                "Handlers.swift",
+                "Models.swift",
+                "HTTPRequest.swift",
+                "HTTPResponse.swift"
             ]
         ),
         .executableTarget(
             name: "LLMGatewayServer",
             dependencies: ["LLMGatewayService"],
-            path: "Generated/Server",
-            sources: ["llm-gateway/main.swift"]
+            path: "Generated/Server/llm-gateway",
+            exclude: ["HTTPKernel.swift", "Router.swift", "Handlers.swift", "Models.swift", "HTTPRequest.swift", "HTTPResponse.swift", "Dockerfile"],
+            sources: ["main.swift"]
         ),
         .target(name: "LLMGatewayClientSDK", path: "Generated/Client/llm-gateway"),
         .target(


### PR DESCRIPTION
## Summary
- rename FunctionCallerClient to LocalFunctionCallerClient
- update planner handlers to use new name
- reorganize Package.swift paths and exclude unused sources

## Testing
- `swift build 2>&1 | grep -m 1 unhandled`
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_68772c46ba9883258748e62f80935844