### PR TITLE
Implement card layout in Dashboard

### DIFF
--- a/repos/DispatcherMacApp/Sources/DispatcherUI/ContentView.swift
+++ b/repos/DispatcherMacApp/Sources/DispatcherUI/ContentView.swift
@@ -9,8 +9,11 @@ public struct ContentView: View {
 
     public var body: some View {
         TabView {
-            DashboardView(manager: manager)
-                .tabItem { Text("Dashboard") }
+            ZStack {
+                DashboardView(manager: manager)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            .tabItem { Text("Dashboard") }
             QueueView()
                 .tabItem { Text("Queue") }
             LogView(manager: manager)

--- a/repos/DispatcherMacApp/Sources/DispatcherUI/DashboardView.swift
+++ b/repos/DispatcherMacApp/Sources/DispatcherUI/DashboardView.swift
@@ -5,32 +5,71 @@ import Teatro
 /// Primary control panel showing dispatcher status and metrics.
 public struct DashboardView: View {
     @ObservedObject var manager: DispatcherManager
+    @State private var command: String = ""
 
     public init(manager: DispatcherManager) {
         self.manager = manager
     }
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(spacing: 20) {
-                Button(manager.isRunning ? "Stop" : "Start") {
-                    manager.isRunning ? manager.stop() : manager.start()
-                }
-                .keyboardShortcut(.defaultAction)
+        ZStack {
+            card
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    }
 
-                Text(manager.isRunning ? "Running" : "Stopped")
-                    .foregroundStyle(manager.isRunning ? .green : .red)
-                Spacer()
-                Text("Cycles: \(manager.cycleCount)")
-                Text(manager.lastBuildResult)
-            }
+    @ViewBuilder
+    private var card: some View {
+        VStack(spacing: 0) {
+            header
             if let last = manager.logs.last {
-                Text(last).font(.footnote).foregroundStyle(.secondary)
+                Text(last)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
             }
+            Divider().background(Color.gray.opacity(0.3))
             TeatroRenderView(content: DispatcherPrompt())
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+            Divider()
+                .background(Color.gray.opacity(0.3))
+                .padding(.top, 20)
+            TextField("Type command…", text: $command, onCommit: {
+                manager.send(command)
+                command = ""
+            })
+            .textFieldStyle(.roundedBorder)
         }
-        .padding()
+        .padding(16)
+        .frame(minWidth: 700, minHeight: 500)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(NSColor.windowBackgroundColor))
+                .shadow(radius: 4)
+        )
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(manager.isRunning ? Color.green : Color.red)
+                .frame(width: 10, height: 10)
+                .animation(.easeInOut(duration: 0.3), value: manager.isRunning)
+            Button(manager.isRunning ? "Stop" : "Start") {
+                manager.isRunning ? manager.stop() : manager.start()
+            }
+            .keyboardShortcut(.defaultAction)
+            .buttonStyle(.bordered)
+            .tint(.blue)
+            .controlSize(.small)
+            Text(manager.isRunning ? "Running" : "Stopped")
+                .foregroundStyle(manager.isRunning ? .green : .red)
+            Spacer()
+            Text("Cycles: \(manager.cycleCount)")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            Text(manager.lastBuildResult)
+        }
+        .padding(.bottom, 8)
     }
 }
 


### PR DESCRIPTION
## Summary
- restyle `DashboardView` with a centred card-like panel
- update `ContentView` to centre the dashboard in its tab

## Testing
- `swift build`

------
https://chatgpt.com/codex/tasks/task_e_687be92b6dfc8325af47999f477fba80