### PR TITLE
Fix SOCK_STREAM constants in generated servers

### DIFF
--- a/repos/fountainai/Generated/Server/baseline-awareness/main.swift
+++ b/repos/fountainai/Generated/Server/baseline-awareness/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        serverFD = socket(AF_INET, SOCK_STREAM, 0)
         guard serverFD >= 0 else { throw RuntimeError.socket }
         var opt: Int32 = 1
         setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))

--- a/repos/fountainai/Generated/Server/bootstrap/main.swift
+++ b/repos/fountainai/Generated/Server/bootstrap/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        serverFD = socket(AF_INET, SOCK_STREAM, 0)
         guard serverFD >= 0 else { throw RuntimeError.socket }
         var opt: Int32 = 1
         setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))

--- a/repos/fountainai/Generated/Server/function-caller/main.swift
+++ b/repos/fountainai/Generated/Server/function-caller/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        serverFD = socket(AF_INET, SOCK_STREAM, 0)
         guard serverFD >= 0 else { throw RuntimeError.socket }
         var opt: Int32 = 1
         setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))

--- a/repos/fountainai/Generated/Server/llm-gateway/main.swift
+++ b/repos/fountainai/Generated/Server/llm-gateway/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        let socketType: Int32 = Int32(SOCK_STREAM.rawValue)
+        let socketType: Int32 = SOCK_STREAM
 
         serverFD = socket(AF_INET, socketType, 0)
         guard serverFD >= 0 else { throw RuntimeError.socket }

--- a/repos/fountainai/Generated/Server/persist/main.swift
+++ b/repos/fountainai/Generated/Server/persist/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        let socketType: Int32 = Int32(SOCK_STREAM.rawValue)
+        let socketType: Int32 = SOCK_STREAM
 
         serverFD = socket(AF_INET, socketType, 0)
         guard serverFD >= 0 else { throw RuntimeError.socket }

--- a/repos/fountainai/Generated/Server/planner/main.swift
+++ b/repos/fountainai/Generated/Server/planner/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        let socketType: Int32 = Int32(SOCK_STREAM.rawValue)
+        let socketType: Int32 = SOCK_STREAM
 
         serverFD = socket(AF_INET, socketType, 0)
         guard serverFD >= 0 else { throw RuntimeError.socket }

--- a/repos/fountainai/Generated/Server/tools-factory/main.swift
+++ b/repos/fountainai/Generated/Server/tools-factory/main.swift
@@ -20,7 +20,7 @@ final class SimpleHTTPRuntime: @unchecked Sendable {
     }
 
     func start() throws {
-        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        serverFD = socket(AF_INET, SOCK_STREAM, 0)
         guard serverFD >= 0 else { throw RuntimeError.socket }
         var opt: Int32 = 1
         setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))


### PR DESCRIPTION
## Summary
- fix incorrect `.rawValue` usage for `SOCK_STREAM` in generated server `main.swift` files

## Testing
- `swift test -v` *(failed: build timed out in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_6878f3a574fc832590ce7477614d473a