### PR TITLE
Apply copyright footer to all docs

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -17,6 +17,7 @@ All contributor guides live under `docs/handbook`. Start from the
   are introduced or removed.
 - Reference that file in documentation and code comments when explaining
   configuration.
+- Ensure every README and other `.md` file ends with the preformatted copyright notice.
 
 ---
 
@@ -217,3 +218,12 @@ main.swift:5 -> main.swift:5:5: error: use of unresolved identifier 'foo'
 **Suggested Fix:** Define or import the missing symbol.
 ```
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,12 @@
 
 `AGENTS.md` has been merged into [AGENT.md](AGENT.md).
 Please update any links or tooling that still refer to this file.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -233,3 +233,12 @@
 - 2025-07-18T05:23:43.294815 Update build log build-20250718-052340.log: 2025-07-18T05:23:43.121150
 - 2025-07-18T05:25:48.756982 Update build log build-20250718-052546.log: 2025-07-18T05:25:48.697541
 - 2025-07-18T05:27:41.572091 Update build log build-20250718-052738.log: 2025-07-18T05:27:41.522467
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/README.md
+++ b/README.md
@@ -66,3 +66,9 @@ The references below expand on each topic and trace the project's evolution.
 - [Code reference](docs/handbook/code_reference.md)
 
 [codex-doc]: https://platform.openai.com/docs/codex/overview
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/agent.md
+++ b/agent.md
@@ -1,3 +1,12 @@
 # Deprecated
 
 This file has been replaced by [AGENT.md](AGENT.md). Please update your references.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/analysis.md
+++ b/analysis.md
@@ -8,3 +8,12 @@ initializer 'init(_:)' requires that '__socket_type' conform to 'BinaryFloatingP
 
 This indicates the constants `AF_INET` and `SOCK_STREAM` need to be explicitly cast to `Int32` when calling `socket()` on Linux. After patching `main.swift` files to use `Int32(AF_INET)` and `Int32(SOCK_STREAM)`, the build could not fully complete due to environment resource limits.
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/design_patterns.md
+++ b/docs/design_patterns.md
@@ -51,3 +51,12 @@ Teatro defines its UI purely through declarations.
 ## Overall Evaluation
 
 The combination of a client/server kernel, plugin-driven gateway, and declarative view engine offers clear separation of concerns. While each pattern introduces trade-offs, the design aligns with common best practices and provides a solid foundation for scaling the system.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/dispatcher_v2.md
+++ b/docs/dispatcher_v2.md
@@ -42,3 +42,12 @@ and integration tests after each successful commit or PR merge.
 
 For tips on reviewing failed builds, see the [README](../README.md#analyzing-swift-logs) section on analyzing Swift logs.
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -85,3 +85,12 @@ tokens remain private. The accompanying `.dockerignore` file ensures these
 values are not copied into Docker build contexts.
 
 See the [handbook](handbook/README.md) for additional setup guides.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/fountainai_mac_ui_plan.md
+++ b/docs/fountainai_mac_ui_plan.md
@@ -46,3 +46,12 @@ This document outlines an iterative approach for building a macOS desktop applic
 ---
 
 Following this plan will produce a fully featured macOS application that leverages FountainAI's microservices and Teatro's declarative rendering system.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -40,3 +40,12 @@ how to configure it, and how the surrounding services fit together. All guides
 reference [`environment_variables.md`](../environment_variables.md) when
 describing required settings.
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/handbook/architecture.md
+++ b/docs/handbook/architecture.md
@@ -48,3 +48,12 @@ For a gentle introduction see [Introduction to Codex-Deployer](introduction.md).
 
 For implementation details see [dispatcher_v2.md](../dispatcher_v2.md).
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/handbook/code_reference.md
+++ b/docs/handbook/code_reference.md
@@ -22,3 +22,12 @@ pydoc deploy.dispatcher_v2
 Generated services live under `repos/fountainai`. Documentation will be produced
 with `swift package generate-documentation` once the build pipeline is enabled.
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/handbook/history.md
+++ b/docs/handbook/history.md
@@ -11,3 +11,12 @@ Codex-Deployer began as an experiment to remove brittle CI pipelines and GitHub 
 - Improve the auto-patch workflow with better conflict handling
 
 Return to the [handbook index](README.md) for additional background material.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/handbook/introduction.md
+++ b/docs/handbook/introduction.md
@@ -51,3 +51,12 @@ list of options.
 - [Dispatcher v2 Overview](../dispatcher_v2.md) – deep dive into how the loop works and how pull requests are opened.
 
 The [handbook README](README.md) contains a complete table of contents with links to additional background material. For API details see [code_reference.md](code_reference.md).
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/log_aggregation.md
+++ b/docs/log_aggregation.md
@@ -19,3 +19,12 @@ services:
 Replace `loki-url` with your aggregator endpoint. The same pattern applies to the Tools Factory and other services.
 
 For manual deployments, run a tool like `fluent-bit` or `promtail` to stream logs from Docker to the aggregator.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/mac_docker_tutorial.md
+++ b/docs/mac_docker_tutorial.md
@@ -100,3 +100,12 @@ This lets the dispatcher build Swift packages that rely on Apple-provided
 frameworks while still running inside a container. Prefer the open source Swift
 toolchain whenever possible, but branch out into vendor-specific builds only
 when necessary.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/mac_local_testing.md
+++ b/docs/mac_local_testing.md
@@ -71,3 +71,12 @@ Press `Ctrl-C` in the terminal running the container to stop the dispatcher.
 - [mac_docker_tutorial.md](mac_docker_tutorial.md) – more details on running the dispatcher locally
 - [environment_variables.md](environment_variables.md) – complete variable reference
 - [managing_environment_variables.md](managing_environment_variables.md) – step‑by‑step setup guide
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/managing_environment_variables.md
+++ b/docs/managing_environment_variables.md
@@ -98,3 +98,12 @@ Using a token avoids interactive Git prompts when cloning private repositories.
 - [mac_docker_tutorial.md](mac_docker_tutorial.md) – full walkthrough for macOS
 
 - [handbook](handbook/README.md) – index of all tutorials
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/pull_request_workflow.md
+++ b/docs/pull_request_workflow.md
@@ -12,3 +12,12 @@ When PR mode is active the dispatcher:
 
 This approach allows human review while keeping automation centralized. Direct push mode remains available by disabling `DISPATCHER_USE_PRS`.
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/secrets_api_proposal.md
+++ b/docs/secrets_api_proposal.md
@@ -31,3 +31,12 @@ Storing long‑lived secrets on disk increases the risk of exposure. Fetching th
 
 Implementing this approach would require extending the dispatcher to perform the API call and parse the response before continuing with the build loop. See [environment_variables.md](environment_variables.md) for the complete list of variables that would be supplied by the secret service.
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/what_is_git.md
+++ b/docs/what_is_git.md
@@ -13,3 +13,12 @@ In the Codex deployer, Git plays a central role. The dispatcher pulls repositori
 *Figure 1: Git's evolution from a patch management tool to the standard version control system.*
 
 *Figure 2: The branching flow used by Codex deployer to orchestrate code updates.*
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/notables/kong_pitch.md
+++ b/notables/kong_pitch.md
@@ -17,3 +17,12 @@ By choosing Kong as our API gateway, we benefit from the following features with
 Configuration variables for the deployment system are documented in [`docs/environment_variables.md`](../docs/environment_variables.md). Although no Kong-specific variables are listed there, we can introduce them in the future and keep that file updated.
 
 Overall, Kong provides production-ready routing, security, observability, and extensibility, reducing the need for a custom gateway built in Swift or Python.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/notables/kong_scenarios.md
+++ b/notables/kong_scenarios.md
@@ -11,3 +11,12 @@ The FountainAI microservices expose OpenAPI-based endpoints that can be unified 
 7. **Declarative Configuration with CI/CD** – Gateway configuration stored under version control can be rolled out automatically as part of the deployer loop. Any environment variables for this process are documented in [docs/environment_variables.md](../docs/environment_variables.md).
 
 These scenarios show how Kong becomes more than a simple router—it orchestrates versioning, tenant management, observability and real-time tooling around FountainAI's services.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/report.md
+++ b/report.md
@@ -89,3 +89,12 @@ NIOHTTPServer.swift:61 -> /srv/deploy/repos/fountainai/Sources/IntegrationRuntim
 |                      `- warning: passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure
 **Suggested Fix:** Review the code around the reported line.
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/AGENTS.md
+++ b/repos/fountainai/AGENTS.md
@@ -9,3 +9,12 @@ This repository uses Swift 6 and Swift Package Manager.
   sudo apt-get update && sudo apt-get install -y clang libicu-dev swift
   ```
 - Summarize the test results in the PR description.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/CHANGELOG.md
+++ b/repos/fountainai/CHANGELOG.md
@@ -7,3 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ## [0.1.0] - 2025-07-07
 ### Added
 - Initial OpenAPI specs and generator skeleton.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/Docs/Historical/FountainAi_implementation_Agenda.md
+++ b/repos/fountainai/Docs/Historical/FountainAi_implementation_Agenda.md
@@ -49,3 +49,12 @@ For each service:
 ---
 
 Following this agenda will lead to a complete set of FountainAI services implemented in Swift, each accompanied by an independent client SDK and clear documentation describing how they fit together.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/Docs/Historical/codex-bootstrap.md
+++ b/repos/fountainai/Docs/Historical/codex-bootstrap.md
@@ -30,3 +30,12 @@ The `README.md` describes the purpose and structure of this project. The `.codex
 - You may use modular directory structure and file naming as appropriate.
 
 Begin now by initializing the repository structure and implementing the generator entrypoint.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/Docs/Historical/codex-plan.md
