### PR TITLE
Add RendererShowcaseView for playground previews

### DIFF
--- a/repos/TeatroPlayground/README.md
+++ b/repos/TeatroPlayground/README.md
@@ -20,8 +20,8 @@ Each experiment includes a short description and invites you to explore how view
 compose and render. Choose an entry from the list to see the underlying Teatro
 view in action.
 
-The latest "Renderer Showcase" experiment demonstrates how a single view is
-rendered via the Codex, HTML, SVG and PNG backends.
+The latest "Renderer Showcase" experiment now presents a dedicated SwiftUI view
+that previews the Codex, HTML, SVG and PNG renderers side by side.
 
 
 ````text

--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/Experiments.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/Experiments.swift
@@ -46,7 +46,7 @@ SCIENTIST
         Experiment(
             title: "Renderer Showcase",
             description: "Outputs the demo view via Codex, HTML, SVG and PNG.") {
-                RendererShowcase()
+                RendererShowcaseView()
         }
     ]
 }

--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/RendererShowcaseView.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/RendererShowcaseView.swift
@@ -1,0 +1,111 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import Teatro
+#if canImport(WebKit)
+import WebKit
+#endif
+
+/// SwiftUI view showcasing multiple renderer outputs.
+public struct RendererShowcaseView: View, Renderable {
+    let demo: Stage
+    public init() {
+        demo = Stage(title: "Render Showcase") {
+            VStack(alignment: .center, padding: 1) {
+                TeatroIcon("🎭")
+                Text("Playground Demo", style: .bold)
+            }
+        }
+    }
+
+    public func render() -> String {
+        RendererShowcase().render()
+    }
+
+    public var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                section(title: "Codex Preview") {
+                    Text(CodexPreviewer.preview(demo))
+                        .font(.system(.body, design: .monospaced))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                section(title: "HTML") {
+                    WebPreview(html: HTMLRenderer.render(demo))
+                        .frame(height: 200)
+                }
+                section(title: "SVG") {
+                    svgImage()
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxHeight: 200)
+                }
+                section(title: "PNG") {
+                    pngImage()
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(maxHeight: 200)
+                }
+            }
+            .padding()
+        }
+    }
+
+    private func section<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title).font(.headline)
+            content()
+        }
+    }
+
+    private func svgImage() -> Image {
+        let svg = SVGRenderer.render(demo)
+        guard let data = svg.data(using: .utf8) else {
+            return Image(systemName: "xmark.octagon")
+        }
+#if os(macOS)
+        if let img = NSImage(data: data) { return Image(nsImage: img) }
+#elseif canImport(UIKit)
+        if let img = UIImage(data: data) { return Image(uiImage: img) }
+#endif
+        return Image(systemName: "xmark.octagon")
+    }
+
+    private func pngImage() -> Image {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("renderer_demo.png")
+        ImageRenderer.renderToPNG(demo, to: url.path)
+#if os(macOS)
+        if let img = NSImage(contentsOf: url) { return Image(nsImage: img) }
+#elseif canImport(UIKit)
+        if let img = UIImage(contentsOfFile: url.path) { return Image(uiImage: img) }
+#endif
+        return Image(systemName: "xmark.octagon")
+    }
+}
+
+#if canImport(WebKit)
+private struct WebPreview: NSViewRepresentable {
+    let html: String
+    func makeNSView(context: Context) -> WKWebView { WKWebView() }
+    func updateNSView(_ nsView: WKWebView, context: Context) {
+        nsView.loadHTMLString(html, baseURL: nil)
+    }
+}
+#else
+private struct WebPreview: View {
+    let html: String
+    var body: some View {
+        Text(html).font(.system(.body, design: .monospaced))
+    }
+}
+#endif
+#endif
+
+#if !canImport(SwiftUI)
+import Teatro
+public struct RendererShowcaseView: Renderable {
+    public init() {}
+    public func render() -> String {
+        RendererShowcase().render()
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add `RendererShowcaseView` for side-by-side renderer previews
- switch the "Renderer Showcase" experiment to the new view
- mention dedicated preview view in `TeatroPlayground` README

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_687d1c04e6e88325ba9493afea6bd592