### PR TITLE
Fix generator import and Task handling

### DIFF
--- a/repos/fountainai/Sources/ClientGenerator/ClientGenerator.swift
+++ b/repos/fountainai/Sources/ClientGenerator/ClientGenerator.swift
@@ -23,7 +23,9 @@ public enum ClientGenerator {
 
         let apiClient = """
         import Foundation
+        #if canImport(FoundationNetworking)
         import FoundationNetworking
+        #endif
 
         public protocol HTTPSession {
             func data(for request: URLRequest) async throws -> (Data, URLResponse)


### PR DESCRIPTION
## Summary
- update client generator to conditionally import FoundationNetworking
- emit `@Sendable` Task blocks and make HTTPServer `@unchecked Sendable`

## Testing
- `swift test -v --filter GeneratorTests.testCLIWithFixtures` *(fails: initializer `init(_)` requires that `__socket_type` conform to `BinaryFloatingPoint`)*

------
https://chatgpt.com/codex/tasks/task_e_68788db8a884832588049e598be04b1c