### PR TITLE
Fix unused variable and optional coercion warnings

### DIFF
--- a/repos/fountainai/Sources/ModelEmitter/ModelEmitter.swift
+++ b/repos/fountainai/Sources/ModelEmitter/ModelEmitter.swift
@@ -33,7 +33,7 @@ public enum ModelEmitter {
                 return
             }
 
-            if let type = schema.type {
+            if let _ = schema.type {
                 output += "public typealias \(name) = \(schema.swiftType)\n\n"
             }
         }

--- a/repos/fountainai/Sources/Parser/SpecLoader.swift
+++ b/repos/fountainai/Sources/Parser/SpecLoader.swift
@@ -16,7 +16,12 @@ public enum SpecLoader {
         guard let yamlString = String(data: data, encoding: .utf8) else {
             throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Input data is not valid UTF-8"))
         }
-        var yamlObject = try Yams.load(yaml: yamlString)
+        guard let loadedYaml = try Yams.load(yaml: yamlString) else {
+            throw DecodingError.dataCorrupted(
+                .init(codingPath: [], debugDescription: "YAML document is empty")
+            )
+        }
+        var yamlObject = loadedYaml
 
         // If using OpenAPI 3.x with `info.title`, normalize to `title`
         if var dict = yamlObject as? [String: Any] {


### PR DESCRIPTION
## Summary
- address unused `type` binding in `ModelEmitter.swift`
- unwrap YAML parsing result in `SpecLoader.swift` to avoid `Any?` coercion

## Testing
- `swift test -v` *(fails: cannot convert value of type '__socket_type' to 'Int32')*

------
https://chatgpt.com/codex/tasks/task_e_6877619ed2a88325bb12ae53b76062b1