### PR TITLE
Add bridges between README sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 *Git-driven deployment companion for Swift services.*
 
+Codex-Deployer orchestrates builds and deployments directly from Git. Powered by
+OpenAI's [Codex][codex-doc], it acts like a **semantic compiler**—interpreting
+build logs and rewriting code automatically. These foundations pave the way for
+FountainAI—a suite of microservices that will extend Codex into a cross-platform
+LLM operating system. Once deployed, FountainAI aims to emancipate from Codex
+and serve as its own semantic reasoning engine.
+
 Copyright (c) 2025 Benedikte Eickhoff. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 
@@ -11,12 +18,15 @@ Codex-Deployer keeps multiple services in lockstep. A small Python loop builds t
 
 ## 1. Problem
 Deploying several Swift services across Linux and macOS quickly becomes brittle. Every project needs a slightly different toolchain and CI feedback is slow.
+To overcome these hurdles, Codex-Deployer unifies builds, logs and fixes in one workflow.
 
 ## 2. Solution
-Codex-Deployer bundles everything in one Git repository. A Python dispatcher pulls the repos, builds each service and commits any fixes. Environment variables configure authentication and optional Docker Compose tests. See [docs/environment_variables.md](docs/environment_variables.md).
+Codex-Deployer bundles everything in one Git repository. A Python dispatcher pulls the repos, builds each service and commits any fixes. Environment variables configure authentication and optional Docker Compose tests[^env-vars].
+Understanding how this works requires a quick look at the architecture.
 
 ## 3. Architecture
-The dispatcher loop lives in `deploy/dispatcher_v2.py`. It writes logs to `deploy/logs/` and reads patch proposals from `feedback/`. A diagram and feature list appear in [Architecture Overview](docs/handbook/architecture.md).
+The dispatcher loop lives in `deploy/dispatcher_v2.py`. It writes logs to `deploy/logs/` and reads patch proposals from `feedback/`. A diagram and feature list appear in the architecture overview[^arch-overview].
+With these components in mind, you can start the dispatcher locally in a few steps.
 
 ## 4. Quick start
 ```bash
@@ -32,10 +42,11 @@ docker run --rm -it \
   codex-deployer-local \
   python3 /srv/deploy/deploy/dispatcher_v2.py
 ```
-For a full explanation of each variable and how to generate tokens, see [managing_environment_variables.md](docs/managing_environment_variables.md).
+For a full explanation of each variable and how to generate tokens, see the setup guide[^manage-env].
+Once the basics are running, the documentation hub walks you through advanced usage.
 
 ## 5. Documentation hub
-Start with the [Handbook](docs/handbook/README.md) for tutorials. The [Introduction](docs/handbook/introduction.md) prepares you for the environment setup and cross‑platform workflow. The [Code Reference](docs/handbook/code_reference.md) links to inline docs.
+Start with the handbook[^handbook] for tutorials. The introduction[^intro] prepares you for the environment setup and cross‑platform workflow. The code reference[^code-ref] links to inline docs.
 
 ## Key files
 | File | Purpose |
@@ -45,7 +56,18 @@ Start with the [Handbook](docs/handbook/README.md) for tutorials. The [Introduct
 | `docs/environment_variables.md` | Variable reference |
 | `AGENT.md` | Agent behaviour contract |
 
+The references below expand on each topic and trace the project's evolution.
+
 ## Further reading
-- [Architecture Overview](docs/handbook/architecture.md)
-- [History and Roadmap](docs/handbook/history.md)
-- [Code Reference](docs/handbook/code_reference.md)
+- Architecture overview[^arch-overview]
+- History and roadmap[^history]
+- Code reference[^code-ref]
+
+[codex-doc]: https://platform.openai.com/docs/codex/overview
+[^env-vars]: `docs/environment_variables.md`
+[^manage-env]: `docs/managing_environment_variables.md`
+[^handbook]: `docs/handbook/README.md`
+[^intro]: `docs/handbook/introduction.md`
+[^code-ref]: `docs/handbook/code_reference.md`
+[^arch-overview]: `docs/handbook/architecture.md`
+[^history]: `docs/handbook/history.md`

--- a/docs/handbook/introduction.md
+++ b/docs/handbook/introduction.md
@@ -4,7 +4,11 @@
 
 Codex-Deployer is an always-on deployment companion built around a simple idea: every build is feedback for the next.
 
-The project bundles several FountainAI services and a Python dispatcher that continuously pulls repositories, compiles the code, and reacts to failures. By keeping the entire deployment logic in Git, the dispatcher acts like a compiler for infrastructure. You operate it just like any other repository: clone it, edit the configuration, and run the dispatcher.
+Powered by OpenAI's [Codex][codex-doc], the dispatcher acts like a **semantic compiler** for infrastructure. It reads build logs, proposes fixes and keeps services coherent. See the official Codex overview[^codex-doc] for more details.
+
+FountainAI expands this concept into a cross-platform LLM operating system. When fully deployed it will extend Codex and eventually operate independently as a semantic reasoning engine.
+
+The project bundles several FountainAI services and a Python dispatcher that continuously pulls repositories, compiles the code, and reacts to failures. Because all deployment logic lives in Git, you operate it just like any other repository: clone it, edit the configuration, and run the dispatcher.
 
 This introduction summarises the core concepts and explains how environment variables drive the system. Follow the links at the end for deeper dives.
 
@@ -47,3 +51,5 @@ list of options.
 - [Dispatcher v2 Overview](../dispatcher_v2.md) – deep dive into how the loop works and how pull requests are opened.
 
 The [handbook README](README.md) contains a complete table of contents with links to additional background material. For API details see [code_reference.md](code_reference.md).
+
+[codex-doc]: https://platform.openai.com/docs/codex/overview


### PR DESCRIPTION
## Summary
- connect Problem -> Solution -> Architecture -> Quick start with short transitions
- guide readers to docs hub and further reading

## Testing
- `python3 -m py_compile analyze_swift_log.py`


------
https://chatgpt.com/codex/tasks/task_e_687a29b7d1ac8325a72dd7ea9871d4c2