### PR TITLE
Fix copyright footer formatting

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -218,12 +218,6 @@ main.swift:5:5: error: use of unresolved identifier 'foo'
 main.swift:5 -> main.swift:5:5: error: use of unresolved identifier 'foo'
 **Suggested Fix:** Define or import the missing symbol.
 ```
-
-
-```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,9 +235,6 @@
 - 2025-07-18T05:27:41.572091 Update build log build-20250718-052738.log: 2025-07-18T05:27:41.522467
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/analysis.md
+++ b/analysis.md
@@ -10,9 +10,6 @@ This indicates the constants `AF_INET` and `SOCK_STREAM` need to be explicitly c
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/docs/design_patterns.md
+++ b/docs/design_patterns.md
@@ -53,9 +53,6 @@ Teatro defines its UI purely through declarations.
 The combination of a client/server kernel, plugin-driven gateway, and declarative view engine offers clear separation of concerns. While each pattern introduces trade-offs, the design aligns with common best practices and provides a solid foundation for scaling the system.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/docs/dispatcher_v2.md
+++ b/docs/dispatcher_v2.md
@@ -44,9 +44,6 @@ For tips on reviewing failed builds, see the [README](../README.md#analyzing-swi
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -82,9 +82,6 @@ values are not copied into Docker build contexts.
 See the [handbook](handbook/README.md) for additional setup guides.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/docs/fountainai_mac_ui_plan.md
+++ b/docs/fountainai_mac_ui_plan.md
@@ -48,9 +48,6 @@ This document outlines an iterative approach for building a macOS desktop applic
 Following this plan will produce a fully featured macOS application that leverages FountainAI's microservices and Teatro's declarative rendering system.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -42,9 +42,6 @@ describing required settings.
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/docs/handbook/architecture.md
+++ b/docs/handbook/architecture.md
@@ -50,9 +50,6 @@ For implementation details see [dispatcher_v2.md](../dispatcher_v2.md).
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/docs/handbook/code_reference.md
+++ b/docs/handbook/code_reference.md
@@ -24,9 +24,6 @@ with `swift package generate-documentation` once the build pipeline is enabled.
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/docs/handbook/history.md
+++ b/docs/handbook/history.md
@@ -13,9 +13,6 @@ Codex-Deployer began as an experiment to remove brittle CI pipelines and GitHub 
 Return to the [handbook index](README.md) for additional background material.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/docs/handbook/introduction.md
+++ b/docs/handbook/introduction.md
@@ -53,9 +53,6 @@ list of options.
 The [handbook README](README.md) contains a complete table of contents with links to additional background material. For API details see [code_reference.md](code_reference.md).
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/docs/log_aggregation.md
+++ b/docs/log_aggregation.md
@@ -21,9 +21,6 @@ Replace `loki-url` with your aggregator endpoint. The same pattern applies to th
 For manual deployments, run a tool like `fluent-bit` or `promtail` to stream logs from Docker to the aggregator.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/docs/mac_docker_tutorial.md
+++ b/docs/mac_docker_tutorial.md
@@ -102,9 +102,6 @@ toolchain whenever possible, but branch out into vendor-specific builds only
 when necessary.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/docs/mac_local_testing.md
+++ b/docs/mac_local_testing.md
@@ -73,9 +73,6 @@ Press `Ctrl-C` in the terminal running the container to stop the dispatcher.
 - [managing_environment_variables.md](managing_environment_variables.md) – step‑by‑step setup guide
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/docs/managing_environment_variables.md
+++ b/docs/managing_environment_variables.md
@@ -100,9 +100,6 @@ Using a token avoids interactive Git prompts when cloning private repositories.
 - [handbook](handbook/README.md) – index of all tutorials
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/docs/pull_request_workflow.md
+++ b/docs/pull_request_workflow.md
@@ -14,9 +14,6 @@ This approach allows human review while keeping automation centralized. Direct p
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/docs/secrets_api_proposal.md
+++ b/docs/secrets_api_proposal.md
@@ -33,9 +33,6 @@ Implementing this approach would require extending the dispatcher to perform the
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/docs/what_is_git.md
+++ b/docs/what_is_git.md
@@ -15,9 +15,6 @@ In the Codex deployer, Git plays a central role. The dispatcher pulls repositori
 *Figure 2: The branching flow used by Codex deployer to orchestrate code updates.*
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/notables/kong_pitch.md
+++ b/notables/kong_pitch.md
@@ -19,9 +19,6 @@ Configuration variables for the deployment system are documented in [`docs/envir
 Overall, Kong provides production-ready routing, security, observability, and extensibility, reducing the need for a custom gateway built in Swift or Python.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/notables/kong_scenarios.md
+++ b/notables/kong_scenarios.md
@@ -13,9 +13,6 @@ The FountainAI microservices expose OpenAPI-based endpoints that can be unified 
 These scenarios show how Kong becomes more than a simple router—it orchestrates versioning, tenant management, observability and real-time tooling around FountainAI's services.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/report.md
+++ b/report.md
@@ -91,9 +91,6 @@ NIOHTTPServer.swift:61 -> /srv/deploy/repos/fountainai/Sources/IntegrationRuntim
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/AGENTS.md
+++ b/repos/fountainai/AGENTS.md
@@ -11,9 +11,6 @@ This repository uses Swift 6 and Swift Package Manager.
 - Summarize the test results in the PR description.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/CHANGELOG.md
+++ b/repos/fountainai/CHANGELOG.md
@@ -9,9 +9,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 - Initial OpenAPI specs and generator skeleton.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/Docs/Historical/FountainAi_implementation_Agenda.md
+++ b/repos/fountainai/Docs/Historical/FountainAi_implementation_Agenda.md
@@ -51,9 +51,6 @@ For each service:
 Following this agenda will lead to a complete set of FountainAI services implemented in Swift, each accompanied by an independent client SDK and clear documentation describing how they fit together.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/Docs/Historical/codex-bootstrap.md
+++ b/repos/fountainai/Docs/Historical/codex-bootstrap.md
@@ -32,9 +32,6 @@ The `README.md` describes the purpose and structure of this project. The `.codex
 Begin now by initializing the repository structure and implementing the generator entrypoint.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/Docs/Historical/codex-plan.md
+++ b/repos/fountainai/Docs/Historical/codex-plan.md
@@ -71,9 +71,6 @@ This plan defines how Codex should build a Swift 6-native OpenAPI code generator
 ---
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/Docs/Historical/improvement-agenda.md
+++ b/repos/fountainai/Docs/Historical/improvement-agenda.md
@@ -60,9 +60,6 @@ The project has a solid start: parsing, model emission, client and server genera
 Addressing these items will close the gap between the current implementation and the aspirations laid out in the execution plan, delivering a more polished and self‑describing project.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/Docs/StatusQuo/FountainAi_openAPI_Status_Report.md
+++ b/repos/fountainai/Docs/StatusQuo/FountainAi_openAPI_Status_Report.md
@@ -66,9 +66,6 @@ Unit tests verify the generator using a simplified fixture rather than the full 
 Implementing these steps will transform the current skeleton generators into production‑ready client libraries and standalone servers for the entire FountainAI suite.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/Docs/StatusQuo/Reports/baseline-awareness-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/baseline-awareness-status.md
@@ -30,9 +30,6 @@ Spec path: `FountainAi/openAPI/v1/baseline-awareness.yml` (version 1.0.0).
 - Structured logging added for easier debugging and monitoring
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/Docs/StatusQuo/Reports/bootstrap-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/bootstrap-status.md
@@ -23,9 +23,6 @@ Spec path: `FountainAi/openAPI/v1/bootstrap.yml` (version 1.0.0).
 - Added structured logging and a Compose workflow example
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/Docs/StatusQuo/Reports/deployment.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/deployment.md
@@ -55,9 +55,6 @@ This workflow lets you run the microservices locally. Future updates will add fu
 All containers emit JSON logs which can be aggregated by your logging stack.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/Docs/StatusQuo/Reports/function-caller-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/function-caller-status.md
@@ -37,9 +37,6 @@ Spec path: `FountainAi/openAPI/v1/function-caller.yml` (version 1.0.0).
 - See [next-steps.md](next-steps.md) for cross-service priorities
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/Docs/StatusQuo/Reports/integration-testing-alternative.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/integration-testing-alternative.md
@@ -38,9 +38,6 @@ All current integration tests use this runtime and run in CI on Linux and macOS.
 Developers run `swift test -v` locally to reproduce the same cross-platform flow.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/Docs/StatusQuo/Reports/llm-gateway-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/llm-gateway-status.md
@@ -29,9 +29,6 @@ Spec path: `FountainAi/openAPI/v2/llm-gateway.yml` (version 2.0.0).
 - Document `OPENAI_API_KEY` and `OPENAI_API_BASE` usage in [environment_variables.md](../../../../../docs/environment_variables.md)
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/Docs/StatusQuo/Reports/next-steps.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/next-steps.md
@@ -21,9 +21,6 @@ All FountainAI services now run using a shared Swift concurrency runtime. Integr
 Completing these steps will transition FountainAI from prototype status to a stable, production‑ready microservice suite.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/Docs/StatusQuo/Reports/persistence-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/persistence-status.md
@@ -25,9 +25,6 @@ Spec path: `FountainAi/openAPI/v1/persist.yml` (version 1.0.0).
 - Add backup and restore procedures
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/Docs/StatusQuo/Reports/planner-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/planner-status.md
@@ -27,9 +27,6 @@ Spec path: `FountainAi/openAPI/v1/planner.yml` (version 1.0.0).
 - Refer to [environment_variables.md](../../../../../docs/environment_variables.md) when configuring the service
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/Docs/StatusQuo/Reports/tools-factory-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/tools-factory-status.md
@@ -38,9 +38,6 @@ Invalid documents return `422` with an `ErrorResponse`.
 - Structured logging and Docker Compose example added for local testing
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/Docs/StatusQuo/future-priorities.md
+++ b/repos/fountainai/Docs/StatusQuo/future-priorities.md
@@ -16,9 +16,6 @@ To progress toward a functional release we should:
 6. **Update the execution plan** – reconcile `Docs/Historical/codex-plan.md` with completed work and these new tasks.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/FountainAi/openAPI/README.md
+++ b/repos/fountainai/FountainAi/openAPI/README.md
@@ -20,9 +20,6 @@ This directory contains the OpenAPI specifications for each FountainAI microserv
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/README.md
+++ b/repos/fountainai/README.md
@@ -177,9 +177,6 @@ MIT License
 © 2025 FountainAI
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/fountainai/VERSIONING.md
+++ b/repos/fountainai/VERSIONING.md
@@ -10,9 +10,6 @@ FountainAI services and the OpenAPI generator follow [Semantic Versioning](https
 Every change to an API spec or the generator must be recorded in `CHANGELOG.md` with the corresponding version number.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/kong-codex/AGENTS.md
+++ b/repos/kong-codex/AGENTS.md
@@ -5,9 +5,6 @@
 - Refer to `../../docs/environment_variables.md` for common variable definitions.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/kong-codex/README.md
+++ b/repos/kong-codex/README.md
@@ -24,9 +24,6 @@ Kong's admin API will be available on `http://localhost:8001` and the proxy
 listens on `http://localhost:8000`. Typesense is reachable at `${TYPESENSE_URL}`.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/kong-codex/agent.md
+++ b/repos/kong-codex/agent.md
@@ -8,9 +8,6 @@ Use `docker-compose.yml` for local testing. Update `docs/environment_variables.m
 when introducing new configuration.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/teatro/AGENTS.md
+++ b/repos/teatro/AGENTS.md
@@ -14,9 +14,6 @@ This repository contains the documentation for **Teatro View Engine**, a declara
 - Maintain this `AGENTS.md` if repository structure changes.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/teatro/Docs/Addendum/README.md
+++ b/repos/teatro/Docs/Addendum/README.md
@@ -78,9 +78,6 @@ This ensures that semantic rendering, narrative structuring, and musical composi
 © 2025 FountainAI — MIT License
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/teatro/Docs/AnimationSystem/README.md
+++ b/repos/teatro/Docs/AnimationSystem/README.md
@@ -65,9 +65,6 @@ This animation system works especially well for:
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/teatro/Docs/CLIIntegration/README.md
+++ b/repos/teatro/Docs/CLIIntegration/README.md
@@ -58,9 +58,6 @@ This CLI is ideal for:
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/teatro/Docs/CoreProtocols/README.md
+++ b/repos/teatro/Docs/CoreProtocols/README.md
@@ -75,9 +75,6 @@ public enum ViewBuilder {
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/teatro/Docs/FountainScreenplayEngine/README.md
+++ b/repos/teatro/Docs/FountainScreenplayEngine/README.md
@@ -125,9 +125,6 @@ CUT TO: >>
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/teatro/Docs/ImplementationPlan/README.md
+++ b/repos/teatro/Docs/ImplementationPlan/README.md
@@ -49,9 +49,6 @@ This roadmap converts the critique and analysis of the Teatro View Engine into c
 This document should evolve alongside the codebase. **Maintain and update this roadmap** as new features land or priorities shift to keep development focused and transparent.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/teatro/Docs/LilyPondMusicRendering/README.md
+++ b/repos/teatro/Docs/LilyPondMusicRendering/README.md
@@ -73,9 +73,6 @@ teatro_theme.ps
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/teatro/Docs/MIDI20DSL/README.md
+++ b/repos/teatro/Docs/MIDI20DSL/README.md
@@ -95,9 +95,6 @@ MIDIRenderer.renderToFile(melody, to: "demo.mid")
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/teatro/Docs/RenderingBackends/README.md
+++ b/repos/teatro/Docs/RenderingBackends/README.md
@@ -97,9 +97,6 @@ public struct CodexPreviewer {
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/teatro/Docs/Summary/README.md
+++ b/repos/teatro/Docs/Summary/README.md
@@ -58,9 +58,6 @@ Teatro/
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/teatro/Docs/ViewImplementationPlan/README.md
+++ b/repos/teatro/Docs/ViewImplementationPlan/README.md
@@ -60,9 +60,6 @@ Update `Package.swift` to add library and executable targets for the new sources
 Following this implementation and testing plan will produce a fully functional Teatro View Engine with deterministic rendering logic and comprehensive unit coverage for every view.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/teatro/Docs/ViewTypes/README.md
+++ b/repos/teatro/Docs/ViewTypes/README.md
@@ -114,9 +114,6 @@ public struct TeatroIcon: Renderable {
 
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/teatro/README.md
+++ b/repos/teatro/README.md
@@ -18,9 +18,6 @@ This repository contains the specification for Teatro, a modular Swift 6 view en
 The `Sources/` directory follows the structure suggested in the documentation and contains placeholders for implementation. `Tests/` remains empty until concrete code is added.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.

--- a/repos/typesense-codex/agent.md
+++ b/repos/typesense-codex/agent.md
@@ -3,9 +3,6 @@
 This agent manages Typesense collections, schemas, and Codex tuning logic.
 
 ```
-
-
-
 ```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.


### PR DESCRIPTION
## Summary
- standardize footer fencing across `AGENT.md` and documentation

## Testing
- `python3 -m py_compile analyze_swift_log.py`
- `python3 analyze_swift_log.py` *(fails: build.log not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a69b519548325b722eb90ed704a31