### PR TITLE
Fix sendable warning in HTTPServer

### DIFF
--- a/repos/fountainai/Generated/Server/baseline-awareness/HTTPServer.swift
+++ b/repos/fountainai/Generated/Server/baseline-awareness/HTTPServer.swift
@@ -34,7 +34,8 @@ import BaselineAwarenessService
             body: self.request.httpBody ?? Data()
         )
         let client = self.client
-        Task { [client] in
+        let strongSelf = self
+        Task { [client, strongSelf] @Sendable in
             do {
                 let resp = try await kernel.handle(req)
                 let httpResponse = HTTPURLResponse(
@@ -43,11 +44,11 @@ import BaselineAwarenessService
                     httpVersion: "HTTP/1.1",
                     headerFields: resp.headers
                 )!
-                client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
-                client?.urlProtocol(self, didLoad: resp.body)
-                client?.urlProtocolDidFinishLoading(self)
+                client?.urlProtocol(strongSelf, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(strongSelf, didLoad: resp.body)
+                client?.urlProtocolDidFinishLoading(strongSelf)
             } catch {
-                client?.urlProtocol(self, didFailWithError: error)
+                client?.urlProtocol(strongSelf, didFailWithError: error)
             }
         }
     }

--- a/repos/fountainai/Tests/GeneratorTests/Fixtures/Generated/Server/HTTPServer.swift
+++ b/repos/fountainai/Tests/GeneratorTests/Fixtures/Generated/Server/HTTPServer.swift
@@ -20,15 +20,16 @@ public class HTTPServer: URLProtocol {
             return
         }
         let req = HTTPRequest(method: request.httpMethod ?? "GET", path: url.path, headers: request.allHTTPHeaderFields ?? [:], body: request.httpBody ?? Data())
-        Task {
+        let strongSelf = self
+        Task { [strongSelf] @Sendable in
             do {
                 let resp = try await kernel.handle(req)
                 let httpResponse = HTTPURLResponse(url: url, statusCode: resp.status, httpVersion: "HTTP/1.1", headerFields: resp.headers)!
-                client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
-                client?.urlProtocol(self, didLoad: resp.body)
-                client?.urlProtocolDidFinishLoading(self)
+                client?.urlProtocol(strongSelf, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(strongSelf, didLoad: resp.body)
+                client?.urlProtocolDidFinishLoading(strongSelf)
             } catch {
-                client?.urlProtocol(self, didFailWithError: error)
+                client?.urlProtocol(strongSelf, didFailWithError: error)
             }
         }
     }

--- a/repos/fountainai/Tests/ServerTests/HTTPServer.swift
+++ b/repos/fountainai/Tests/ServerTests/HTTPServer.swift
@@ -24,15 +24,16 @@ import FoundationNetworking
         }
         let req = HTTPRequest(method: self.request.httpMethod ?? "GET", path: url.path, headers: self.request.allHTTPHeaderFields ?? [:], body: self.request.httpBody ?? Data())
         let client = self.client
-        Task { [client] in
+        let strongSelf = self
+        Task { [client, strongSelf] @Sendable in
             do {
                 let resp = try await kernel.handle(req)
                 let httpResponse = HTTPURLResponse(url: url, statusCode: resp.status, httpVersion: "HTTP/1.1", headerFields: resp.headers)!
-                client?.urlProtocol(self, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
-                client?.urlProtocol(self, didLoad: resp.body)
-                client?.urlProtocolDidFinishLoading(self)
+                client?.urlProtocol(strongSelf, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(strongSelf, didLoad: resp.body)
+                client?.urlProtocolDidFinishLoading(strongSelf)
             } catch {
-                client?.urlProtocol(self, didFailWithError: error)
+                client?.urlProtocol(strongSelf, didFailWithError: error)
             }
         }
     }


### PR DESCRIPTION
## Summary
- fix 'sending' warning by capturing `self` in a constant and marking the task closure `@Sendable`

## Testing
- `swift test -v` *(fails: build did not complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_687757648e24832599fe72ec350007f4