+++ b/repos/fountainai/Docs/Historical/codex-plan.md
@@ -69,3 +69,12 @@ This plan defines how Codex should build a Swift 6-native OpenAPI code generator
 - [ ] Consider GitHub Actions workflow for `swift build` + `swift test`.
 
 ---
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/Docs/Historical/improvement-agenda.md
+++ b/repos/fountainai/Docs/Historical/improvement-agenda.md
@@ -58,3 +58,12 @@ The project has a solid start: parsing, model emission, client and server genera
    - Evaluate deeper validation of OpenAPI documents to catch more errors during parsing.
 
 Addressing these items will close the gap between the current implementation and the aspirations laid out in the execution plan, delivering a more polished and self‑describing project.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/Docs/StatusQuo/FountainAi_openAPI_Status_Report.md
+++ b/repos/fountainai/Docs/StatusQuo/FountainAi_openAPI_Status_Report.md
@@ -64,3 +64,12 @@ Unit tests verify the generator using a simplified fixture rather than the full 
 - Maintain a changelog of spec revisions and corresponding generated versions.
 
 Implementing these steps will transform the current skeleton generators into production‑ready client libraries and standalone servers for the entire FountainAI suite.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/Docs/StatusQuo/Reports/baseline-awareness-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/baseline-awareness-status.md
