### PR TITLE
Enhance Dispatcher macOS GUI

### DIFF
--- a/repos/DispatcherMacApp/Sources/DispatcherUI/ContentView.swift
+++ b/repos/DispatcherMacApp/Sources/DispatcherUI/ContentView.swift
@@ -3,18 +3,22 @@ import SwiftUI
 import Teatro
 
 public struct ContentView: View {
+    @StateObject private var manager = DispatcherManager()
+
     public init() {}
+
     public var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("Dispatcher GUI")
-                .font(.title)
-            Button("Start Dispatcher") {
-                print("Start dispatcher tapped")
-            }
-            TeatroRenderView(content: DispatcherPrompt())
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        TabView {
+            DashboardView(manager: manager)
+                .tabItem { Text("Dashboard") }
+            QueueView()
+                .tabItem { Text("Queue") }
+            LogView(manager: manager)
+                .tabItem { Text("Logs") }
+            SettingsView()
+                .tabItem { Text("Settings") }
         }
-        .padding()
+        .frame(minWidth: 700, minHeight: 500)
     }
 }
 

--- a/repos/DispatcherMacApp/Sources/DispatcherUI/DashboardView.swift
+++ b/repos/DispatcherMacApp/Sources/DispatcherUI/DashboardView.swift
@@ -1,0 +1,39 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Primary control panel showing dispatcher status and metrics.
+public struct DashboardView: View {
+    @ObservedObject var manager: DispatcherManager
+
+    public init(manager: DispatcherManager) {
+        self.manager = manager
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 20) {
+                Button(manager.isRunning ? "Stop" : "Start") {
+                    manager.isRunning ? manager.stop() : manager.start()
+                }
+                .keyboardShortcut(.defaultAction)
+
+                Text(manager.isRunning ? "Running" : "Stopped")
+                    .foregroundStyle(manager.isRunning ? .green : .red)
+                Spacer()
+                Text("Cycles: \(manager.cycleCount)")
+                Text(manager.lastBuildResult)
+            }
+            if let last = manager.logs.last {
+                Text(last).font(.footnote).foregroundStyle(.secondary)
+            }
+            TeatroRenderView(content: DispatcherPrompt())
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    DashboardView(manager: DispatcherManager())
+}
+#endif

--- a/repos/DispatcherMacApp/Sources/DispatcherUI/DispatcherManager.swift
+++ b/repos/DispatcherMacApp/Sources/DispatcherUI/DispatcherManager.swift
@@ -1,0 +1,64 @@
+#if canImport(SwiftUI)
+import Foundation
+import Combine
+
+/// Manages the lifecycle of ``dispatcher_v2.py`` and streams log output.
+public final class DispatcherManager: ObservableObject {
+    @Published public private(set) var isRunning: Bool = false
+    @Published public private(set) var logs: [String] = []
+    @Published public private(set) var cycleCount: Int = 0
+    @Published public private(set) var lastBuildResult: String = ""
+
+    private var process: Process?
+    private var logPipe = Pipe()
+    private var cancellables = Set<AnyCancellable>()
+
+    public init() {}
+
+    /// Launch the Python dispatcher if not already running.
+    public func start() {
+        guard !isRunning else { return }
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        proc.arguments = ["deploy/dispatcher_v2.py"]
+        proc.standardOutput = logPipe
+        proc.standardError = logPipe
+        proc.terminationHandler = { [weak self] _ in
+            DispatchQueue.main.async { self?.isRunning = false }
+        }
+        do {
+            try proc.run()
+            captureOutput()
+            process = proc
+            isRunning = true
+        } catch {
+            append("Failed to start dispatcher: \(error.localizedDescription)")
+        }
+    }
+
+    /// Terminate the running dispatcher process.
+    public func stop() {
+        guard let proc = process, proc.isRunning else { return }
+        proc.terminate()
+        process = nil
+        isRunning = false
+    }
+
+    private func captureOutput() {
+        logPipe.fileHandleForReading.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            guard !data.isEmpty, let str = String(data: data, encoding: .utf8) else { return }
+            DispatchQueue.main.async {
+                self?.append(str)
+            }
+        }
+    }
+
+    private func append(_ line: String) {
+        logs.append(contentsOf: line.split(separator: "\n").map(String.init))
+        if line.contains("=== New Cycle ===") { cycleCount += 1 }
+        if line.contains("swift build succeeded") { lastBuildResult = "✅ build" }
+        if line.contains("swift build failed") { lastBuildResult = "❌ build" }
+    }
+}
+#endif

