### PR TITLE
Update docs with standard footer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,13 +5,14 @@ Please update any links or tooling that still refer to this file.
 
 ---
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
 
 > **Build requirement:** Swift 6.1 tool-chain
 
 ````text
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
 ````
+
+`````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+`````
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -569,7 +569,8 @@
 - 2025-07-19T02:56:17.953211 Update build log build-20250719-025615.log: 2025-07-19T02:56:17.879705
 - 2025-07-19T02:58:16.416544 Update build log build-20250719-025814.log: 2025-07-19T02:58:16.338290
 - 2025-07-19T03:00:16.204650 Update build log build-20250719-030013.log: 2025-07-19T03:00:15.819937
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/analysis.md
+++ b/analysis.md
@@ -9,7 +9,8 @@ initializer 'init(_:)' requires that '__socket_type' conform to 'BinaryFloatingP
 This indicates the constants `AF_INET` and `SOCK_STREAM` need to be explicitly cast to `Int32` when calling `socket()` on Linux. After patching `main.swift` files to use `Int32(AF_INET)` and `Int32(SOCK_STREAM)`, the build could not fully complete due to environment resource limits.
 
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/design_patterns.md
+++ b/docs/design_patterns.md
@@ -52,7 +52,8 @@ Teatro defines its UI purely through declarations.
 
 The combination of a client/server kernel, plugin-driven gateway, and declarative view engine offers clear separation of concerns. While each pattern introduces trade-offs, the design aligns with common best practices and provides a solid foundation for scaling the system.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/dispatcher_v2.md
