### PR TITLE
Add shared view builder aliases

### DIFF
--- a/repos/GUITeatro/Sources/GUITeatroUI/ContentView.swift
+++ b/repos/GUITeatro/Sources/GUITeatroUI/ContentView.swift
@@ -2,9 +2,6 @@
 import SwiftUI
 import Teatro
 
-public typealias TViewBuilder = Teatro.ViewBuilder
-public typealias SViewBuilder = SwiftUI.ViewBuilder
-
 public struct ContentView: View {
     @StateObject private var manager = ProcessManager()
 

--- a/repos/GUITeatro/Sources/GUITeatroUI/DashboardView.swift
+++ b/repos/GUITeatro/Sources/GUITeatroUI/DashboardView.swift
@@ -2,9 +2,6 @@
 import SwiftUI
 import Teatro
 
-public typealias TViewBuilder = Teatro.ViewBuilder
-public typealias SViewBuilder = SwiftUI.ViewBuilder
-
 /// Primary control panel showing dispatcher status and metrics.
 public struct DashboardView: View {
     @ObservedObject var manager: ProcessManager

--- a/repos/GUITeatro/Sources/GUITeatroUI/ProcessPrompt.swift
+++ b/repos/GUITeatro/Sources/GUITeatroUI/ProcessPrompt.swift
@@ -1,12 +1,24 @@
 #if canImport(SwiftUI)
 import SwiftUI
+import Teatro
 
-public struct ProcessPrompt: View {
+/// Placeholder prompt view used for renderer testing.
+public struct ProcessPrompt: View, Renderable {
     public init() {}
+
     public var body: some View {
         EmptyView() // TODO
     }
+
+    public func render() -> String {
+        "" // TODO: update with prompt content
+    }
 }
 #else
-public struct ProcessPrompt {}
+import Teatro
+
+public struct ProcessPrompt: Renderable {
+    public init() {}
+    public func render() -> String { "" }
+}
 #endif

--- a/repos/GUITeatro/Sources/GUITeatroUI/TeatroRenderView.swift
+++ b/repos/GUITeatro/Sources/GUITeatroUI/TeatroRenderView.swift
@@ -2,9 +2,6 @@
 import SwiftUI
 import Teatro
 
-public typealias TViewBuilder = Teatro.ViewBuilder
-public typealias SViewBuilder = SwiftUI.ViewBuilder
-
 public struct TeatroRenderView: View {
     let content: Renderable
     public init(content: Renderable) {

--- a/repos/GUITeatro/Sources/GUITeatroUI/ViewBuilders.swift
+++ b/repos/GUITeatro/Sources/GUITeatroUI/ViewBuilders.swift
@@ -1,0 +1,8 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import Teatro
+
+/// Convenience aliases for Teatro and SwiftUI result builders.
+public typealias TViewBuilder = Teatro.ViewBuilder
+public typealias SViewBuilder = SwiftUI.ViewBuilder
+#endif


### PR DESCRIPTION
## Summary
- centralize SwiftUI/Teatro view builder aliases in `ViewBuilders.swift`
- remove duplicate alias declarations from individual views
- make `ProcessPrompt` conform to `Renderable`

## Testing
- `swift build`

------
https://chatgpt.com/codex/tasks/task_e_687c6d720ce88325b37aa0ca347b8351