### PR TITLE
Add FountainAI Playground guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Codex-Deployer unifies builds, logs, and semantic fixes in a single Git-bound lo
 - [Code Reference](docs/handbook/code_reference.md) – links to inline API docs.
 - [History and Roadmap](docs/handbook/history.md) – how the project evolved and what's next.
 - [TeatroPlayground GUI Plan](docs/teatro_playground_gui_plan.md) – draft plan for a Teatro-based GUI.
+- [FountainAI Playground Guidelines](docs/fountainai_playground_guidelines.md) – rules for safe UI prototyping.
 
 ## Quick start
 Clone the repository, copy the sample environment file, and start the dispatcher in Docker.

--- a/docs/fountainai_playground_guidelines.md
+++ b/docs/fountainai_playground_guidelines.md
@@ -1,0 +1,11 @@
+# FountainAI Playground Guidelines
+
+The FountainAI Playground is a lightweight space for experimenting with GUI ideas. It is **not** intended for production deployments. Treat it as a sandbox where UI prototypes can evolve without affecting live services.
+
+Keep API tokens and other secrets private. Follow the setup described in [environment_variables.md](environment_variables.md) and store tokens in your environment rather than hard-coding them. The playground should read configuration from those variables just like the dispatcher.
+
+To start exploring, create a simple view that fetches data from a FountainAI service. Begin with mock responses so you can focus on the UI layout before integrating network calls. Once you are comfortable with the view structure, swap in the real service clients and build on that foundation.
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -35,6 +35,7 @@ repository itself see the [main README](../../README.md).
 
 - [FountainAI macOS UI Plan](../fountainai_mac_ui_plan.md)
 - [TeatroPlayground GUI Plan](../teatro_playground_gui_plan.md)
+- [FountainAI Playground Guidelines](../fountainai_playground_guidelines.md)
 
 These documents should give you a complete picture of how the dispatcher works,
 how to configure it, and how the surrounding services fit together. All guides


### PR DESCRIPTION
## Summary
- document FountainAI Playground usage rules
- reference the new guidelines from the README and handbook

## Testing
- `python3 -m py_compile analyze_swift_log.py deploy/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687c93431d7c8325886c39bd7925bac7