### PR TITLE
Fix preview guard in ContentView

### DIFF
--- a/repos/DispatcherMacApp/Sources/DispatcherUI/ContentView.swift
+++ b/repos/DispatcherMacApp/Sources/DispatcherUI/ContentView.swift
@@ -18,7 +18,7 @@ public struct ContentView: View {
     }
 }
 
-#if canImport(SwiftUI) && DEBUG && !SWIFT_PACKAGE
+#if canImport(SwiftUI)
 #Preview {
     ContentView()
 }


### PR DESCRIPTION
## Summary
- narrow the SwiftUI preview compile guard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bded580148325822b04f40e533dc0