--- a/repos/DispatcherMacApp/Sources/DispatcherUI/LogView.swift
+++ b/repos/DispatcherMacApp/Sources/DispatcherUI/LogView.swift
@@ -1,0 +1,36 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Scrollable log output using a monospaced font.
+public struct LogView: View {
+    @ObservedObject var manager: DispatcherManager
+
+    public init(manager: DispatcherManager) {
+        self.manager = manager
+    }
+
+    public var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 2) {
+                    ForEach(Array(manager.logs.enumerated()), id: \.offset) { idx, line in
+                        Text(line)
+                            .font(.system(.body, design: .monospaced))
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .id(idx)
+                    }
+                }
+                .onChange(of: manager.logs.count) { _ in
+                    if let last = manager.logs.indices.last {
+                        withAnimation { proxy.scrollTo(last, anchor: .bottom) }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    LogView(manager: DispatcherManager())
+}
+#endif

--- a/repos/DispatcherMacApp/Sources/DispatcherUI/QueueView.swift
+++ b/repos/DispatcherMacApp/Sources/DispatcherUI/QueueView.swift
@@ -1,0 +1,39 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Displays pending JSON patches from the feedback directory.
+public struct QueueView: View {
+    @State private var files: [String] = []
+    var timer = Timer.publish(every: 5, on: .main, in: .common).autoconnect()
+
+    public init() {}
+
+    public var body: some View {
+        Table(of: String.self) {
+            TableColumn("File") { item in
+                Text(item)
+            }
+        } rows: {
+            ForEach(files, id: \.self) { file in
+                TableRow(file)
+            }
+        }
+        .onReceive(timer) { _ in refresh() }
+        .onAppear { refresh() }
+    }
+
+    private func feedbackDir() -> URL {
+        URL(fileURLWithPath: "/srv/deploy/feedback")
+    }
+
+    private func refresh() {
+        let path = feedbackDir()
+        let items = (try? FileManager.default.contentsOfDirectory(atPath: path.path)) ?? []
+        files = items.sorted()
+    }
+}
+
+#Preview {
+    QueueView()
+}
+#endif

--- a/repos/DispatcherMacApp/Sources/DispatcherUI/SettingsView.swift
+++ b/repos/DispatcherMacApp/Sources/DispatcherUI/SettingsView.swift
@@ -1,0 +1,54 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Edit dispatcher.env variables.
+public struct SettingsView: View {
+    @State private var values: [String: String] = [:]
+
+    public init() {}
+
+    public var body: some View {
+        Form {
+            ForEach(values.keys.sorted(), id: \.self) { key in
+                HStack {
+                    Text(key).frame(width: 200, alignment: .trailing)
+                    TextField("", text: Binding(
+                        get: { values[key] ?? "" },
+                        set: { values[key] = $0 }
+                    ))
+                }
+            }
+            Button("Save") { save() }
+        }
+        .padding()
+        .onAppear { load() }
+    }
+
+    private var fileURL: URL {
+        URL(fileURLWithPath: "/srv/deploy/dispatcher.env")
+    }
+
+    private func load() {
+        guard let data = try? String(contentsOf: fileURL) else { return }
+        var dict: [String: String] = [:]
+        for line in data.split(separator: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("#") || trimmed.isEmpty { continue }
+            let parts = trimmed.split(separator: "=", maxSplits: 1)
+            if parts.count == 2 {
+                dict[String(parts[0])] = String(parts[1])
+            }
+        }
+        values = dict
+    }
+
+    private func save() {
+        let content = values.keys.sorted().map { "\($0)=\(values[$0] ?? "")" }.joined(separator: "\n")
+        try? content.write(to: fileURL, atomically: true, encoding: .utf8)
+    }
+}
+
+#Preview {
+    SettingsView()
+}
+#endif


### PR DESCRIPTION
## Summary
- add Dashboard, Queue, Logs and Settings views
- manage python dispatcher process with DispatcherManager
- show logs and metrics live
- hook all views into ContentView

## Testing
- `swift build`
- `swift test` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_687be19b549c83259525021232626c53