### PR TITLE
Add SocketFixAgent for cross-platform socket constants

### DIFF
--- a/repos/fountainai/Makefile
+++ b/repos/fountainai/Makefile
@@ -1,0 +1,10 @@
+.PHONY: socketfix build test
+
+socketfix:
+	swift run SocketFixAgent
+
+build:
+	swift build
+
+test:
+	swift test -v

--- a/repos/fountainai/Package.swift
+++ b/repos/fountainai/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
         .executable(name: "planner-server", targets: ["PlannerServer"]),
         .executable(name: "tools-factory-server", targets: ["ToolsFactoryServer"]),
         .executable(name: "llm-gateway-server", targets: ["LLMGatewayServer"]),
+        .executable(name: "SocketFixAgent", targets: ["SocketFixAgent"]),
     ],
     dependencies: [
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
@@ -195,6 +196,10 @@ let package = Package(
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio")
             ]
+        ),
+        .executableTarget(
+            name: "SocketFixAgent",
+            path: "Tools/Agents"
         ),
         .executableTarget(
             name: "Generator",

--- a/repos/fountainai/README.md
+++ b/repos/fountainai/README.md
@@ -93,6 +93,16 @@ Add or modify any service spec under the appropriate version directory inside `F
 - **Missing Swift toolchain** – install dependencies with `sudo apt-get update && sudo apt-get install -y clang libicu-dev swift`.
 - **Build failures** – run `swift build -v` to see compilation output and verify you generated sources for the intended service.
 
+### Developer Tools
+
+Run the SocketFix agent after regeneration to ensure server code builds on both macOS and Linux:
+
+```bash
+make socketfix
+```
+
+This rewrites any unsafe `rawValue` socket constants under `Generated/Server/*/main.swift`.
+
 ---
 
 ## ✅ Codex Compatibility

--- a/repos/fountainai/Tools/Agents/SocketFixAgent.swift
+++ b/repos/fountainai/Tools/Agents/SocketFixAgent.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+struct SocketFixAgent {
+    private let constants = ["AF_INET", "SOCK_STREAM", "SOCK_DGRAM", "IPPROTO_TCP"]
+    private let fileManager = FileManager.default
+
+    func run() throws {
+        let generatedPath = "Generated/Server"
+        guard let enumerator = fileManager.enumerator(atPath: generatedPath) else {
+            return
+        }
+        var patched: [String] = []
+        for case let file as String in enumerator {
+            if file.hasSuffix("main.swift") {
+                let path = generatedPath + "/" + file
+                var contents = try String(contentsOfFile: path)
+                let original = contents
+                for constant in constants {
+                    let pattern = "\\b" + constant + "\\.rawValue\\b"
+                    let regex = try NSRegularExpression(pattern: pattern)
+                    let range = NSRange(contents.startIndex..<contents.endIndex, in: contents)
+                    contents = regex.stringByReplacingMatches(in: contents, options: [], range: range, withTemplate: constant)
+                }
+                if contents != original {
+                    try contents.write(toFile: path, atomically: true, encoding: .utf8)
+                    patched.append(path)
+                }
+            }
+        }
+        if patched.isEmpty {
+            print("No socket constants needed fixing")
+        } else {
+            print("Patched \(patched.count) files:")
+            for f in patched { print("- \(f)") }
+        }
+    }
+}
+
+@main
+struct Main {
+    static func main() throws {
+        try SocketFixAgent().run()
+    }
+}


### PR DESCRIPTION
## Summary
- add SocketFixAgent to rewrite socket `.rawValue` usages
- provide Makefile helper for running the agent
- document SocketFixAgent in README
- expose SocketFixAgent target from `Package.swift`

## Testing
- `swift build` *(fails: cannot convert value of type '__socket_type' to specified type 'Int32')*
- `swift test -v` *(fails: cannot convert value of type '__socket_type' to specified type 'Int32')*

------
https://chatgpt.com/codex/tasks/task_e_6878f89e2be88325b2cd207a1d4a4a50