### PR TITLE
Fix builder usage and explicit Alignment

### DIFF
--- a/repos/teatro/Sources/ViewCore/DispatcherPrompt.swift
+++ b/repos/teatro/Sources/ViewCore/DispatcherPrompt.swift
@@ -6,7 +6,7 @@ public struct DispatcherPrompt: Renderable {
     public func render() -> String {
         Stage(title: "Dispatcher") {
             Panel(width: 640, height: 900, cornerRadius: 12) {
-                VStack(alignment: .leading) {
+                VStack(alignment: Alignment.leading) {
                     Dot(color: "green", diameter: 10)
                     Rule()
                     Text("<content>")

--- a/repos/teatro/Sources/ViewCore/HStack.swift
+++ b/repos/teatro/Sources/ViewCore/HStack.swift
@@ -3,7 +3,7 @@ public struct HStack: Layouting {
     public let alignment: Alignment
     public let padding: Int
 
-    public init(alignment: Alignment = .leading, padding: Int = 0, @ViewBuilder _ content: () -> [Renderable]) {
+    public init(alignment: Alignment = Alignment.leading, padding: Int = 0, @ViewBuilder _ content: () -> [Renderable]) {
         self.alignment = alignment
         self.padding = padding
         self.children = content()

--- a/repos/teatro/Sources/ViewCore/Panel.swift
+++ b/repos/teatro/Sources/ViewCore/Panel.swift
@@ -4,9 +4,9 @@ public struct Panel: Renderable {
     public let width: Int
     public let height: Int
     public let cornerRadius: Int
-    public let content: Renderable
+    public let content: [Renderable]
 
-    public init(width: Int, height: Int, cornerRadius: Int = 0, @ViewBuilder content: () -> Renderable) {
+    public init(width: Int, height: Int, cornerRadius: Int = 0, @ViewBuilder content: () -> [Renderable]) {
         self.width = width
         self.height = height
         self.cornerRadius = cornerRadius
@@ -14,6 +14,6 @@ public struct Panel: Renderable {
     }
 
     public func render() -> String {
-        "[Panel \(width)x\(height) r:\(cornerRadius)]\n" + content.render()
+        "[Panel \(width)x\(height) r:\(cornerRadius)]\n" + content.map { $0.render() }.joined(separator: "\n")
     }
 }

--- a/repos/teatro/Sources/ViewCore/VStack.swift
+++ b/repos/teatro/Sources/ViewCore/VStack.swift
@@ -3,7 +3,7 @@ public struct VStack: Layouting {
     public let alignment: Alignment
     public let padding: Int
 
-    public init(alignment: Alignment = .leading, padding: Int = 0, @ViewBuilder _ content: () -> [Renderable]) {
+    public init(alignment: Alignment = Alignment.leading, padding: Int = 0, @ViewBuilder _ content: () -> [Renderable]) {
         self.alignment = alignment
         self.padding = padding
         self.children = content()


### PR DESCRIPTION
## Summary
- ensure `HStack` and `VStack` default to `Alignment.leading`
- update `Panel` to accept an array of `Renderable` values
- adjust `DispatcherPrompt` to use the explicit enum

## Testing
- `swift build -Xswiftc -debug-diagnostic-names`
- `swift test -Xswiftc -debug-diagnostic-names`

------
https://chatgpt.com/codex/tasks/task_e_687ba0ec017c8325b7b4f3d58faf4a6a