@@ -28,3 +28,12 @@ Spec path: `FountainAi/openAPI/v1/baseline-awareness.yml` (version 1.0.0).
 - `/corpus/history/stream` streams analytics via Server-Sent Events
 - Prometheus metrics now record request durations for performance insights
 - Structured logging added for easier debugging and monitoring
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/Docs/StatusQuo/Reports/bootstrap-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/bootstrap-status.md
@@ -21,3 +21,12 @@ Spec path: `FountainAi/openAPI/v1/bootstrap.yml` (version 1.0.0).
 - Added authentication middleware and Prometheus monitoring
 - Implemented reflection promotion logic and streaming analytics
 - Added structured logging and a Compose workflow example
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/Docs/StatusQuo/Reports/deployment.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/deployment.md
@@ -53,3 +53,12 @@ docker compose down
 
 This workflow lets you run the microservices locally. Future updates will add full networking and durable persistence.
 All containers emit JSON logs which can be aggregated by your logging stack.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/Docs/StatusQuo/Reports/function-caller-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/function-caller-status.md
@@ -35,3 +35,12 @@ Spec path: `FountainAi/openAPI/v1/function-caller.yml` (version 1.0.0).
 - **Completed**: Registered functions persist across restarts via Typesense integration
 - Document Kubernetes deployment examples
 - See [next-steps.md](next-steps.md) for cross-service priorities
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/Docs/StatusQuo/Reports/integration-testing-alternative.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/integration-testing-alternative.md
@@ -36,3 +36,12 @@ This document describes the cross-platform runtime now used for integration test
 
 All current integration tests use this runtime and run in CI on Linux and macOS.
 Developers run `swift test -v` locally to reproduce the same cross-platform flow.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/Docs/StatusQuo/Reports/llm-gateway-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/llm-gateway-status.md
@@ -27,3 +27,12 @@ Spec path: `FountainAi/openAPI/v2/llm-gateway.yml` (version 2.0.0).
 - Add integration tests for the `/chat` endpoint
 - Provide Docker build and deployment instructions
 - Document `OPENAI_API_KEY` and `OPENAI_API_BASE` usage in [environment_variables.md](../../../../../docs/environment_variables.md)
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/Docs/StatusQuo/Reports/next-steps.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/next-steps.md
@@ -19,3 +19,12 @@ All FountainAI services now run using a shared Swift concurrency runtime. Integr
 5. **Document configuration** – reference required environment variables in [environment_variables.md](../../../../../docs/environment_variables.md) from all service documentation.
 
 Completing these steps will transition FountainAI from prototype status to a stable, production‑ready microservice suite.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/Docs/StatusQuo/Reports/persistence-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/persistence-status.md
