### PR TITLE
Update docs for codex‑FountainAI maintainer role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Codex-Deployer Handbook
 
-*Git-driven deployment companion for Swift services.*
+*Originally a Git-driven deployment companion for Swift services, now the codex‑FountainAI maintainer and GPT contributor.*
 
 ## Abstract
-Codex-Deployer unifies builds, logs, and semantic fixes in a single Git-bound loop. It primarily runs `deploy/dispatcher_v2.py` to build the local **FountainAI** sources vendored under `repos/`. The project began as a pragmatic helper for Codex but ultimately clears the path for FountainAI, a platform where large language models orchestrate tools, analyse knowledge drift, and learn from reflection. As the deployment loop compiles and patches code, it mirrors FountainAI's broader reasoning flow, where plans are executed step by step and every outcome informs the next iteration.
+Codex-Deployer unifies builds, logs, and semantic fixes in a single Git-bound loop. It primarily runs `deploy/dispatcher_v2.py` to build the local **FountainAI** sources vendored under `repos/`. The project began as a pragmatic helper for Codex but has grown into the codex‑FountainAI maintainer and GPT contributor. It still clears the path for FountainAI, a platform where large language models orchestrate tools, analyse knowledge drift, and learn from reflection. As the deployment loop compiles and patches code, it mirrors FountainAI's broader reasoning flow, where plans are executed step by step and every outcome informs the next iteration.
 
 ## Table of Contents
 - [Introduction to Codex-Deployer](docs/handbook/introduction.md) – overview of the dispatcher and how environment variables shape the workflow.
@@ -38,7 +38,7 @@ docker run --rm -it \
 For an explanation of each variable and how to generate tokens, see the [setup guide](docs/managing_environment_variables.md).
 
 ## From Codex to FountainAI
-Codex-Deployer focuses on deployment. For an overview of the broader FountainAI platform and its APIs, see [docs/future_vision.md](docs/future_vision.md).
+While deployment remains central, the repository now serves as the codex‑FountainAI maintainer and GPT contributor. For an overview of the broader FountainAI platform and its APIs, see [docs/future_vision.md](docs/future_vision.md).
 
 `````text
 ©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -2,7 +2,7 @@
 
 *Central index of guides and references.*
 
-Welcome to the early draft of the **Codex-Deployer Handbook**. This folder aggregates the existing tutorials and reference material for operating the deployment loop.
+Welcome to the early draft of the **Codex-Deployer Handbook**. This folder aggregates the existing tutorials and reference material for operating the deployment loop. The project has expanded from a simple deployment helper to the codex‑FountainAI maintainer and GPT contributor.
 
 The goal is to centralize onboarding documentation so new contributors can
 locate all relevant guides in one place. For a high level overview of the

--- a/docs/handbook/history.md
+++ b/docs/handbook/history.md
@@ -2,7 +2,7 @@
 
 *Origin story and future tasks.*
 
-Codex-Deployer began as an experiment to remove brittle CI pipelines and GitHub Actions from the deployment process. It evolved into an always-on, Git-native compiler loop. While it is not a conventional CI tool, the focus on reasoning-driven deployments sets it apart: Codex continuously patches and rebuilds services without external runners.
+Codex-Deployer began as an experiment to remove brittle CI pipelines and GitHub Actions from the deployment process. It evolved into an always-on, Git-native compiler loop. While it is not a conventional CI tool, the focus on reasoning-driven deployments sets it apart: Codex continuously patches and rebuilds services without external runners. Today it acts as the codex‑FountainAI maintainer and GPT contributor, coordinating updates across repositories.
 
 ## Next Steps
 

--- a/docs/handbook/introduction.md
+++ b/docs/handbook/introduction.md
@@ -2,7 +2,7 @@
 
 *From overview to environment variables.*
 
-Codex-Deployer is an always-on deployment companion built around a simple idea: every build is feedback for the next.
+Codex-Deployer started as an always-on deployment companion built around a simple idea: every build is feedback for the next. Today it operates as the codex‑FountainAI maintainer and GPT contributor.
 
 Powered by OpenAI's [Codex](https://platform.openai.com/docs/codex/overview), the dispatcher acts like a **semantic compiler** for infrastructure. It reads build logs, proposes fixes and keeps services coherent. See the official Codex overview for more details.
 


### PR DESCRIPTION
## Summary
- clarify the current role of Codex-Deployer as the codex‑FountainAI maintainer and GPT contributor
- adjust language in handbook docs to keep historical context while reflecting the new focus

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687cb02e04948325a1756f6849094f9c