### PR TITLE
Add basic renderable test target

### DIFF
--- a/repos/teatro/Package.swift
+++ b/repos/teatro/Package.swift
@@ -21,6 +21,11 @@ let package = Package(
             name: "RenderCLI",
             dependencies: ["Teatro"],
             path: "Sources/CLI"
+        ),
+        .testTarget(
+            name: "TeatroTests",
+            dependencies: ["Teatro"],
+            path: "Tests"
         )
     ]
 )

--- a/repos/teatro/Tests/BasicRenderableTests.swift
+++ b/repos/teatro/Tests/BasicRenderableTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import Teatro
+
+final class BasicRenderableTests: XCTestCase {
+    func testSimpleRenderablesProduceOutput() {
+        let text = Text("Hello")
+        XCTAssertFalse(text.render().isEmpty)
+
+        let stack = VStack {
+            Text("A")
+            Text("B")
+        }
+        XCTAssertFalse(stack.render().isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- add a test target in Teatro `Package.swift`
- check that `Text` and `VStack` renderers emit non-empty output

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_687d1db780c4832595aa38a89091ecb8