### PR TITLE
Add evaluation of making repo public

### DIFF
--- a/docs/evaluations/public_repo_discussion.md
+++ b/docs/evaluations/public_repo_discussion.md
@@ -1,0 +1,37 @@
+# Evaluation: Making codex-deployer Public
+
+This document summarizes the pros and cons of switching the `codex-deployer` repository from private to public. The analysis highlights potential benefits of community involvement alongside the risks of exposing internal logic.
+
+## Advantages
+
+1. **Community contributions and feedback** – Public visibility invites outside developers to submit bug reports and pull requests, potentially improving code quality.
+2. **Transparency and credibility** – An open repository demonstrates confidence in the code and can enhance FountainCoach's reputation.
+3. **Recruiting and networking** – Prospective collaborators can examine the codebase, making it easier to attract contributors with expertise in Swift-based deployment tools.
+4. **Integration with open-source infrastructure** – Public repositories work well with GitHub Actions and third-party tooling, allowing for badges and automated scanners.
+5. **Cross-project synergies** – If other components are also open-source, having this repo public clarifies how the pieces fit together.
+6. **Visibility and marketing** – Open code can showcase FountainCoach technology and help drive awareness.
+
+## Risks
+
+1. **Exposure of sensitive configuration** – Scripts may refer to internal systems or reveal infrastructure details. These must be reviewed and scrubbed before publishing.
+2. **Intellectual property concerns** – Competitors gain access to workflow logic and could copy unique approaches.
+3. **Maintenance overhead** – External issues and pull requests require ongoing triage and documentation updates.
+4. **License and legal review** – A clear open-source license is needed, and any third-party code must be vetted.
+5. **Potential reputation impact** – Security vulnerabilities or brittle code become more visible once the project is public.
+6. **Loss of control over derivatives** – Forks and alternative versions might not align with the project's goals.
+
+## Mitigation Strategies
+
+- Conduct a thorough audit to remove hard-coded secrets or references to private infrastructure.
+- Consider keeping certain modules private if they contain proprietary logic.
+- Maintain strong documentation so newcomers can navigate the project easily.
+- Provide guidelines for responsible disclosure of security issues.
+- Use versioning and changelogs to track compatibility when new releases are made.
+
+## Conclusion
+
+Making `codex-deployer` public could foster community growth and transparency, but it also requires preparation. By carefully reviewing the repository for sensitive material and setting clear contribution guidelines, FountainCoach can weigh the benefits of open collaboration against the risks of exposing internal workflows.
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````


### PR DESCRIPTION
## Summary
- document pros and cons of switching `codex-deployer` from private to public
- place the evaluation in a new `docs/evaluations` folder

## Testing
- `repos/fountainai/run-tests.sh` *(fails: cannot convert value of type `__socket_type` to `Int32`)*

------
https://chatgpt.com/codex/tasks/task_e_687b2855f2708325b09cd798504949b0