### PR TITLE
Implement basic Teatro Mac GUI views

### DIFF
--- a/repos/teatro/Sources/ViewCore/DispatcherPrompt.swift
+++ b/repos/teatro/Sources/ViewCore/DispatcherPrompt.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct DispatcherPrompt: Renderable {
+    public init() {}
+
+    public func render() -> String {
+        Stage(title: "Dispatcher") {
+            Panel(width: 640, height: 900, cornerRadius: 12) {
+                VStack(alignment: .leading) {
+                    Dot(color: "green", diameter: 10)
+                    Rule()
+                    Text("<content>")
+                    Rule()
+                    InputCursor()
+                }
+            }
+        }.render()
+    }
+}

--- a/repos/teatro/Sources/ViewCore/Dot.swift
+++ b/repos/teatro/Sources/ViewCore/Dot.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct Dot: Renderable {
+    public let color: String
+    public let diameter: Int
+
+    public init(color: String = "black", diameter: Int = 10) {
+        self.color = color
+        self.diameter = diameter
+    }
+
+    public func render() -> String {
+        "\u{25CF}" // ●
+    }
+}

--- a/repos/teatro/Sources/ViewCore/InputCursor.swift
+++ b/repos/teatro/Sources/ViewCore/InputCursor.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct InputCursor: Renderable {
+    public init() {}
+
+    public func render() -> String {
+        "|"
+    }
+}

--- a/repos/teatro/Sources/ViewCore/Panel.swift
+++ b/repos/teatro/Sources/ViewCore/Panel.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct Panel: Renderable {
+    public let width: Int
+    public let height: Int
+    public let cornerRadius: Int
+    public let content: Renderable
+
+    public init(width: Int, height: Int, cornerRadius: Int = 0, @ViewBuilder content: () -> Renderable) {
+        self.width = width
+        self.height = height
+        self.cornerRadius = cornerRadius
+        self.content = content()
+    }
+
+    public func render() -> String {
+        "[Panel \(width)x\(height) r:\(cornerRadius)]\n" + content.render()
+    }
+}

--- a/repos/teatro/Sources/ViewCore/Rule.swift
+++ b/repos/teatro/Sources/ViewCore/Rule.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct Rule: Renderable {
+    public init() {}
+
+    public func render() -> String {
+        String(repeating: "-", count: 10)
+    }
+}

--- a/repos/teatro/Tests/ViewCoreTests.swift
+++ b/repos/teatro/Tests/ViewCoreTests.swift
@@ -23,4 +23,18 @@ final class ViewCoreTests: XCTestCase {
         }
         XCTAssertEqual(stack.render(), " A B")
     }
+
+    func testPanelRendering() {
+        let panel = Panel(width: 100, height: 100, cornerRadius: 5) {
+            Text("X")
+        }
+        let expected = "[Panel 100x100 r:5]\nX"
+        XCTAssertEqual(panel.render(), expected)
+    }
+
+    func testDotRuleCursorRendering() {
+        XCTAssertEqual(Dot().render(), "\u{25CF}")
+        XCTAssertEqual(Rule().render(), String(repeating: "-", count: 10))
+        XCTAssertEqual(InputCursor().render(), "|")
+    }
 }


### PR DESCRIPTION
## Summary
- add `Panel`, `Dot`, `Rule`, and `InputCursor` primitives
- implement `DispatcherPrompt` example view
- exercise new types in `ViewCoreTests`

## Testing
- `swift build` *(fails: command not found)*
- `swift test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b97fd960483258de4a889638d1237