### PR TITLE
Add TeatroView project skeleton

### DIFF
--- a/docs/teatro_view_plan.md
+++ b/docs/teatro_view_plan.md
@@ -1,0 +1,22 @@
+# TeatroView Feature Project
+
+TeatroView provides a graphical interface for Typesense using the Teatro view engine. It consumes the comprehensive OpenAPI specification shipped under `repos/typesense-codex/openapi/openapi.yml`.
+
+## Objectives
+
+- Generate a Swift client from the OpenAPI file to access collections and search APIs.
+- Expose Teatro-based views for browsing collections, searching documents, and editing schemas.
+- Bootstrap default schemas by reusing `repos/typesense-codex/scripts/bootstrap_typesense.py`.
+- Package the app as an open-source project under `repos/TeatroView` so contributors can build and run it on macOS.
+
+## Roadmap
+
+1. **Client Generation** – automate Swift client generation from the OpenAPI spec.
+2. **Data Layer** – read `TYPESENSE_URL` and `TYPESENSE_API_KEY` to configure API calls.
+3. **Teatro Views** – implement collection browser, search UI, and schema editor.
+4. **SwiftUI Shell** – embed Teatro scenes in a minimal SwiftUI app.
+5. **Documentation** – keep `README.md` and this plan updated as features land.
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````

--- a/repos/TeatroView/Package.swift
+++ b/repos/TeatroView/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "TeatroView",
+    platforms: [.macOS(.v14)],
+    products: [
+        .executable(name: "TeatroView", targets: ["TeatroView"])
+    ],
+    dependencies: [
+        .package(path: "../teatro")
+    ],
+    targets: [
+        .executableTarget(
+            name: "TeatroView",
+            dependencies: [
+                .product(name: "Teatro", package: "teatro")
+            ],
+            path: "Sources/TeatroView"
+        ),
+        .testTarget(
+            name: "TeatroViewTests",
+            dependencies: ["TeatroView"],
+            path: "Tests"
+        )
+    ]
+)

--- a/repos/TeatroView/README.md
+++ b/repos/TeatroView/README.md
@@ -1,0 +1,28 @@
+# TeatroView – Typesense GUI
+
+TeatroView is an experimental GUI for [Typesense](https://typesense.org) built with the [Teatro](../teatro) view engine. It demonstrates how Teatro renders SwiftUI scenes while providing a simple interface to manage and search a Typesense instance.
+
+## Build and Run
+
+Make sure the following environment variables are set so the app can reach your server:
+
+| Variable | Purpose |
+|----------|---------|
+| `TYPESENSE_URL` | Base URL for a running Typesense instance |
+| `TYPESENSE_API_KEY` | API key used for requests |
+
+```
+export TYPESENSE_URL=http://localhost:8108
+export TYPESENSE_API_KEY=xyz
+swift run TeatroView
+```
+
+The app builds with Swift Package Manager. Open the package in Xcode for SwiftUI previews or run from the command line as shown above.
+
+## Contributing
+
+This project lives in the `TeatroView` directory of the `codex-deployer` monorepo. Issues and pull requests are welcome. Please keep the README updated if you change build steps or environment variables. Refer to `docs/environment_variables.md` for the full list of variables used across the project.
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````

--- a/repos/TeatroView/Sources/TeatroView/main.swift
+++ b/repos/TeatroView/Sources/TeatroView/main.swift
@@ -1,0 +1,20 @@
+import Teatro
+#if canImport(SwiftUI)
+import SwiftUI
+
+@main
+struct TeatroViewApp: App {
+    var body: some Scene {
+        WindowGroup {
+            Text("TeatroView Placeholder")
+        }
+    }
+}
+#else
+@main
+struct TeatroViewCLI {
+    static func main() {
+        print("TeatroView requires SwiftUI and macOS to run.")
+    }
+}
+#endif

--- a/repos/TeatroView/Tests/TeatroViewTests.swift
+++ b/repos/TeatroView/Tests/TeatroViewTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import TeatroView
+
+final class TeatroViewTests: XCTestCase {
+    func testExample() throws {
+        XCTAssertTrue(true)
+    }
+}


### PR DESCRIPTION
## Summary
- start new `TeatroView` package for a Typesense GUI using Teatro
- document build instructions and required env vars
- outline the feature roadmap for the new GUI

## Testing
- `swift build` and `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_687d9e7be1d483258d97123a07f3411d