### PR TITLE
Mark HTTPServer as @unchecked Sendable

### DIFF
--- a/repos/fountainai/Generated/Server/baseline-awareness/HTTPServer.swift
+++ b/repos/fountainai/Generated/Server/baseline-awareness/HTTPServer.swift
@@ -55,3 +55,5 @@ import BaselineAwarenessService
 
     override public func stopLoading() {}
 }
+
+extension HTTPServer: @unchecked Sendable {}

--- a/repos/fountainai/Tests/GeneratorTests/Fixtures/Generated/Server/HTTPServer.swift
+++ b/repos/fountainai/Tests/GeneratorTests/Fixtures/Generated/Server/HTTPServer.swift
@@ -36,3 +36,5 @@ public class HTTPServer: URLProtocol {
 
     override public func stopLoading() {}
 }
+
+extension HTTPServer: @unchecked Sendable {}

--- a/repos/fountainai/Tests/ServerTests/HTTPServer.swift
+++ b/repos/fountainai/Tests/ServerTests/HTTPServer.swift
@@ -40,3 +40,5 @@ import FoundationNetworking
 
     override public func stopLoading() {}
 }
+
+extension HTTPServer: @unchecked Sendable {}


### PR DESCRIPTION
## Summary
- mark `HTTPServer` as conforming to `@unchecked Sendable` to silence concurrency warnings

## Testing
- `swift test -v` *(fails: cannot convert value of type '__socket_type' to expected argument type 'Int32')*

------
https://chatgpt.com/codex/tasks/task_e_68775dd2a1e483259556d0dea1dd5477