### PR TITLE
Add tests for demo experiments

### DIFF
--- a/repos/TeatroPlayground/Package.swift
+++ b/repos/TeatroPlayground/Package.swift
@@ -25,6 +25,11 @@ let package = Package(
                 "TeatroPlaygroundUI"
             ],
             path: "Sources/TeatroPlayground"
+        ),
+        .testTarget(
+            name: "TeatroPlaygroundTests",
+            dependencies: ["TeatroPlaygroundUI"],
+            path: "Tests"
         )
     ]
 )

--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/Experiments.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/Experiments.swift
@@ -1,9 +1,8 @@
-#if canImport(SwiftUI)
 import Teatro
 import Foundation
 
 /// A single showcase of a Teatro feature.
-public struct Experiment: Identifiable, Sendable {
+public struct Experiment: Identifiable {
     public let id = UUID()
     public let title: String
     public let description: String
@@ -46,4 +45,3 @@ SCIENTIST
         }
     ]
 }
-#endif

--- a/repos/TeatroPlayground/Tests/DemoExperimentsTests.swift
+++ b/repos/TeatroPlayground/Tests/DemoExperimentsTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import TeatroPlaygroundUI
+
+final class DemoExperimentsTests: XCTestCase {
+    @MainActor
+    func testDemoExperimentRendersNonEmpty() async throws {
+        for experiment in DemoExperiments.all {
+            let output = experiment.view.render()
+            XCTAssertFalse(output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, "\(experiment.title) rendered empty output")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enable building `DemoExperiments` on Linux
- add tests verifying demo experiments render text
- declare the new test target in Package.swift

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_687d0f8388248325abc00dbe698bba58