+++ b/docs/dispatcher_v2.md
@@ -42,7 +42,8 @@ and integration tests after each successful commit or PR merge.
 
 For tips on reviewing failed builds, see the [README](../README.md#analyzing-swift-logs) section on analyzing Swift logs.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -81,7 +81,8 @@ values are not copied into Docker build contexts.
 
 See the [handbook](handbook/README.md) for additional setup guides.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/fountainai_mac_ui_plan.md
+++ b/docs/fountainai_mac_ui_plan.md
@@ -47,7 +47,8 @@ This document outlines an iterative approach for building a macOS desktop applic
 
 Following this plan will produce a fully featured macOS application that leverages FountainAI's microservices and Teatro's declarative rendering system.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/guit_teatro_gui_plan.md
+++ b/docs/guit_teatro_gui_plan.md
@@ -47,3 +47,8 @@ By approaching Teatro with a dedicated macOS app, we lower the entry barrier for
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ````
+
+`````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+`````
+

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -42,7 +42,8 @@ reference [`environment_variables.md`](../environment_variables.md) when
 describing required settings.
 
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/handbook/architecture.md
+++ b/docs/handbook/architecture.md
@@ -49,7 +49,8 @@ For a gentle introduction see [Introduction to Codex-Deployer](introduction.md).
 For implementation details see [dispatcher_v2.md](../dispatcher_v2.md).
 
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/handbook/code_reference.md
+++ b/docs/handbook/code_reference.md
@@ -23,7 +23,8 @@ Generated services live under `repos/fountainai`. Documentation will be produced
 with `swift package generate-documentation` once the build pipeline is enabled.
 
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/handbook/history.md
+++ b/docs/handbook/history.md
@@ -12,7 +12,8 @@ Codex-Deployer began as an experiment to remove brittle CI pipelines and GitHub 
 
 Return to the [handbook index](README.md) for additional background material.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/handbook/introduction.md
+++ b/docs/handbook/introduction.md
@@ -52,7 +52,8 @@ list of options.
 
 The [handbook README](README.md) contains a complete table of contents with links to additional background material. For API details see [code_reference.md](code_reference.md).
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/log_aggregation.md
+++ b/docs/log_aggregation.md
@@ -20,7 +20,8 @@ Replace `loki-url` with your aggregator endpoint. The same pattern applies to th
 
 For manual deployments, run a tool like `fluent-bit` or `promtail` to stream logs from Docker to the aggregator.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/mac_docker_tutorial.md
+++ b/docs/mac_docker_tutorial.md
@@ -101,7 +101,8 @@ frameworks while still running inside a container. Prefer the open source Swift
 toolchain whenever possible, but branch out into vendor-specific builds only
 when necessary.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/mac_local_testing.md
+++ b/docs/mac_local_testing.md
@@ -72,7 +72,8 @@ Press `Ctrl-C` in the terminal running the container to stop the dispatcher.
 - [environment_variables.md](environment_variables.md) – complete variable reference
 - [managing_environment_variables.md](managing_environment_variables.md) – step‑by‑step setup guide
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/managing_environment_variables.md
+++ b/docs/managing_environment_variables.md
@@ -99,7 +99,8 @@ Using a token avoids interactive Git prompts when cloning private repositories.
 
 - [handbook](handbook/README.md) – index of all tutorials
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/pull_request_workflow.md
+++ b/docs/pull_request_workflow.md
@@ -13,7 +13,8 @@ When PR mode is active the dispatcher:
 This approach allows human review while keeping automation centralized. Direct push mode remains available by disabling `DISPATCHER_USE_PRS`.
 
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/secrets_api_proposal.md
+++ b/docs/secrets_api_proposal.md
@@ -32,7 +32,8 @@ Storing long‑lived secrets on disk increases the risk of exposure. Fetching th
 Implementing this approach would require extending the dispatcher to perform the API call and parse the response before continuing with the build loop. See [environment_variables.md](environment_variables.md) for the complete list of variables that would be supplied by the secret service.
 
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/notables/kong_pitch.md
+++ b/notables/kong_pitch.md
@@ -18,7 +18,8 @@ Configuration variables for the deployment system are documented in [`docs/envir
 
 Overall, Kong provides production-ready routing, security, observability, and extensibility, reducing the need for a custom gateway built in Swift or Python.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/notables/kong_scenarios.md
+++ b/notables/kong_scenarios.md
@@ -12,7 +12,8 @@ The FountainAI microservices expose OpenAPI-based endpoints that can be unified 
 
 These scenarios show how Kong becomes more than a simple router—it orchestrates versioning, tenant management, observability and real-time tooling around FountainAI's services.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/report.md
+++ b/report.md
@@ -88,6 +88,8 @@ NIOHTTPServer.swift:61 -> /srv/deploy/repos/fountainai/Sources/IntegrationRuntim
 |                      `- warning: passing closure as a 'sending' parameter risks causing data races between code in the current task and concurrent execution of the closure
 **Suggested Fix:** Review the code around the reported line.
 ```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/AGENTS.md
+++ b/repos/fountainai/AGENTS.md
@@ -10,7 +10,8 @@ This repository uses Swift 6 and Swift Package Manager.
   ```
 - Summarize the test results in the PR description.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/CHANGELOG.md
+++ b/repos/fountainai/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/) and this 
 ### Added
 - Initial OpenAPI specs and generator skeleton.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/Docs/Historical/FountainAi_implementation_Agenda.md
+++ b/repos/fountainai/Docs/Historical/FountainAi_implementation_Agenda.md
@@ -50,7 +50,8 @@ For each service:
 
 Following this agenda will lead to a complete set of FountainAI services implemented in Swift, each accompanied by an independent client SDK and clear documentation describing how they fit together.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/Docs/Historical/codex-bootstrap.md
+++ b/repos/fountainai/Docs/Historical/codex-bootstrap.md
@@ -31,7 +31,8 @@ The `README.md` describes the purpose and structure of this project. The `.codex
 
 Begin now by initializing the repository structure and implementing the generator entrypoint.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/Docs/Historical/codex-plan.md
+++ b/repos/fountainai/Docs/Historical/codex-plan.md
@@ -70,7 +70,8 @@ This plan defines how Codex should build a Swift 6-native OpenAPI code generator
 
 ---
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/Docs/Historical/improvement-agenda.md
+++ b/repos/fountainai/Docs/Historical/improvement-agenda.md
@@ -59,7 +59,8 @@ The project has a solid start: parsing, model emission, client and server genera
 
 Addressing these items will close the gap between the current implementation and the aspirations laid out in the execution plan, delivering a more polished and self‑describing project.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/Docs/StatusQuo/FountainAi_openAPI_Status_Report.md
+++ b/repos/fountainai/Docs/StatusQuo/FountainAi_openAPI_Status_Report.md
@@ -65,7 +65,8 @@ Unit tests verify the generator using a simplified fixture rather than the full 
 
 Implementing these steps will transform the current skeleton generators into production‑ready client libraries and standalone servers for the entire FountainAI suite.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/Docs/StatusQuo/Reports/baseline-awareness-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/baseline-awareness-status.md
@@ -29,7 +29,8 @@ Spec path: `FountainAi/openAPI/v1/baseline-awareness.yml` (version 1.0.0).
 - Prometheus metrics now record request durations for performance insights
 - Structured logging added for easier debugging and monitoring
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/Docs/StatusQuo/Reports/bootstrap-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/bootstrap-status.md
@@ -22,7 +22,8 @@ Spec path: `FountainAi/openAPI/v1/bootstrap.yml` (version 1.0.0).
 - Implemented reflection promotion logic and streaming analytics
 - Added structured logging and a Compose workflow example
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/Docs/StatusQuo/Reports/deployment.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/deployment.md
@@ -54,7 +54,8 @@ docker compose down
 This workflow lets you run the microservices locally. Future updates will add full networking and durable persistence.
 All containers emit JSON logs which can be aggregated by your logging stack.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/Docs/StatusQuo/Reports/function-caller-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/function-caller-status.md
@@ -36,7 +36,8 @@ Spec path: `FountainAi/openAPI/v1/function-caller.yml` (version 1.0.0).
 - Document Kubernetes deployment examples
 - See [next-steps.md](next-steps.md) for cross-service priorities
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/Docs/StatusQuo/Reports/integration-testing-alternative.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/integration-testing-alternative.md
@@ -37,7 +37,8 @@ This document describes the cross-platform runtime now used for integration test
 All current integration tests use this runtime and run in CI on Linux and macOS.
 Developers run `swift test -v` locally to reproduce the same cross-platform flow.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/Docs/StatusQuo/Reports/llm-gateway-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/llm-gateway-status.md
@@ -28,7 +28,8 @@ Spec path: `FountainAi/openAPI/v2/llm-gateway.yml` (version 2.0.0).
 - Provide Docker build and deployment instructions
 - Document `OPENAI_API_KEY` and `OPENAI_API_BASE` usage in [environment_variables.md](../../../../../docs/environment_variables.md)
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/Docs/StatusQuo/Reports/next-steps.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/next-steps.md
@@ -20,7 +20,8 @@ All FountainAI services now run using a shared Swift concurrency runtime. Integr
 
 Completing these steps will transition FountainAI from prototype status to a stable, production‑ready microservice suite.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/Docs/StatusQuo/Reports/persistence-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/persistence-status.md
@@ -24,7 +24,8 @@ Spec path: `FountainAi/openAPI/v1/persist.yml` (version 1.0.0).
 - Document required environment variables
 - Add backup and restore procedures
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/Docs/StatusQuo/Reports/planner-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/planner-status.md
@@ -26,7 +26,8 @@ Spec path: `FountainAi/openAPI/v1/planner.yml` (version 1.0.0).
 - Document environment variables and external dependencies
 - Refer to [environment_variables.md](../../../../../docs/environment_variables.md) when configuring the service
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/Docs/StatusQuo/Reports/tools-factory-status.md
+++ b/repos/fountainai/Docs/StatusQuo/Reports/tools-factory-status.md
@@ -37,7 +37,8 @@ Invalid documents return `422` with an `ErrorResponse`.
 - **Completed**: `typesense-codex/scripts/bootstrap_typesense.py` creates required collections for production Typesense instances.
 - Structured logging and Docker Compose example added for local testing
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/Docs/StatusQuo/future-priorities.md
+++ b/repos/fountainai/Docs/StatusQuo/future-priorities.md
@@ -15,7 +15,8 @@ To progress toward a functional release we should:
 5. **Automate CI and container builds** – run `swift build` and `swift test` on every pull request and document Docker workflows for deployment.
 6. **Update the execution plan** – reconcile `Docs/Historical/codex-plan.md` with completed work and these new tasks.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/FountainAi/openAPI/README.md
+++ b/repos/fountainai/FountainAi/openAPI/README.md
@@ -19,7 +19,8 @@ This directory contains the OpenAPI specifications for each FountainAI microserv
 - **Planner → LLM Gateway & Function Caller**: the Planner coordinates with the LLM Gateway for language model responses and triggers registered functions through the Function Caller.
 
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/README.md
+++ b/repos/fountainai/README.md
@@ -176,7 +176,8 @@ Current status reports reside in [Docs/StatusQuo](Docs/StatusQuo/).
 MIT License  
 © 2025 FountainAI
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/fountainai/VERSIONING.md
+++ b/repos/fountainai/VERSIONING.md
@@ -9,7 +9,8 @@ FountainAI services and the OpenAPI generator follow [Semantic Versioning](https
 
 Every change to an API spec or the generator must be recorded in `CHANGELOG.md` with the corresponding version number.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/kong-codex/AGENTS.md
+++ b/repos/kong-codex/AGENTS.md
@@ -4,7 +4,8 @@
 - Keep the README updated when configuration or environment variables change.
 - Refer to `../../docs/environment_variables.md` for common variable definitions.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/kong-codex/README.md
+++ b/repos/kong-codex/README.md
@@ -23,7 +23,8 @@ docker compose up -d
 Kong's admin API will be available on `http://localhost:8001` and the proxy
 listens on `http://localhost:8000`. Typesense is reachable at `${TYPESENSE_URL}`.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/kong-codex/agent.md
+++ b/repos/kong-codex/agent.md
@@ -7,7 +7,8 @@ Kong runs in db-less mode using `kong.yaml` as the declarative config.
 Use `docker-compose.yml` for local testing. Update `docs/environment_variables.md`
 when introducing new configuration.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/teatro/AGENTS.md
+++ b/repos/teatro/AGENTS.md
@@ -13,7 +13,8 @@ This repository contains the documentation for **Teatro View Engine**, a declara
 - There are currently no automated tests. If you add code, provide appropriate tests and ensure they run via `swift test`.
 - Maintain this `AGENTS.md` if repository structure changes.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/teatro/Docs/Addendum/README.md
+++ b/repos/teatro/Docs/Addendum/README.md
@@ -77,7 +77,8 @@ This ensures that semantic rendering, narrative structuring, and musical composi
 
 © 2025 FountainAI — MIT License
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/teatro/Docs/AnimationSystem/README.md
+++ b/repos/teatro/Docs/AnimationSystem/README.md
@@ -64,7 +64,8 @@ This animation system works especially well for:
 - Drift and semantic arc transitions
 
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/teatro/Docs/CLIIntegration/README.md
+++ b/repos/teatro/Docs/CLIIntegration/README.md
@@ -57,7 +57,8 @@ This CLI is ideal for:
 - Rendering `.fountain`, `.mid`, or `.ly` views via CLI with extended routing
 
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/teatro/Docs/CoreProtocols/README.md
+++ b/repos/teatro/Docs/CoreProtocols/README.md
@@ -72,6 +72,8 @@ public enum ViewBuilder {
     }
 }
 ```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/teatro/Docs/FountainScreenplayEngine/README.md
+++ b/repos/teatro/Docs/FountainScreenplayEngine/README.md
@@ -124,7 +124,8 @@ CUT TO: >>
 - Embed semantic cues for lighting, props, and character arcs via `TeatroIcon` and `CodexPreviewer`
 
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/teatro/Docs/ImplementationPlan/README.md
+++ b/repos/teatro/Docs/ImplementationPlan/README.md
@@ -48,7 +48,8 @@ This roadmap converts the critique and analysis of the Teatro View Engine into c
 
 This document should evolve alongside the codebase. **Maintain and update this roadmap** as new features land or priorities shift to keep development focused and transparent.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/teatro/Docs/LilyPondMusicRendering/README.md
+++ b/repos/teatro/Docs/LilyPondMusicRendering/README.md
@@ -72,7 +72,8 @@ teatro_theme.ps
 - Combine with GPT output templates to embed titles, composer metadata, lyrics, and spacing settings
 
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/teatro/Docs/MIDI20DSL/README.md
+++ b/repos/teatro/Docs/MIDI20DSL/README.md
@@ -94,7 +94,8 @@ MIDIRenderer.renderToFile(melody, to: "demo.mid")
 - Pairs well with `Animator` for synchronizing scenes and sounds
 
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/teatro/Docs/RenderingBackends/README.md
+++ b/repos/teatro/Docs/RenderingBackends/README.md
@@ -94,6 +94,8 @@ public struct CodexPreviewer {
     }
 }
 ```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/teatro/Docs/Summary/README.md
