### PR TITLE
Fix Sendable warning in tests

### DIFF
--- a/repos/fountainai/Tests/ServerTests/HTTPServer.swift
+++ b/repos/fountainai/Tests/ServerTests/HTTPServer.swift
@@ -42,3 +42,6 @@ import FoundationNetworking
 }
 
 extension HTTPServer: @unchecked Sendable {}
+
+extension HTTPKernel: @unchecked Sendable {}
+extension HTTPRequest: @unchecked Sendable {}


### PR DESCRIPTION
## Summary
- allow HTTPKernel and HTTPRequest to be captured in @Sendable tasks

## Testing
- `swift test -v` *(fails: 15 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687884c71ea08325b32c420dde021ef8