@@ -23,3 +23,12 @@ Spec path: `FountainAi/openAPI/v1/persist.yml` (version 1.0.0).
 - Provide containerization instructions for deploying with Typesense
 - Document required environment variables
 - Add backup and restore procedures
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/Docs/StatusQuo/Reports/planner-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/planner-status.md
@@ -25,3 +25,12 @@ Spec path: `FountainAi/openAPI/v1/planner.yml` (version 1.0.0).
 - **Completed**: Implemented full workflow orchestration calling the LLM Gateway and Function Caller
 - Document environment variables and external dependencies
 - Refer to [environment_variables.md](../../../../../docs/environment_variables.md) when configuring the service
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/Docs/StatusQuo/Reports/tools-factory-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/tools-factory-status.md
@@ -36,3 +36,12 @@ Invalid documents return `422` with an `ErrorResponse`.
 - **Completed**: Validation rules now detect duplicate `operationId` values and missing path parameters, returning detailed `ErrorResponse` messages.
 - **Completed**: `typesense-codex/scripts/bootstrap_typesense.py` creates required collections for production Typesense instances.
 - Structured logging and Docker Compose example added for local testing
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/Docs/StatusQuo/future-priorities.md
+++ b/repos/fountainai/Docs/StatusQuo/future-priorities.md
@@ -14,3 +14,12 @@ To progress toward a functional release we should:
 4. **Introduce integration tests** – use the generated SDKs to call the running servers and verify end‑to‑end flows.
 5. **Automate CI and container builds** – run `swift build` and `swift test` on every pull request and document Docker workflows for deployment.
 6. **Update the execution plan** – reconcile `Docs/Historical/codex-plan.md` with completed work and these new tasks.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/FountainAi/openAPI/README.md
