### PR TITLE
Add Teatro playground demos

### DIFF
--- a/repos/TeatroPlayground/README.md
+++ b/repos/TeatroPlayground/README.md
@@ -13,6 +13,13 @@ swift run TeatroPlayground
 
 For live previews, open `ContentView.swift` in Xcode and use the SwiftUI preview canvas.
 
+## Interactive Experiments
+
+The main window now lists several demo scenes that highlight Teatro's building blocks.
+Each experiment includes a short description and invites you to explore how views
+compose and render. Choose an entry from the list to see the underlying Teatro
+view in action.
+
 
 ````text
 ©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/ContentView.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/ContentView.swift
@@ -1,19 +1,28 @@
 #if canImport(SwiftUI)
 import SwiftUI
+import Teatro
 
-/// Blank container view for FountainAI UX experiments.
+/// Interactive container showcasing Teatro demo experiments.
 public struct ContentView: View {
     public init() {}
 
     public var body: some View {
-        Text("FountainAI UX experiments")
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        NavigationView {
+            List(DemoExperiments.all) { experiment in
+                NavigationLink(destination: TeatroRenderView(content: experiment.view)) {
+                    VStack(alignment: .leading) {
+                        Text(experiment.title).font(.headline)
+                        Text(experiment.description).font(.caption)
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .navigationTitle("Teatro Experiments")
+        }
     }
 }
 
-#if canImport(SwiftUI)
 #Preview {
     ContentView()
 }
-#endif
 #endif

--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/Experiments.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/Experiments.swift
@@ -1,0 +1,49 @@
+#if canImport(SwiftUI)
+import Teatro
+import Foundation
+
+/// A single showcase of a Teatro feature.
+public struct Experiment: Identifiable {
+    public let id = UUID()
+    public let title: String
+    public let description: String
+    public let view: Renderable
+
+    public init(title: String, description: String, @TViewBuilder content: () -> Renderable) {
+        self.title = title
+        self.description = description
+        self.view = content()
+    }
+}
+
+/// Pre-built experiments demonstrating Teatro's capabilities.
+public enum DemoExperiments {
+    public static let all: [Experiment] = [
+        Experiment(
+            title: "Hello Teatro",
+            description: "A warm welcome rendered in bold text.") {
+                Text("Hello, Teatro!", style: .bold)
+        },
+        Experiment(
+            title: "Stack of Quotes",
+            description: "A vertical layout showing basic alignment.") {
+                VStack(alignment: .leading, padding: 2) {
+                    Text("The stage is yours.")
+                    Text("Craft each line with care.", style: .italic)
+                    Text("Applause awaits.")
+                }
+        },
+        Experiment(
+            title: "Scene Sample",
+            description: "A short Fountain screenplay snippet rendered as a stage.") {
+                Stage(title: "Opening") {
+                    FountainSceneView(fountainText: """
+INT. LAB - NIGHT
+SCIENTIST
+    It's alive!
+""")
+                }
+        }
+    ]
+}
+#endif


### PR DESCRIPTION
## Summary
- add initial demo experiments and navigation UI
- document interactive experiments in README

## Testing
- `swift build` in `repos/TeatroPlayground`


------
https://chatgpt.com/codex/tasks/task_e_687d0a54ea648325942b121946da6ae6