### PR TITLE
Fix SwiftUI ViewBuilder ambiguity

### DIFF
--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/RendererShowcaseView.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/RendererShowcaseView.swift
@@ -17,7 +17,7 @@ public struct RendererShowcaseView: View, Renderable {
         }
     }
 
-    public func render() -> String {
+    public nonisolated func render() -> String {
         RendererShowcase().render()
     }
 
@@ -50,7 +50,7 @@ public struct RendererShowcaseView: View, Renderable {
         }
     }
 
-    private func section<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+    private func section<Content: View>(title: String, @SViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             Text(title).font(.headline)
             content()


### PR DESCRIPTION
## Summary
- make `render()` nonisolated to satisfy `Renderable`
- use `@SViewBuilder` to avoid clashes with Teatro's `ViewBuilder`

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_687d1fdae7408325834d659d710641fe