### PR TITLE
Fix warnings

### DIFF
--- a/repos/fountainai/Sources/IntegrationRuntime/AsyncHTTPClientDriver.swift
+++ b/repos/fountainai/Sources/IntegrationRuntime/AsyncHTTPClientDriver.swift
@@ -5,7 +5,7 @@ import NIOHTTP1
 public final class AsyncHTTPClientDriver: HTTPClientProtocol, @unchecked Sendable {
     let client: HTTPClient
 
-    public init(eventLoopGroupProvider: HTTPClient.EventLoopGroupProvider = .createNew) {
+    public init(eventLoopGroupProvider: HTTPClient.EventLoopGroupProvider = .singleton) {
         self.client = HTTPClient(eventLoopGroupProvider: eventLoopGroupProvider)
     }
 

--- a/repos/fountainai/Sources/IntegrationRuntime/HTTPRequest.swift
+++ b/repos/fountainai/Sources/IntegrationRuntime/HTTPRequest.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public struct NoBody: Codable {}
 
-public struct HTTPRequest {
+public struct HTTPRequest: Sendable {
     public let method: String
     public let path: String
     public var headers: [String: String]

--- a/repos/fountainai/Sources/IntegrationRuntime/HTTPResponse.swift
+++ b/repos/fountainai/Sources/IntegrationRuntime/HTTPResponse.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct HTTPResponse {
+public struct HTTPResponse: Sendable {
     public var status: Int
     public var headers: [String: String]
     public var body: Data

--- a/repos/fountainai/Sources/IntegrationRuntime/NIOHTTPServer.swift
+++ b/repos/fountainai/Sources/IntegrationRuntime/NIOHTTPServer.swift
@@ -66,7 +66,7 @@ public final class NIOHTTPServer: @unchecked Sendable {
                         var responseHead = HTTPResponseHead(version: head.version, status: .init(statusCode: resp.status))
                         responseHead.headers = headers
                         context.write(self.wrapOutboundOut(.head(responseHead)), promise: nil)
-                        var buffer = context.channel.allocator.buffer(bytes: resp.body)
+                        let buffer = context.channel.allocator.buffer(bytes: resp.body)
                         context.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
                         context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
                     }
@@ -79,3 +79,5 @@ public final class NIOHTTPServer: @unchecked Sendable {
 }
 
 extension NIOHTTPServer.HTTPHandler: @unchecked Sendable {}
+
+extension ChannelHandlerContext: @unchecked Sendable {}


### PR DESCRIPTION
## Summary
- fix AsyncHTTPClientDriver deprecation
- make request/response sendable
- clean up server warnings

## Testing
- `swift test -v` *(failed: output exceeded limit)*

------
https://chatgpt.com/codex/tasks/task_e_68773a2ca7c0832596545599977e9e64