### PR TITLE
Add README for GUITeatro macOS playground

### DIFF
--- a/repos/GUITeatro/README.md
+++ b/repos/GUITeatro/README.md
@@ -1,0 +1,18 @@
+# GUITeatro
+
+GUITeatro acts as a macOS playground for the [Teatro](../teatro) view engine. It bundles the `GUITeatroUI` library together with a simple SwiftUI app so developers can experiment with Teatro-based UIs in a standalone environment.
+
+## Building
+
+Run the package with Swift Package Manager:
+
+```bash
+swift build
+```
+
+For live previews, open `ContentView.swift` in Xcode and use the SwiftUI preview canvas.
+
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````


### PR DESCRIPTION
## Summary
- document GUITeatro as a macOS playground for Teatro
- show how to build using Swift Package Manager
- explain how to open `ContentView` in Xcode for previews

## Testing
- `swift build` in `repos/GUITeatro`


------
https://chatgpt.com/codex/tasks/task_e_687c6f30956c8325b21e98dce8560a2e