### PR TITLE
Add early Codex introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 *Git-driven deployment companion for Swift services.*
 
+Powered by OpenAI's [Codex](https://platform.openai.com/docs/guides/codex),
+the dispatcher acts like a **semantic compiler**. It interprets build logs,
+rewrites code automatically and keeps services in sync without waiting for
+traditional CI feedback.
+
 Copyright (c) 2025 Benedikte Eickhoff. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 

--- a/docs/handbook/introduction.md
+++ b/docs/handbook/introduction.md
@@ -4,7 +4,9 @@
 
 Codex-Deployer is an always-on deployment companion built around a simple idea: every build is feedback for the next.
 
-The project bundles several FountainAI services and a Python dispatcher that continuously pulls repositories, compiles the code, and reacts to failures. By keeping the entire deployment logic in Git, the dispatcher acts like a compiler for infrastructure. You operate it just like any other repository: clone it, edit the configuration, and run the dispatcher.
+Powered by OpenAI's [Codex](https://platform.openai.com/docs/guides/codex), the dispatcher acts like a **semantic compiler** for infrastructure. It reads build logs, proposes fixes and keeps services coherent.
+
+The project bundles several FountainAI services and a Python dispatcher that continuously pulls repositories, compiles the code, and reacts to failures. Because all deployment logic lives in Git, you operate it just like any other repository: clone it, edit the configuration, and run the dispatcher.
 
 This introduction summarises the core concepts and explains how environment variables drive the system. Follow the links at the end for deeper dives.
 


### PR DESCRIPTION
## Summary
- explain Codex's semantic compiler role at the top of the README
- mention Codex in the Handbook introduction with a link to OpenAI docs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a29b7d1ac8325a72dd7ea9871d4c2