### PR TITLE
Clean up header notices and update page footers

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,9 +1,5 @@
 # 🤖 AGENT.md
 
-Copyright (c) 2025 Benedikte Eickhoff.
-All rights reserved.
-This software is proprietary and confidential.
-Unauthorized copying or distribution is strictly prohibited.
 
 > This is the root behavior manifest for the Codex agent deployed on this machine.
 
@@ -17,7 +13,12 @@ All contributor guides live under `docs/handbook`. Start from the
   are introduced or removed.
 - Reference that file in documentation and code comments when explaining
   configuration.
-- Ensure every README and other `.md` file ends with the preformatted copyright notice.
+- Ensure every README and other `.md` file ends with the footer:
+
+```
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```
 
 ---
 
@@ -224,6 +225,6 @@ main.swift:5 -> main.swift:5:5: error: use of unresolved identifier 'foo'
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,7 @@
 
 `AGENTS.md` has been merged into [AGENT.md](AGENT.md).
 Please update any links or tooling that still refer to this file.
-
 ```
-
-
-
-```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -239,6 +239,6 @@
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/README.md
+++ b/README.md
@@ -46,6 +46,6 @@ The dispatcher acts as a **semantic compiler**, applying patches and rebuilding 
 For deeper context and a complete list of documents, explore the pages linked in the table of contents. They describe how FountainAI will emancipate from Codex, using the same reasoning flow but expanded to dynamic tool orchestration and persistent semantic memory.
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/agent.md
+++ b/agent.md
@@ -3,10 +3,6 @@
 This file has been replaced by [AGENT.md](AGENT.md). Please update your references.
 
 ```
-
-
-
-```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/analysis.md
+++ b/analysis.md
@@ -14,6 +14,6 @@ This indicates the constants `AF_INET` and `SOCK_STREAM` need to be explicitly c
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/docs/design_patterns.md
+++ b/docs/design_patterns.md
@@ -57,6 +57,6 @@ The combination of a client/server kernel, plugin-driven gateway, and declarativ
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/docs/dispatcher_v2.md
+++ b/docs/dispatcher_v2.md
@@ -48,6 +48,6 @@ For tips on reviewing failed builds, see the [README](../README.md#analyzing-swi
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -1,10 +1,5 @@
 # Environment Variables
 
-Copyright (c) 2025 Benedikte Eickhoff.
-All rights reserved.
-This software is proprietary and confidential.
-Unauthorized copying or distribution is strictly prohibited.
-
 This document lists the environment variables used by the Codex deployer.
 
 | Variable | Default | Purpose |
@@ -91,6 +86,6 @@ See the [handbook](handbook/README.md) for additional setup guides.
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/docs/fountainai_mac_ui_plan.md
+++ b/docs/fountainai_mac_ui_plan.md
@@ -52,6 +52,6 @@ Following this plan will produce a fully featured macOS application that leverag
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -46,6 +46,6 @@ describing required settings.
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/docs/handbook/architecture.md
+++ b/docs/handbook/architecture.md
@@ -54,6 +54,6 @@ For implementation details see [dispatcher_v2.md](../dispatcher_v2.md).
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/docs/handbook/code_reference.md
+++ b/docs/handbook/code_reference.md
@@ -28,6 +28,6 @@ with `swift package generate-documentation` once the build pipeline is enabled.
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/docs/handbook/history.md
+++ b/docs/handbook/history.md
@@ -17,6 +17,6 @@ Return to the [handbook index](README.md) for additional background material.
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/docs/handbook/introduction.md
+++ b/docs/handbook/introduction.md
@@ -57,6 +57,6 @@ The [handbook README](README.md) contains a complete table of contents with link
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/docs/log_aggregation.md
+++ b/docs/log_aggregation.md
@@ -25,6 +25,6 @@ For manual deployments, run a tool like `fluent-bit` or `promtail` to stream log
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/docs/mac_docker_tutorial.md
+++ b/docs/mac_docker_tutorial.md
@@ -106,6 +106,6 @@ when necessary.
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/docs/mac_local_testing.md
+++ b/docs/mac_local_testing.md
@@ -77,6 +77,6 @@ Press `Ctrl-C` in the terminal running the container to stop the dispatcher.
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/docs/managing_environment_variables.md
+++ b/docs/managing_environment_variables.md
@@ -104,6 +104,6 @@ Using a token avoids interactive Git prompts when cloning private repositories.
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/docs/pull_request_workflow.md
+++ b/docs/pull_request_workflow.md
@@ -18,6 +18,6 @@ This approach allows human review while keeping automation centralized. Direct p
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/docs/secrets_api_proposal.md
+++ b/docs/secrets_api_proposal.md
@@ -37,6 +37,6 @@ Implementing this approach would require extending the dispatcher to perform the
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/docs/what_is_git.md
+++ b/docs/what_is_git.md
@@ -19,6 +19,6 @@ In the Codex deployer, Git plays a central role. The dispatcher pulls repositori
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/notables/kong_pitch.md
+++ b/notables/kong_pitch.md
@@ -23,6 +23,6 @@ Overall, Kong provides production-ready routing, security, observability, and ex
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/notables/kong_scenarios.md
+++ b/notables/kong_scenarios.md
@@ -17,6 +17,6 @@ These scenarios show how Kong becomes more than a simple router—it orchestrate
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/report.md
+++ b/report.md
@@ -95,6 +95,6 @@ NIOHTTPServer.swift:61 -> /srv/deploy/repos/fountainai/Sources/IntegrationRuntim
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/AGENTS.md
+++ b/repos/fountainai/AGENTS.md
@@ -15,6 +15,6 @@ This repository uses Swift 6 and Swift Package Manager.
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/CHANGELOG.md
+++ b/repos/fountainai/CHANGELOG.md
@@ -13,6 +13,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/Docs/Historical/FountainAi_implementation_Agenda.md
+++ b/repos/fountainai/Docs/Historical/FountainAi_implementation_Agenda.md
@@ -55,6 +55,6 @@ Following this agenda will lead to a complete set of FountainAI services impleme
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/Docs/Historical/codex-bootstrap.md
+++ b/repos/fountainai/Docs/Historical/codex-bootstrap.md
@@ -36,6 +36,6 @@ Begin now by initializing the repository structure and implementing the generato
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/Docs/Historical/codex-plan.md
+++ b/repos/fountainai/Docs/Historical/codex-plan.md
@@ -75,6 +75,6 @@ This plan defines how Codex should build a Swift 6-native OpenAPI code generator
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/Docs/Historical/improvement-agenda.md
+++ b/repos/fountainai/Docs/Historical/improvement-agenda.md
@@ -64,6 +64,6 @@ Addressing these items will close the gap between the current implementation and
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/Docs/StatusQuo/FountainAi_openAPI_Status_Report.md
+++ b/repos/fountainai/Docs/StatusQuo/FountainAi_openAPI_Status_Report.md
@@ -70,6 +70,6 @@ Implementing these steps will transform the current skeleton generators into pro
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/Docs/StatusQuo/Reports/baseline-awareness-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/baseline-awareness-status.md
@@ -34,6 +34,6 @@ Spec path: `FountainAi/openAPI/v1/baseline-awareness.yml` (version 1.0.0).
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/Docs/StatusQuo/Reports/bootstrap-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/bootstrap-status.md
@@ -27,6 +27,6 @@ Spec path: `FountainAi/openAPI/v1/bootstrap.yml` (version 1.0.0).
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/Docs/StatusQuo/Reports/deployment.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/deployment.md
@@ -59,6 +59,6 @@ All containers emit JSON logs which can be aggregated by your logging stack.
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/Docs/StatusQuo/Reports/function-caller-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/function-caller-status.md
@@ -41,6 +41,6 @@ Spec path: `FountainAi/openAPI/v1/function-caller.yml` (version 1.0.0).
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/Docs/StatusQuo/Reports/integration-testing-alternative.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/integration-testing-alternative.md
@@ -42,6 +42,6 @@ Developers run `swift test -v` locally to reproduce the same cross-platform flow
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/Docs/StatusQuo/Reports/llm-gateway-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/llm-gateway-status.md
@@ -33,6 +33,6 @@ Spec path: `FountainAi/openAPI/v2/llm-gateway.yml` (version 2.0.0).
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/Docs/StatusQuo/Reports/next-steps.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/next-steps.md
@@ -25,6 +25,6 @@ Completing these steps will transition FountainAI from prototype status to a sta
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/Docs/StatusQuo/Reports/persistence-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/persistence-status.md
@@ -29,6 +29,6 @@ Spec path: `FountainAi/openAPI/v1/persist.yml` (version 1.0.0).
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/Docs/StatusQuo/Reports/planner-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/planner-status.md
@@ -31,6 +31,6 @@ Spec path: `FountainAi/openAPI/v1/planner.yml` (version 1.0.0).
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/Docs/StatusQuo/Reports/tools-factory-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/tools-factory-status.md
@@ -42,6 +42,6 @@ Invalid documents return `422` with an `ErrorResponse`.
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/Docs/StatusQuo/future-priorities.md
+++ b/repos/fountainai/Docs/StatusQuo/future-priorities.md
@@ -20,6 +20,6 @@ To progress toward a functional release we should:
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/FountainAi/openAPI/README.md
+++ b/repos/fountainai/FountainAi/openAPI/README.md
@@ -24,6 +24,6 @@ This directory contains the OpenAPI specifications for each FountainAI microserv
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/README.md
+++ b/repos/fountainai/README.md
@@ -1,10 +1,5 @@
 # swift-codex-openapi-kernel
 
-Copyright (c) 2025 Benedikte Eickhoff.
-All rights reserved.
-This software is proprietary and confidential.
-Unauthorized copying or distribution is strictly prohibited.
-
 *A fully Codex-compatible Swift 6 tool that generates both client SDKs and native HTTP server kernels from OpenAPI 3.1 — with zero dependencies on external frameworks like Vapor.*
 
 ---
@@ -186,6 +181,6 @@ MIT License
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/fountainai/VERSIONING.md
+++ b/repos/fountainai/VERSIONING.md
@@ -14,6 +14,6 @@ Every change to an API spec or the generator must be recorded in `CHANGELOG.md` 
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/kong-codex/AGENTS.md
+++ b/repos/kong-codex/AGENTS.md
@@ -9,6 +9,6 @@
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/kong-codex/README.md
+++ b/repos/kong-codex/README.md
@@ -1,10 +1,5 @@
 # 🧠 kong-codex
 
-Copyright (c) 2025 Benedikte Eickhoff.
-All rights reserved.
-This software is proprietary and confidential.
-Unauthorized copying or distribution is strictly prohibited.
-
 Codex-managed configuration for the Kong API gateway. This repository includes a
 `docker-compose.yml` setup that launches Kong in db-less mode with a
 Typesense instance used by FountainAI.
@@ -33,6 +28,6 @@ listens on `http://localhost:8000`. Typesense is reachable at `${TYPESENSE_URL}`
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/kong-codex/agent.md
+++ b/repos/kong-codex/agent.md
@@ -12,6 +12,6 @@ when introducing new configuration.
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/teatro/AGENTS.md
+++ b/repos/teatro/AGENTS.md
@@ -18,6 +18,6 @@ This repository contains the documentation for **Teatro View Engine**, a declara
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/teatro/Docs/Addendum/README.md
+++ b/repos/teatro/Docs/Addendum/README.md
@@ -82,6 +82,6 @@ This ensures that semantic rendering, narrative structuring, and musical composi
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/teatro/Docs/AnimationSystem/README.md
+++ b/repos/teatro/Docs/AnimationSystem/README.md
@@ -69,6 +69,6 @@ This animation system works especially well for:
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/teatro/Docs/CLIIntegration/README.md
+++ b/repos/teatro/Docs/CLIIntegration/README.md
@@ -62,6 +62,6 @@ This CLI is ideal for:
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/teatro/Docs/CoreProtocols/README.md
+++ b/repos/teatro/Docs/CoreProtocols/README.md
@@ -79,6 +79,6 @@ public enum ViewBuilder {
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/teatro/Docs/FountainScreenplayEngine/README.md
+++ b/repos/teatro/Docs/FountainScreenplayEngine/README.md
@@ -129,6 +129,6 @@ CUT TO: >>
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/teatro/Docs/ImplementationPlan/README.md
+++ b/repos/teatro/Docs/ImplementationPlan/README.md
@@ -53,6 +53,6 @@ This document should evolve alongside the codebase. **Maintain and update this r
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/teatro/Docs/LilyPondMusicRendering/README.md
+++ b/repos/teatro/Docs/LilyPondMusicRendering/README.md
@@ -77,6 +77,6 @@ teatro_theme.ps
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/teatro/Docs/MIDI20DSL/README.md
+++ b/repos/teatro/Docs/MIDI20DSL/README.md
@@ -99,6 +99,6 @@ MIDIRenderer.renderToFile(melody, to: "demo.mid")
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/teatro/Docs/RenderingBackends/README.md
+++ b/repos/teatro/Docs/RenderingBackends/README.md
@@ -101,6 +101,6 @@ public struct CodexPreviewer {
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/teatro/Docs/Summary/README.md
+++ b/repos/teatro/Docs/Summary/README.md
@@ -62,6 +62,6 @@ Teatro/
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/teatro/Docs/ViewImplementationPlan/README.md
+++ b/repos/teatro/Docs/ViewImplementationPlan/README.md
@@ -64,6 +64,6 @@ Following this implementation and testing plan will produce a fully functional T
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/teatro/Docs/ViewTypes/README.md
+++ b/repos/teatro/Docs/ViewTypes/README.md
@@ -118,6 +118,6 @@ public struct TeatroIcon: Renderable {
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/teatro/README.md
+++ b/repos/teatro/README.md
@@ -1,13 +1,6 @@
 # Teatro View Engine
 *A Declarative, Codex-Controllable Rendering Framework in Swift*
-
-Copyright (c) 2025 Benedikte Eickhoff.
-All rights reserved.
-This software is proprietary and confidential.
-Unauthorized copying or distribution is strictly prohibited.
-
 This repository contains the specification for Teatro, a modular Swift 6 view engine. The original long-form documentation has been split into separate files under the `Docs` directory.
-
 ## Documentation
 - [Core Protocols](Docs/CoreProtocols/README.md)
 - [View Types](Docs/ViewTypes/README.md)
@@ -29,6 +22,6 @@ The `Sources/` directory follows the structure suggested in the documentation an
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/typesense-codex/README.md
+++ b/repos/typesense-codex/README.md
@@ -1,17 +1,8 @@
 # 🧠 typesense-codex
 
-Copyright (c) 2025 Benedikte Eickhoff.
-All rights reserved.
-This software is proprietary and confidential.
-Unauthorized copying or distribution is strictly prohibited.
-
 Codex-managed Typesense schema + feedback registry for FountainAI.
 
 ```
-
-
-
-```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/typesense-codex/agent.md
+++ b/repos/typesense-codex/agent.md
@@ -7,6 +7,6 @@ This agent manages Typesense collections, schemas, and Codex tuning logic.
 
 
 ```
-© 2025 Benedikte Eickhoff. All rights reserved.
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```


### PR DESCRIPTION
## Summary
- remove header copyright lines from docs
- set updated footer text in AGENT.md and all Markdown files
- document footer requirement in AGENT.md

## Testing
- `python3 analyze_swift_log.py` *(fails: build.log not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a62eefc0c8325944914e334e3df40