### PR TITLE
Fix TeatroRenderView init usage

### DIFF
--- a/repos/DispatcherMacApp/Sources/DispatcherUI/ContentView.swift
+++ b/repos/DispatcherMacApp/Sources/DispatcherUI/ContentView.swift
@@ -11,7 +11,7 @@ public struct ContentView: View {
             Button("Start Dispatcher") {
                 print("Start dispatcher tapped")
             }
-            TeatroRenderView(prompt: DispatcherPrompt())
+            TeatroRenderView(content: DispatcherPrompt())
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .padding()

--- a/repos/DispatcherMacApp/Sources/DispatcherUI/TeatroRenderView.swift
+++ b/repos/DispatcherMacApp/Sources/DispatcherUI/TeatroRenderView.swift
@@ -3,8 +3,10 @@ import SwiftUI
 import Teatro
 
 public struct TeatroRenderView: View {
-    public init() {}
     let content: Renderable
+    public init(content: Renderable) {
+        self.content = content
+    }
     public var body: some View {
         Text(content.render())
             .font(.system(.body, design: .monospaced))


### PR DESCRIPTION
## Summary
- update `TeatroRenderView` to take `content` parameter in SwiftUI path
- call new initializer from `ContentView`

## Testing
- `swift build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bdb3fc1e8832587a67b5cfb10dd70