### PR TITLE
Add documentation handbook directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ At its heart is a single principle:
 | `docs/fountainai_mac_ui_plan.md` | Plan for a macOS UI using FountainAI and Teatro |
 | `docs/what_is_git.md` | Intro to Git with history and flow |
 | `docs/design_patterns.md` | Evaluation of client/server, plugin, and declarative patterns |
+| `docs/handbook/README.md` | Central hub for all deployment guides |
 
 ---
 

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -1,0 +1,29 @@
+# Codex-Deployer Handbook
+
+Welcome to the early draft of the **Codex-Deployer Handbook**. This folder aggregates the
+existing tutorials and reference material for operating the deployment loop.
+The goal is to centralize onboarding documentation so new contributors can
+locate all relevant guides in one place.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+  - [Running on macOS with Docker](../mac_docker_tutorial.md)
+  - [Local Testing on macOS](../mac_local_testing.md)
+  - [Managing Environment Variables](../managing_environment_variables.md)
+  - [Environment Variables Reference](../environment_variables.md)
+- [Dispatcher Details](#dispatcher-details)
+  - [Dispatcher v2 Overview](../dispatcher_v2.md)
+  - [Pull Request Workflow](../pull_request_workflow.md)
+- [Background Reading](#background-reading)
+  - [Design Pattern Evaluation](../design_patterns.md)
+  - [Log Aggregation Setup](../log_aggregation.md)
+  - [Secrets API Proposal](../secrets_api_proposal.md)
+  - [What is Git?](../what_is_git.md)
+  - [FountainAI macOS UI Plan](../fountainai_mac_ui_plan.md)
+
+These documents should give you a complete picture of how the dispatcher works,
+how to configure it, and how the surrounding services fit together. All guides
+reference [`environment_variables.md`](../environment_variables.md) when
+describing required settings.
+


### PR DESCRIPTION
## Summary
- add `docs/handbook` with a README linking all tutorials and references
- link to the handbook from the main README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6879da36af248325b13ba44384ebca98