### PR TITLE
Add Mac file sharing helper

### DIFF
--- a/deploy/mac_file_sharing.py
+++ b/deploy/mac_file_sharing.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Ensure the repository directory is shared with Docker Desktop on macOS."""
+import json
+import os
+import sys
+from pathlib import Path
+
+SETTINGS_PATH = Path.home() / 'Library/Group Containers/group.com.docker/settings.json'
+
+def add_share(path: Path) -> bool:
+    if not SETTINGS_PATH.exists():
+        print('Docker Desktop settings not found. Are you on macOS with Docker Desktop installed?')
+        return False
+    try:
+        data = json.loads(SETTINGS_PATH.read_text())
+    except json.JSONDecodeError as exc:
+        print(f'Failed to parse {SETTINGS_PATH}: {exc}')
+        return False
+
+    dirs = data.get('filesharingDirectories', [])
+    path_str = str(path.resolve())
+    if path_str in dirs:
+        print(f'{path_str} already in file sharing list.')
+        return True
+    dirs.append(path_str)
+    data['filesharingDirectories'] = dirs
+    SETTINGS_PATH.write_text(json.dumps(data, indent=2))
+    print(f'Added {path_str} to file sharing list.')
+    return True
+
+def main() -> int:
+    if sys.platform != 'darwin':
+        print('This script only runs on macOS.')
+        return 1
+    target = Path(sys.argv[1]) if len(sys.argv) > 1 else Path.cwd()
+    if add_share(target):
+        print('Please restart Docker Desktop for changes to take effect.')
+        return 0
+    return 1
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/docs/mac_docker_tutorial.md
+++ b/docs/mac_docker_tutorial.md
@@ -78,6 +78,7 @@ For a more detailed workflow including local integration tests, see [mac_local_t
 - Map additional volumes if you want the cloned service repositories (like `fountainai`) to persist outside the container.
 - Edit files on your host; the container sees changes immediately because the project directory is mounted.
 - On macOS ensure the repository directory is listed under Docker Desktop > Settings > Resources > File Sharing, otherwise integration tests fail with "mounts denied" errors.
+- Run `python3 deploy/mac_file_sharing.py` to automatically add the repository directory to Docker Desktop's file sharing list. Restart Docker Desktop after running the script.
 
 ## 6. Cross-platform compilation
 
@@ -105,3 +106,7 @@ when necessary.
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```
+
+````text
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````


### PR DESCRIPTION
## Summary
- add `mac_file_sharing.py` helper to modify Docker Desktop settings
- document helper in the macOS Docker tutorial

## Testing
- `python3 -m py_compile deploy/mac_file_sharing.py`

------
https://chatgpt.com/codex/tasks/task_e_687dab4ed5708325be509102b7df8dd1