### PR TITLE
Fix SwiftUI previews for swift build

### DIFF
--- a/repos/DispatcherMacApp/Sources/DispatcherMacApp/ContentView.swift
+++ b/repos/DispatcherMacApp/Sources/DispatcherMacApp/ContentView.swift
@@ -17,12 +17,11 @@ struct ContentView: View {
     }
 }
 
-#Preview
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
-    }
+#if canImport(SwiftUI) && DEBUG
+#Preview {
+    ContentView()
 }
+#endif
 #else
 import Teatro
 


### PR DESCRIPTION
## Summary
- remove Xcode preview provider and use `#Preview` macro only under DEBUG
- keep fallback `ContentView` stub for non-SwiftUI targets

## Testing
- `swift build`
- `swift test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687bbe4fb8c483259d235dde6efdc1e9