### PR TITLE
Fix unused corpusId warnings

### DIFF
--- a/repos/fountainai/Generated/Server/persist/Handlers.swift
+++ b/repos/fountainai/Generated/Server/persist/Handlers.swift
@@ -11,7 +11,7 @@ public struct Handlers {
         self.typesense = typesense
     }
     public func addbaseline(_ request: HTTPRequest) async throws -> HTTPResponse {
-        guard let corpusId = request.path.split(separator: "/").dropFirst(2).first,
+        guard request.path.split(separator: "/").dropFirst(2).first != nil,
               let model = try? JSONDecoder().decode(Baseline.self, from: request.body) else {
             return HTTPResponse(status: 400)
         }
@@ -30,7 +30,7 @@ public struct Handlers {
     }
 
     public func addreflection(_ request: HTTPRequest) async throws -> HTTPResponse {
-        guard let corpusId = request.path.split(separator: "/").dropFirst(2).first,
+        guard request.path.split(separator: "/").dropFirst(2).first != nil,
               let reflection = try? JSONDecoder().decode(Reflection.self, from: request.body) else {
             return HTTPResponse(status: 400)
         }


### PR DESCRIPTION
## Summary
- remove unused `corpusId` bindings in Persist handlers

## Testing
- `swift test -v` *(failed: environment limits prevented completion)*

------
https://chatgpt.com/codex/tasks/task_e_68775fc3649483259e8f6c70c6c73e5f