### PR TITLE
Fix tests by resetting Typesense state

### DIFF
--- a/repos/fountainai/Generated/Server/Shared/TypesenseClient.swift
+++ b/repos/fountainai/Generated/Server/Shared/TypesenseClient.swift
@@ -290,4 +290,16 @@ public actor TypesenseClient {
         let r = reflections[corpusId]?.count ?? 0
         return b + d + p + r
     }
+
+    /// Clears all stored data. Tests call this to avoid state leakage.
+    public func reset() async {
+        corpora.removeAll()
+        functions.removeAll()
+        baselines.removeAll()
+        drifts.removeAll()
+        patterns.removeAll()
+        reflections.removeAll()
+        roles.removeAll()
+        saveCache()
+    }
 }

--- a/repos/fountainai/Tests/IntegrationTests/ServicesIntegrationTests.swift
+++ b/repos/fountainai/Tests/IntegrationTests/ServicesIntegrationTests.swift
@@ -19,6 +19,21 @@ import ServiceShared
 @testable import LLMGatewayClientSDK
 
 final class ServicesIntegrationTests: XCTestCase {
+    var cachePath: String!
+
+    override func setUp() async throws {
+        cachePath = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString).path
+        setenv("FUNCTIONS_CACHE_PATH", cachePath, 1)
+        FileManager.default.createFile(atPath: cachePath, contents: Data(), attributes: nil)
+        await TypesenseClient.shared.reset()
+    }
+
+    override func tearDown() async throws {
+        await TypesenseClient.shared.reset()
+        unsetenv("FUNCTIONS_CACHE_PATH")
+        try? FileManager.default.removeItem(atPath: cachePath)
+    }
     func startServer(with kernel: IntegrationRuntime.HTTPKernel) async throws -> (NIOHTTPServer, Int) {
         let server = NIOHTTPServer(kernel: kernel)
         let port = try await server.start(port: 0)


### PR DESCRIPTION
## Summary
- add a `reset()` helper to `TypesenseClient` for clearing in-memory state
- isolate integration test runs by setting a temp `FUNCTIONS_CACHE_PATH` and clearing Typesense state

## Testing
- `swift test -v` *(failed: compilation took too long in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_687898e44cd0832593c182da76571f60