### PR TITLE
Add Dispatcher Mac UI starter package

### DIFF
--- a/docs/dispatcher_mac_gui_plan.md
+++ b/docs/dispatcher_mac_gui_plan.md
@@ -37,12 +37,13 @@ While the initial release focuses on dispatcher controls, the same Teatro-based 
 1. Create a small Swift Package that embeds Teatro and exposes the dispatcher process management code.
 2. Prototype the settings form and log viewer using Teatro's SwiftUI preview support.
 3. Iterate based on feedback, expanding the UI to cover additional services as FountainAI evolves.
+4. Open `repos/DispatcherMacApp/` in Xcode to preview `ContentView` and begin UI experimentation.
 
 ---
 
 By approaching the dispatcher as a macOS app, we lower the entry barrier for experimentation and pave the way for deeper FountainAI integrations.
 
-```
+````
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
-```
+````

--- a/repos/DispatcherMacApp/.gitignore
+++ b/repos/DispatcherMacApp/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/repos/DispatcherMacApp/Package.swift
+++ b/repos/DispatcherMacApp/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "DispatcherMacApp",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "DispatcherMacApp", targets: ["DispatcherMacApp"])
+    ],
+    dependencies: [
+        .package(path: "../teatro")
+    ],
+    targets: [
+        .executableTarget(
+            name: "DispatcherMacApp",
+            dependencies: [
+                .product(name: "Teatro", package: "teatro")
+            ],
+            path: "Sources"
+        )
+    ]
+)

--- a/repos/DispatcherMacApp/Sources/DispatcherMacApp/ContentView.swift
+++ b/repos/DispatcherMacApp/Sources/DispatcherMacApp/ContentView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+import Teatro
+
+struct ContentView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Dispatcher GUI")
+                .font(.title)
+            Button("Start Dispatcher") {
+                print("Start dispatcher tapped")
+            }
+            TeatroRenderView(content: DispatcherPrompt())
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .padding()
+    }
+}
+
+#Preview
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/repos/DispatcherMacApp/Sources/DispatcherMacApp/DispatcherMacApp.swift
+++ b/repos/DispatcherMacApp/Sources/DispatcherMacApp/DispatcherMacApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct DispatcherMacApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/repos/DispatcherMacApp/Sources/DispatcherMacApp/TeatroRenderView.swift
+++ b/repos/DispatcherMacApp/Sources/DispatcherMacApp/TeatroRenderView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+import Teatro
+
+struct TeatroRenderView: View {
+    let content: Renderable
+    var body: some View {
+        Text(content.render())
+            .font(.system(.body, design: .monospaced))
+            .padding()
+            .background(Color(NSColor.textBackgroundColor))
+    }
+}


### PR DESCRIPTION
## Summary
- create `DispatcherMacApp` Swift package for the macOS GUI
- show a starter `ContentView` with a preview-ready Teatro renderer
- update the GUI plan doc with instructions to open the package in Xcode

## Testing
- `swift build` *(fails: return expression of type '[any Renderable]' does not conform to 'Renderable')*

------
https://chatgpt.com/codex/tasks/task_e_687b9b20fe108325813b41d9d2ddccaa