### PR TITLE
Add teatro-playground repo support

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -88,6 +88,7 @@ Build logs and applied feedback patches are automatically pushed back to GitHub 
 | `typesense-codex` | Typesense indexing schemas and bootstrapping logic |
 | `codex-deployer` | This repo — hosts the dispatcher, feedback, and loop logic |
 | `teatro` | Teatro view engine and rendering framework |
+| `teatro-playground` | GUI experiments and staging for Teatro components |
 
 > **Note**: `fountainai` refers to the GitHub repo
 > [`Fountain-Coach/swift-codex-openapi-kernel`](https://github.com/Fountain-Coach/swift-codex-openapi-kernel).  
@@ -115,8 +116,9 @@ Accepted values for **`"repo"`**:
 - `"fountainai"` → application logic (Swift services)  
 - `"kong-codex"` → API routes and plugins  
 - `"typesense-codex"` → schema or search logic  
-- `"codex-deployer"` → dispatcher logic or system config  
-- `"teatro"` → Teatro components  
+- `"codex-deployer"` → dispatcher logic or system config
+- `"teatro"` → Teatro components
+- `"teatro-playground"` → GUI experiments for Teatro
 
 ---
 
@@ -128,6 +130,7 @@ Accepted values for **`"repo"`**:
 | `/srv/deploy/repos/kong-codex/` | Kong gateway config + plugins |
 | `/srv/deploy/repos/typesense-codex/` | Typesense indexing definitions |
 | `/srv/deploy/repos/teatro/` | Teatro view engine |
+| `/srv/deploy/repos/teatro-playground/` | Teatro Playground GUI experiments |
 | `/srv/deploy/deploy/` | Contains `dispatcher_v2.py` and runtime control logic |
 | `/srv/deploy/logs/` | Build logs from `swift build` and other commands |
 | `/srv/deploy/feedback/` | Codex-pushed semantic patches |

--- a/deploy/dispatcher.py
+++ b/deploy/dispatcher.py
@@ -1,6 +1,6 @@
 import subprocess, os, time, datetime
 
-REPO_NAMES = ["fountainai", "kong-codex", "typesense-codex", "teatro"]
+REPO_NAMES = ["fountainai", "kong-codex", "typesense-codex", "teatro", "teatro-playground"]
 REPOS_DIR = "/srv/deploy/repos"
 
 LOG_DIR = "/srv/deploy/logs"

--- a/deploy/dispatcher_v2.py
+++ b/deploy/dispatcher_v2.py
@@ -22,7 +22,7 @@ import urllib.request
 import urllib.error
 
 # Managed repositories now live directly under ``repos/`` in this repository.
-REPO_NAMES = ["fountainai", "kong-codex", "typesense-codex", "teatro"]
+REPO_NAMES = ["fountainai", "kong-codex", "typesense-codex", "teatro", "teatro-playground"]
 REPOS_DIR = "/srv/deploy/repos"
 from codex_changelog import generate_commit_message, append_changelog
 


### PR DESCRIPTION
## Summary
- update dispatcher repo list with `teatro-playground`
- document the new repo in AGENT.md

## Testing
- `python3 -m py_compile deploy/dispatcher.py deploy/dispatcher_v2.py`


------
https://chatgpt.com/codex/tasks/task_e_687c86a292ac83259107f656256d0e2d