### PR TITLE
Add Dispatcher Mac GUI concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Codex-Deployer unifies builds, logs, and semantic fixes in a single Git-bound lo
 - [Pull Request Workflow](docs/pull_request_workflow.md) – how patches are proposed and merged.
 - [Code Reference](docs/handbook/code_reference.md) – links to inline API docs.
 - [History and Roadmap](docs/handbook/history.md) – how the project evolved and what's next.
+- [Dispatcher Mac GUI Concept](docs/dispatcher_mac_gui_plan.md) – draft plan for a Teatro-based GUI.
 
 ## Quick start
 Clone the repository, copy the sample environment file, and start the dispatcher in Docker.

--- a/docs/dispatcher_mac_gui_plan.md
+++ b/docs/dispatcher_mac_gui_plan.md
@@ -1,0 +1,49 @@
+# Dispatcher Mac GUI Concept
+
+This document proposes a lightweight macOS application for controlling **dispatcher_v2.py** through a graphical interface. By providing a friendly UI, new contributors can experiment with dispatcher settings without editing shell scripts or environment files. The application uses the Teatro View Engine to render views and will also serve as an entry point for FountainAI features in the future.
+
+## 1. Goals
+
+1. Simplify configuration of environment variables such as `GITHUB_TOKEN` and `DISPATCHER_INTERVAL`.
+2. Offer buttons to start, stop, and monitor the dispatcher process directly on macOS.
+3. Present recent build logs and patch history in an accessible format.
+4. Lay the groundwork for integrating FountainAI service clients once they become available.
+
+## 2. Architecture Overview
+
+- **Teatro Views** provide the declarative layout for forms, log consoles, and status indicators.
+- A small Swift wrapper around **dispatcher_v2.py** launches the process and streams output to the UI.
+- Configuration values are stored in a user-visible file (e.g. `dispatcher.env`) managed through the UI.
+- The same environment variables documented in [environment_variables.md](environment_variables.md) are respected, ensuring parity with the command-line workflow.
+
+## 3. Basic UI Flow
+
+1. The main window lists all editable settings with descriptions pulled from the environment documentation.
+2. A "Start Dispatcher" button spawns the Python loop as a child process and begins streaming logs.
+3. Logs appear in a scrolling text view rendered via Teatro, with color highlights for errors and warnings.
+4. When running, a status indicator shows the current cycle and last build result.
+5. Users can stop the dispatcher at any time or open the log file in Finder for deeper inspection.
+
+## 4. FountainAI Integration Path
+
+While the initial release focuses on dispatcher controls, the same Teatro-based shell can host FountainAI tools. Future iterations could:
+
+- Display plan execution results from the Planner service.
+- List reflections and baseline snapshots from the Awareness API.
+- Provide quick actions for bootstrapping new corpora via the Bootstrap service.
+
+## 5. Next Steps
+
+1. Create a small Swift Package that embeds Teatro and exposes the dispatcher process management code.
+2. Prototype the settings form and log viewer using Teatro's SwiftUI preview support.
+3. Iterate based on feedback, expanding the UI to cover additional services as FountainAI evolves.
+
+---
+
+By approaching the dispatcher as a macOS app, we lower the entry barrier for experimentation and pave the way for deeper FountainAI integrations.
+
+```
+```
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -34,6 +34,7 @@ repository itself see the [main README](../../README.md).
 - [History and Roadmap](history.md)
 
 - [FountainAI macOS UI Plan](../fountainai_mac_ui_plan.md)
+- [Dispatcher Mac GUI Concept](../dispatcher_mac_gui_plan.md)
 
 These documents should give you a complete picture of how the dispatcher works,
 how to configure it, and how the surrounding services fit together. All guides


### PR DESCRIPTION
## Summary
- document a macOS app concept for controlling dispatcher_v2.py using Teatro
- link the new plan from the handbook and root README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a8da1bfd08325a490d2176d04d925