### PR TITLE
Add Markdown renderer for Teatro

### DIFF
--- a/repos/teatro/Docs/CLIIntegration/README.md
+++ b/repos/teatro/Docs/CLIIntegration/README.md
@@ -8,7 +8,7 @@ The Teatro View Engine includes a lightweight command-line interface (CLI) imple
 
 ```swift
 public enum RenderTarget: String {
-    case html, svg, png, codex
+    case html, svg, png, markdown, codex
 }
 ```
 
@@ -33,6 +33,8 @@ public struct RenderCLI {
             print(SVGRenderer.render(view))
         case .png:
             ImageRenderer.renderToPNG(view)
+        case .markdown:
+            print(MarkdownRenderer.render(view))
         case .codex:
             print(CodexPreviewer.preview(view))
         }
@@ -48,6 +50,7 @@ public struct RenderCLI {
 swift run RenderCLI html
 swift run RenderCLI svg
 swift run RenderCLI png
+swift run RenderCLI markdown
 swift run RenderCLI codex
 ```
 

--- a/repos/teatro/Docs/RenderingBackends/README.md
+++ b/repos/teatro/Docs/RenderingBackends/README.md
@@ -94,6 +94,21 @@ public struct CodexPreviewer {
     }
 }
 ```
+
+---
+
+### 3.5 MarkdownRenderer
+
+Renders view output inside a fenced Markdown code block. Useful when embedding
+rendered scenes in documentation or CLI tools.
+
+```swift
+public struct MarkdownRenderer {
+    public static func render(_ view: Renderable) -> String {
+        "```\n" + view.render() + "\n```"
+    }
+}
+```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```

--- a/repos/teatro/Docs/Summary/README.md
+++ b/repos/teatro/Docs/Summary/README.md
@@ -8,7 +8,7 @@ The **Teatro View Engine** is a modular, fully declarative view system written i
   Composable `Renderable` types (`Text`, `VStack`, `Stage`, etc.) support layout, alignment, styling, and introspection.
 
 - **Rendering Backends**  
-  Multiple output targets including HTML, SVG, PNG (via Cairo), and Codex introspection.
+  Multiple output targets including HTML, SVG, Markdown, PNG (via Cairo), and Codex introspection.
 
 - **CLI Integration**  
   A command-line entry point allows rendering from terminal or scriptable pipelines.

--- a/repos/teatro/Docs/ViewImplementationPlan/README.md
+++ b/repos/teatro/Docs/ViewImplementationPlan/README.md
@@ -35,7 +35,7 @@ Additional renderable components appear in other documentation sections:
 ### 10.4 Renderers and CLI
 Although not strictly views, renderers are important for integration testing:
 
-- Implement `HTMLRenderer`, `SVGRenderer`, `ImageRenderer`, and `CodexPreviewer` under `Sources/Renderers` exactly as shown in the docs.
+- Implement `HTMLRenderer`, `SVGRenderer`, `ImageRenderer`, `MarkdownRenderer`, and `CodexPreviewer` under `Sources/Renderers` exactly as shown in the docs.
 - Implement `RenderCLI` in `Sources/CLI` to wire up the renderers. Use `swift run` in tests to ensure the binary can be invoked with different targets.
 
 ### 10.5 Animation System

--- a/repos/teatro/Sources/CLI/RenderCLI.swift
+++ b/repos/teatro/Sources/CLI/RenderCLI.swift
@@ -1,6 +1,6 @@
 import Teatro
 public enum RenderTarget: String {
-    case html, svg, png, codex
+    case html, svg, png, markdown, codex
 }
 
 public struct RenderCLI {
@@ -21,6 +21,8 @@ public struct RenderCLI {
             print(SVGRenderer.render(view))
         case .png:
             ImageRenderer.renderToPNG(view)
+        case .markdown:
+            print(MarkdownRenderer.render(view))
         case .codex:
             print(CodexPreviewer.preview(view))
         }

--- a/repos/teatro/Sources/Renderers/MarkdownRenderer.swift
+++ b/repos/teatro/Sources/Renderers/MarkdownRenderer.swift
@@ -1,0 +1,5 @@
+public struct MarkdownRenderer {
+    public static func render(_ view: Renderable) -> String {
+        "```\n" + view.render() + "\n```"
+    }
+}

--- a/repos/teatro/Tests/RendererTests.swift
+++ b/repos/teatro/Tests/RendererTests.swift
@@ -14,4 +14,11 @@ final class RendererTests: XCTestCase {
         XCTAssertTrue(svg.contains("<svg"))
         XCTAssertTrue(svg.contains("Hi"))
     }
+
+    func testMarkdownRenderer() {
+        let text = Text("Hi")
+        let md = MarkdownRenderer.render(text)
+        XCTAssertTrue(md.contains("```"))
+        XCTAssertTrue(md.contains("Hi"))
+    }
 }


### PR DESCRIPTION
## Summary
- add `MarkdownRenderer` implementation
- support Markdown output via `RenderCLI`
- document Markdown renderer in CLI guide and rendering backends
- mention markdown in summary and implementation plan docs
- test Markdown renderer

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_687da24b31548325a3ace95363818237