### PR TITLE
Fix Swift concurrency test warnings

### DIFF
--- a/repos/fountainai/Tests/ServerTests/HTTPKernel.swift
+++ b/repos/fountainai/Tests/ServerTests/HTTPKernel.swift
@@ -11,3 +11,6 @@ public struct HTTPKernel {
         try await router.route(request)
     }
 }
+
+// Allow using HTTPKernel across concurrency domains for tests
+extension HTTPKernel: @unchecked Sendable {}

--- a/repos/fountainai/Tests/ServerTests/HTTPRequest.swift
+++ b/repos/fountainai/Tests/ServerTests/HTTPRequest.swift
@@ -15,3 +15,6 @@ public struct HTTPRequest {
         self.body = body
     }
 }
+
+// Allow using HTTPRequest across concurrency domains for tests
+extension HTTPRequest: @unchecked Sendable {}

--- a/repos/fountainai/Tests/ServerTests/ServerTests.swift
+++ b/repos/fountainai/Tests/ServerTests/ServerTests.swift
@@ -54,7 +54,7 @@ final class ServerTests: XCTestCase {
 
     func testHTTPServerViaURLSession() async throws {
         let kernel = HTTPKernel()
-        await HTTPServer.register(kernel: kernel)
+        HTTPServer.register(kernel: kernel)
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [HTTPServer.self]
         let session = URLSession(configuration: config)


### PR DESCRIPTION
## Summary
- mark HTTPKernel and HTTPRequest types as `Sendable` in tests
- remove unnecessary await from server registration

## Testing
- `swift test -v` *(fails: Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_68788a5bb6148325abf0ca8b2cfb042b