### PR TITLE
Fix Linux socket type cast

### DIFF
--- a/repos/fountainai/Generated/Server/baseline-awareness/main.swift
+++ b/repos/fountainai/Generated/Server/baseline-awareness/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        serverFD = socket(AF_INET, SOCK_STREAM, 0)
+        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
         guard serverFD >= 0 else { throw RuntimeError.socket }
         var opt: Int32 = 1
         setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))

--- a/repos/fountainai/Generated/Server/bootstrap/main.swift
+++ b/repos/fountainai/Generated/Server/bootstrap/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        serverFD = socket(AF_INET, SOCK_STREAM, 0)
+        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
         guard serverFD >= 0 else { throw RuntimeError.socket }
         var opt: Int32 = 1
         setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))

--- a/repos/fountainai/Generated/Server/function-caller/main.swift
+++ b/repos/fountainai/Generated/Server/function-caller/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        serverFD = socket(AF_INET, SOCK_STREAM, 0)
+        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
         guard serverFD >= 0 else { throw RuntimeError.socket }
         var opt: Int32 = 1
         setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))

--- a/repos/fountainai/Generated/Server/llm-gateway/main.swift
+++ b/repos/fountainai/Generated/Server/llm-gateway/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        serverFD = socket(AF_INET, SOCK_STREAM, 0)
+        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
         guard serverFD >= 0 else { throw RuntimeError.socket }
         var opt: Int32 = 1
         setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))

--- a/repos/fountainai/Generated/Server/persist/main.swift
+++ b/repos/fountainai/Generated/Server/persist/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        serverFD = socket(AF_INET, SOCK_STREAM, 0)
+        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
         guard serverFD >= 0 else { throw RuntimeError.socket }
         var opt: Int32 = 1
         setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))

--- a/repos/fountainai/Generated/Server/planner/main.swift
+++ b/repos/fountainai/Generated/Server/planner/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        serverFD = socket(AF_INET, SOCK_STREAM, 0)
+        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
         guard serverFD >= 0 else { throw RuntimeError.socket }
         var opt: Int32 = 1
         setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))

--- a/repos/fountainai/Generated/Server/tools-factory/main.swift
+++ b/repos/fountainai/Generated/Server/tools-factory/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        serverFD = socket(AF_INET, SOCK_STREAM, 0)
+        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
         guard serverFD >= 0 else { throw RuntimeError.socket }
         var opt: Int32 = 1
         setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))


### PR DESCRIPTION
## Summary
- cast SOCK_STREAM using `Int32(SOCK_STREAM.rawValue)` for Linux compatibility

## Testing
- `swift build -c debug`
- `swift test -q` *(fails: capture of non-Sendable types in `ServerTests`)*

------
https://chatgpt.com/codex/tasks/task_e_6878811adad883258725e3e94150b639