### PR TITLE
Remove @main attribute

### DIFF
--- a/repos/fountainai/Sources/Generator/main.swift
+++ b/repos/fountainai/Sources/Generator/main.swift
@@ -4,7 +4,6 @@ import ModelEmitter
 import ClientGenerator
 import ServerGenerator
 
-@main
 struct GeneratorCLI {
     static func run(args: [String]) throws {
         var inputPath: String?
@@ -34,3 +33,5 @@ struct GeneratorCLI {
         try run(args: Array(CommandLine.arguments.dropFirst()))
     }
 }
+
+try GeneratorCLI.main()


### PR DESCRIPTION
## Summary
- remove @main from `GeneratorCLI`
- manually call `GeneratorCLI.main()` at the file bottom

## Testing
- `swift test -v` *(failed: build process too heavy to complete in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68775074bb3c83259fe893204d2acef6