### PR TITLE
Fix fixtures and socket casts

### DIFF
--- a/repos/fountainai/Generated/Server/Shared/TypesenseClient.swift
+++ b/repos/fountainai/Generated/Server/Shared/TypesenseClient.swift
@@ -97,6 +97,15 @@ public actor TypesenseClient {
 
     // MARK: - Functions
     public func addFunction(_ fn: Function) async {
+        var fn = fn
+        if fn.parametersSchema == nil {
+            fn = Function(description: fn.description,
+                         functionId: fn.functionId,
+                         httpMethod: fn.httpMethod,
+                         httpPath: fn.httpPath,
+                         name: fn.name,
+                         parametersSchema: "{}")
+        }
         if let _ = baseURL {
             let body = try? JSONEncoder().encode(fn)
             _ = try? await request(path: "functions", method: "POST", body: body)

--- a/repos/fountainai/Generated/Server/llm-gateway/main.swift
+++ b/repos/fountainai/Generated/Server/llm-gateway/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        serverFD = socket(Int32(AF_INET), Int32(SOCK_STREAM), 0)
+        serverFD = socket(Int32(AF_INET), Int32(SOCK_STREAM.rawValue), Int32(0))
         guard serverFD >= 0 else { throw RuntimeError.socket }
         var opt: Int32 = 1
         setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))

--- a/repos/fountainai/Generated/Server/persist/main.swift
+++ b/repos/fountainai/Generated/Server/persist/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        serverFD = socket(Int32(AF_INET), Int32(SOCK_STREAM), 0)
+        serverFD = socket(Int32(AF_INET), Int32(SOCK_STREAM.rawValue), Int32(0))
         guard serverFD >= 0 else { throw RuntimeError.socket }
         var opt: Int32 = 1
         setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))

--- a/repos/fountainai/Generated/Server/planner/main.swift
+++ b/repos/fountainai/Generated/Server/planner/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        serverFD = socket(Int32(AF_INET), Int32(SOCK_STREAM), 0)
+        serverFD = socket(Int32(AF_INET), Int32(SOCK_STREAM.rawValue), Int32(0))
         guard serverFD >= 0 else { throw RuntimeError.socket }
         var opt: Int32 = 1
         setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))

--- a/repos/fountainai/Tests/IntegrationTests/ServicesIntegrationTests.swift
+++ b/repos/fountainai/Tests/IntegrationTests/ServicesIntegrationTests.swift
@@ -200,7 +200,7 @@ final class ServicesIntegrationTests: XCTestCase {
     }
 
     func testFunctionCallerListFunctions() async throws {
-        let json = #"{"description":"test","functionId":"f1","httpMethod":"GET","httpPath":"http://example.com","name":"fn"}"#.data(using: .utf8)!
+        let json = #"{"description":"test","functionId":"f1","httpMethod":"GET","httpPath":"http://example.com","name":"fn","parametersSchema":"{}"}"#.data(using: .utf8)!
         let fn = try JSONDecoder().decode(ServiceShared.Function.self, from: json)
         await TypesenseClient.shared.addFunction(fn)
         let serviceKernel = FunctionCallerService.HTTPKernel()


### PR DESCRIPTION
## Summary
- fix type mismatch when calling `socket`
- ensure added functions carry empty parameters schema
- include parameters schema in `testFunctionCallerListFunctions`

## Testing
- `swift build --product planner-server` *(fails: none)*
- `swift test -v --jobs 1` *(failed to complete in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6878c698db588325b03d92050e5a46a2