+++ b/repos/fountainai/FountainAi/openAPI/README.md
@@ -18,3 +18,12 @@ This directory contains the OpenAPI specifications for each FountainAI microserv
 - **Tools Factory → Function Caller**: the Tools Factory persists function definitions that the Function Caller dynamically invokes.
 - **Planner → LLM Gateway & Function Caller**: the Planner coordinates with the LLM Gateway for language model responses and triggers registered functions through the Function Caller.
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/README.md
+++ b/repos/fountainai/README.md
@@ -180,3 +180,12 @@ Current status reports reside in [Docs/StatusQuo](Docs/StatusQuo/).
 
 MIT License  
 © 2025 FountainAI
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/fountainai/VERSIONING.md
+++ b/repos/fountainai/VERSIONING.md
@@ -8,3 +8,12 @@ FountainAI services and the OpenAPI generator follow [Semantic Versioning](https
 - Bug fixes and documentation updates bump the **patch** version.
 
 Every change to an API spec or the generator must be recorded in `CHANGELOG.md` with the corresponding version number.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/kong-codex/AGENTS.md
+++ b/repos/kong-codex/AGENTS.md
@@ -3,3 +3,12 @@
 - Use `docker-compose.yml` to run Kong in db-less mode together with the local Typesense service.
 - Keep the README updated when configuration or environment variables change.
 - Refer to `../../docs/environment_variables.md` for common variable definitions.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/kong-codex/README.md
+++ b/repos/kong-codex/README.md
@@ -27,3 +27,12 @@ docker compose up -d
 
 Kong's admin API will be available on `http://localhost:8001` and the proxy
 listens on `http://localhost:8000`. Typesense is reachable at `${TYPESENSE_URL}`.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/kong-codex/agent.md
+++ b/repos/kong-codex/agent.md
@@ -6,3 +6,12 @@ Kong runs in db-less mode using `kong.yaml` as the declarative config.
 
 Use `docker-compose.yml` for local testing. Update `docs/environment_variables.md`
 when introducing new configuration.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/teatro/AGENTS.md
+++ b/repos/teatro/AGENTS.md
@@ -12,3 +12,12 @@ This repository contains the documentation for **Teatro View Engine**, a declara
 ## Repo Tasks for Codex
 - There are currently no automated tests. If you add code, provide appropriate tests and ensure they run via `swift test`.
 - Maintain this `AGENTS.md` if repository structure changes.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/teatro/Docs/Addendum/README.md
+++ b/repos/teatro/Docs/Addendum/README.md
@@ -76,3 +76,12 @@ This ensures that semantic rendering, narrative structuring, and musical composi
 ---
 
 © 2025 FountainAI — MIT License
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/teatro/Docs/AnimationSystem/README.md
+++ b/repos/teatro/Docs/AnimationSystem/README.md
@@ -63,3 +63,12 @@ This animation system works especially well for:
 - `.fountain` screenplay line reveals
 - Drift and semantic arc transitions
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/teatro/Docs/CLIIntegration/README.md
+++ b/repos/teatro/Docs/CLIIntegration/README.md
@@ -56,3 +56,12 @@ This CLI is ideal for:
 - Connecting renderable output to other tools (e.g., orchestration logs, build pipelines)
 - Rendering `.fountain`, `.mid`, or `.ly` views via CLI with extended routing
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/teatro/Docs/CoreProtocols/README.md
+++ b/repos/teatro/Docs/CoreProtocols/README.md
@@ -73,3 +73,12 @@ public enum ViewBuilder {
 }
 ```
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/teatro/Docs/FountainScreenplayEngine/README.md
+++ b/repos/teatro/Docs/FountainScreenplayEngine/README.md
@@ -123,3 +123,12 @@ CUT TO: >>
 - Pair with `Stage` to segment narrative structure into episodic slices
 - Embed semantic cues for lighting, props, and character arcs via `TeatroIcon` and `CodexPreviewer`
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/teatro/Docs/ImplementationPlan/README.md
+++ b/repos/teatro/Docs/ImplementationPlan/README.md
@@ -47,3 +47,12 @@ This roadmap converts the critique and analysis of the Teatro View Engine into c
 ---
 
 This document should evolve alongside the codebase. **Maintain and update this roadmap** as new features land or priorities shift to keep development focused and transparent.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/teatro/Docs/LilyPondMusicRendering/README.md
+++ b/repos/teatro/Docs/LilyPondMusicRendering/README.md
@@ -71,3 +71,12 @@ teatro_theme.ps
 - If needed, Codex can be prompted to emit safe `.ly` fragments
 - Combine with GPT output templates to embed titles, composer metadata, lyrics, and spacing settings
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/teatro/Docs/MIDI20DSL/README.md
+++ b/repos/teatro/Docs/MIDI20DSL/README.md
@@ -93,3 +93,12 @@ MIDIRenderer.renderToFile(melody, to: "demo.mid")
 - Compatible with future `MIDIPianoRoll` visual rendering
 - Pairs well with `Animator` for synchronizing scenes and sounds
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/teatro/Docs/RenderingBackends/README.md
+++ b/repos/teatro/Docs/RenderingBackends/README.md
@@ -95,3 +95,12 @@ public struct CodexPreviewer {
 }
 ```
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/teatro/Docs/Summary/README.md
+++ b/repos/teatro/Docs/Summary/README.md
@@ -56,3 +56,12 @@ Teatro/
 
 ---
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/teatro/Docs/ViewImplementationPlan/README.md
+++ b/repos/teatro/Docs/ViewImplementationPlan/README.md
@@ -58,3 +58,12 @@ Update `Package.swift` to add library and executable targets for the new sources
 ---
 
 Following this implementation and testing plan will produce a fully functional Teatro View Engine with deterministic rendering logic and comprehensive unit coverage for every view.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/teatro/Docs/ViewTypes/README.md
+++ b/repos/teatro/Docs/ViewTypes/README.md
@@ -112,3 +112,12 @@ public struct TeatroIcon: Renderable {
 }
 ```
 
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/teatro/README.md
+++ b/repos/teatro/README.md
@@ -23,3 +23,12 @@ This repository contains the specification for Teatro, a modular Swift 6 view en
 - [Addendum: Apple Platform Compatibility](Docs/Addendum/README.md)
 
 The `Sources/` directory follows the structure suggested in the documentation and contains placeholders for implementation. `Tests/` remains empty until concrete code is added.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/typesense-codex/README.md
+++ b/repos/typesense-codex/README.md
@@ -6,3 +6,12 @@ This software is proprietary and confidential.
 Unauthorized copying or distribution is strictly prohibited.
 
 Codex-managed Typesense schema + feedback registry for FountainAI.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/repos/typesense-codex/agent.md
+++ b/repos/typesense-codex/agent.md
@@ -1,3 +1,12 @@
 # 🤖 agent.md
 
 This agent manages Typesense collections, schemas, and Codex tuning logic.
+
+```
+
+
+
+```
+© 2025 Benedikte Eickhoff. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```


### PR DESCRIPTION
## Summary
- add standard copyright footer block to all Markdown
- mention the footer requirement in AGENT behavior

## Testing
- `swift test -v` *(fails: process timed out)*

------
https://chatgpt.com/codex/tasks/task_e_687a5acc73c08325bf45934e7b1ab737