### PR TITLE
Switch playground preview to portrait layout

### DIFF
--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/ContentView.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/ContentView.swift
@@ -22,7 +22,15 @@ public struct ContentView: View {
     }
 }
 
-#Preview {
-    ContentView()
+#Preview(traits: .fixedLayout(width: 420, height: 640)) {
+    ZStack {
+        Color(NSColor.windowBackgroundColor)
+        ContentView()
+            .padding()
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .shadow(radius: 4)
+            .padding()
+    }
 }
 #endif


### PR DESCRIPTION
## Summary
- make TeatroPlayground's Xcode preview use a portrait layout
- style the preview so the content looks like a sheet of paper on a desktop

## Testing
- `swift build >/tmp/build.log`
- `swift test >/tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_687d32e5415c8325ab87ef385707ebbd