### PR TITLE
Rename GUI plan and update references

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Codex-Deployer unifies builds, logs, and semantic fixes in a single Git-bound lo
 - [Pull Request Workflow](docs/pull_request_workflow.md) – how patches are proposed and merged.
 - [Code Reference](docs/handbook/code_reference.md) – links to inline API docs.
 - [History and Roadmap](docs/handbook/history.md) – how the project evolved and what's next.
-- [TeatroPlayground Concept](docs/guit_teatro_gui_plan.md) – draft plan for a Teatro-based GUI.
+- [TeatroPlayground GUI Plan](docs/teatro_playground_gui_plan.md) – draft plan for a Teatro-based GUI.
 
 ## Quick start
 Clone the repository, copy the sample environment file, and start the dispatcher in Docker.
@@ -53,6 +53,6 @@ FountainAI aims to unify these services under a persistent reasoning loop that s
 | Planner | http://planner.fountain.coach/api/v1 | Orchestrates planning workflows across the LLM Gateway and Function Caller. | [v1/planner.yml](repos/fountainai/FountainAi/openAPI/v1/planner.yml) |
 | Tools Factory | http://tools-factory.fountain.coach/api/v1 | Registers new tool definitions in the shared Typesense collection consumed by the Function Caller. | [v1/tools-factory.yml](repos/fountainai/FountainAi/openAPI/v1/tools-factory.yml) |
 
-````text
+`````text
 ©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
-````
+`````

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -34,7 +34,7 @@ repository itself see the [main README](../../README.md).
 - [History and Roadmap](history.md)
 
 - [FountainAI macOS UI Plan](../fountainai_mac_ui_plan.md)
-- [TeatroPlayground Concept](../guit_teatro_gui_plan.md)
+- [TeatroPlayground GUI Plan](../teatro_playground_gui_plan.md)
 
 These documents should give you a complete picture of how the dispatcher works,
 how to configure it, and how the surrounding services fit together. All guides
@@ -42,7 +42,6 @@ reference [`environment_variables.md`](../environment_variables.md) when
 describing required settings.
 
 
-```
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-```
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````

--- a/docs/teatro_playground_gui_plan.md
+++ b/docs/teatro_playground_gui_plan.md
@@ -1,4 +1,4 @@
-# TeatroPlayground Concept
+# TeatroPlayground GUI Plan
 
 This document describes a lightweight macOS application for exploring Teatro features through a graphical interface. By providing a friendly UI, new contributors can experiment with Teatro components without editing shell scripts or environment files. The application serves as a playground for FountainAI tools and demonstrates how Teatro renders interfaces.
 
@@ -43,7 +43,6 @@ TeatroPlayground begins as a playground for Teatro components, but it will grow 
 
 By approaching Teatro with a dedicated macOS app, we lower the entry barrier for experimentation and pave the way for deeper FountainAI integrations.
 
-````
-© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
-Unauthorized copying or distribution is strictly prohibited.
-````
+`````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+`````


### PR DESCRIPTION
## Summary
- rename docs/guit_teatro_gui_plan.md -> docs/teatro_playground_gui_plan.md
- rename document heading to TeatroPlayground GUI Plan
- update handbook link and README link to new filename
- apply footer policy updates across modified docs

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_687c855fa8708325ba3f0229d5fc540c