### PR TITLE
Add Renderer Showcase demo

### DIFF
--- a/repos/TeatroPlayground/README.md
+++ b/repos/TeatroPlayground/README.md
@@ -20,6 +20,9 @@ Each experiment includes a short description and invites you to explore how view
 compose and render. Choose an entry from the list to see the underlying Teatro
 view in action.
 
+The latest "Renderer Showcase" experiment demonstrates how a single view is
+rendered via the Codex, HTML, SVG and PNG backends.
+
 
 ````text
 ©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/Experiments.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/Experiments.swift
@@ -42,6 +42,11 @@ SCIENTIST
     It's alive!
 """)
                 }
+        },
+        Experiment(
+            title: "Renderer Showcase",
+            description: "Outputs the demo view via Codex, HTML, SVG and PNG.") {
+                RendererShowcase()
         }
     ]
 }

--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/RendererShowcase.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/RendererShowcase.swift
@@ -1,0 +1,22 @@
+import Teatro
+
+public struct RendererShowcase: Renderable {
+    public init() {}
+    public func render() -> String {
+        let demo = Stage(title: "Render Showcase") {
+            VStack(alignment: .center, padding: 1) {
+                TeatroIcon("🎭")
+                Text("Playground Demo", style: .bold)
+            }
+        }
+        var result = "-- Codex Preview --\n"
+        result += CodexPreviewer.preview(demo)
+        result += "\n\n-- HTML --\n"
+        result += HTMLRenderer.render(demo)
+        result += "\n\n-- SVG --\n"
+        result += SVGRenderer.render(demo)
+        ImageRenderer.renderToPNG(demo, to: "renderer_demo.png")
+        result += "\n\nPNG output written to renderer_demo.png"
+        return result
+    }
+}


### PR DESCRIPTION
## Summary
- showcase all renderers in TeatroPlayground
- mention the new experiment in the playground README

## Testing
- `swift build` in `Teatro`
- `swift test` in `Teatro` *(fails: no tests found)*
- `swift build` in `TeatroPlayground`
- `swift test` in `TeatroPlayground`

------
https://chatgpt.com/codex/tasks/task_e_687d147446708325a12f8d1d30c0cf0c