### PR TITLE
Add log analyzer usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ At its heart is a single principle:
 | `dispatcher_v2.py` | The daemon loop (v2.4): pulls repos, builds services, opens PRs by default |
 | `logs/latest.log` | Most recent Swift build/test output |
 | `logs/build-*.log` | Historical logs for each dispatcher cycle |
+| `analyze_swift_log.py` | Parse `build.log` and produce a Markdown report |
+| `report.md` | Output of the log analyzer |
 | `feedback/` | Codex inbox – write here to apply changes or fix builds |
 | `commands/restart-services.sh` | Optional legacy restart script |
 | `commands/restart-target.sh` | Restart a service specified in feedback |
@@ -136,6 +138,16 @@ likewise prevents these files from entering the Docker context.
 ### Running on macOS
 
 Docker Desktop requires explicit volume sharing. Open **Settings → Resources → File Sharing** and add `/srv/deploy/repos/kong-codex/`. Restart Docker Desktop before running `docker compose` or the Kong configuration mount will fail.
+
+### Analyzing Swift Logs
+
+After a build, you can summarize errors recorded in `build.log`:
+
+```bash
+python3 analyze_swift_log.py
+```
+
+The script reads `build.log` from the current directory and writes `report.md` with one section per log segment and a suggested fix. Open `report.md` in your editor to review the results.
 
 ---
 

--- a/docs/dispatcher_v2.md
+++ b/docs/dispatcher_v2.md
@@ -40,3 +40,5 @@ step-by-step setup guide, including GitHub token creation. The systemd unit read
 `DISPATCHER_BUILD_DOCKER=1` and `DISPATCHER_RUN_E2E=1` to trigger Docker builds
 and integration tests after each successful commit or PR merge.
 
+For tips on reviewing failed builds, see the [README](../README.md#analyzing-swift-logs) section on analyzing Swift logs.
+

--- a/docs/mac_local_testing.md
+++ b/docs/mac_local_testing.md
@@ -59,6 +59,8 @@ ls deploy/logs
 cat deploy/logs/build.log
 ```
 
+To generate a concise error report, run `python3 analyze_swift_log.py` from the repository root. It will produce `report.md` summarizing each log segment. See [README](../README.md#analyzing-swift-logs) for details.
+
 ## 6. Stopping
 
 Press `Ctrl-C` in the terminal running the container to stop the dispatcher.


### PR DESCRIPTION
## Summary
- document how to run `analyze_swift_log.py`
- note generated `report.md`
- link log analyzer instructions from dispatcher v2 and macOS testing docs
- list analyzer script in key files table

## Testing
- `swift --version`
- `swift test -v` *(failed to complete due to lengthy build, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_6878bc42d9ec832582054c641bda77a3