### PR TITLE
Fix Task capture syntax

### DIFF
--- a/repos/fountainai/Generated/Server/baseline-awareness/HTTPServer.swift
+++ b/repos/fountainai/Generated/Server/baseline-awareness/HTTPServer.swift
@@ -34,7 +34,8 @@ import BaselineAwarenessService
             body: self.request.httpBody ?? Data()
         )
         let client = self.client
-        Task { [client, strongSelf = self] @Sendable in
+        let strongSelf = self
+        Task { @Sendable in
             do {
                 let resp = try await kernel.handle(req)
                 let httpResponse = HTTPURLResponse(

--- a/repos/fountainai/Tests/GeneratorTests/Fixtures/Generated/Server/HTTPServer.swift
+++ b/repos/fountainai/Tests/GeneratorTests/Fixtures/Generated/Server/HTTPServer.swift
@@ -20,7 +20,8 @@ public class HTTPServer: URLProtocol {
             return
         }
         let req = HTTPRequest(method: request.httpMethod ?? "GET", path: url.path, headers: request.allHTTPHeaderFields ?? [:], body: request.httpBody ?? Data())
-        Task { [strongSelf = self] @Sendable in
+        let strongSelf = self
+        Task { @Sendable in
             do {
                 let resp = try await kernel.handle(req)
                 let httpResponse = HTTPURLResponse(url: url, statusCode: resp.status, httpVersion: "HTTP/1.1", headerFields: resp.headers)!

--- a/repos/fountainai/Tests/ServerTests/HTTPServer.swift
+++ b/repos/fountainai/Tests/ServerTests/HTTPServer.swift
@@ -24,7 +24,8 @@ import FoundationNetworking
         }
         let req = HTTPRequest(method: self.request.httpMethod ?? "GET", path: url.path, headers: self.request.allHTTPHeaderFields ?? [:], body: self.request.httpBody ?? Data())
         let client = self.client
-        Task { [client, strongSelf = self] @Sendable in
+        let strongSelf = self
+        Task { @Sendable in
             do {
                 let resp = try await kernel.handle(req)
                 let httpResponse = HTTPURLResponse(url: url, statusCode: resp.status, httpVersion: "HTTP/1.1", headerFields: resp.headers)!


### PR DESCRIPTION
## Summary
- update HTTPServer closure capture syntax

## Testing
- `swift test` *(fails: cannot convert value of type '__socket_type' to expected argument type 'Int32')*

------
https://chatgpt.com/codex/tasks/task_e_68775bd95bfc83258e5f5d51a02fcc62