+++ b/repos/teatro/Docs/Summary/README.md
@@ -57,7 +57,8 @@ Teatro/
 ---
 
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/teatro/Docs/ViewImplementationPlan/README.md
+++ b/repos/teatro/Docs/ViewImplementationPlan/README.md
@@ -59,7 +59,8 @@ Update `Package.swift` to add library and executable targets for the new sources
 
 Following this implementation and testing plan will produce a fully functional Teatro View Engine with deterministic rendering logic and comprehensive unit coverage for every view.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/teatro/Docs/ViewTypes/README.md
+++ b/repos/teatro/Docs/ViewTypes/README.md
@@ -111,6 +111,8 @@ public struct TeatroIcon: Renderable {
     }
 }
 ```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/teatro/README.md
+++ b/repos/teatro/README.md
@@ -17,7 +17,8 @@ This repository contains the specification for Teatro, a modular Swift 6 view en
 
 The `Sources/` directory follows the structure suggested in the documentation and contains placeholders for implementation. `Tests/` remains empty until concrete code is added.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/typesense-codex/README.md
+++ b/repos/typesense-codex/README.md
@@ -2,7 +2,8 @@
 
 Codex-managed Typesense schema + feedback registry for FountainAI.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/repos/typesense-codex/agent.md
+++ b/repos/typesense-codex/agent.md
@@ -2,7 +2,8 @@
 
 This agent manages Typesense collections, schemas, and Codex tuning logic.
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+


### PR DESCRIPTION
## Summary
- normalize disclaimers to the standard single-line footer across docs and sub-repos

## Testing
- `swift test -c debug --skip-build` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687c7251e32883258fc103214ca22430