### PR TITLE
Update README instructions for TeatroView and Playground

### DIFF
--- a/repos/TeatroPlayground/README.md
+++ b/repos/TeatroPlayground/README.md
@@ -11,6 +11,12 @@ swift build
 swift run TeatroPlayground
 ```
 
+This project also relies on the [Teatro](../teatro) package being available at `../teatro`. If the folder is missing, clone the repository before building:
+
+```bash
+git clone https://github.com/fountain-coach/teatro ../teatro
+```
+
 For live previews, open `ContentView.swift` in Xcode and use the SwiftUI preview canvas.
 
 ## Interactive Experiments

--- a/repos/TeatroView/README.md
+++ b/repos/TeatroView/README.md
@@ -19,6 +19,16 @@ swift run TeatroView
 
 The app builds with Swift Package Manager. Open the package in Xcode for SwiftUI previews or run from the command line as shown above.
 
+### Dependency Layout
+
+`Package.swift` expects the [Teatro](../teatro) package to be present one directory up at `../teatro`. If you cloned this project by itself, clone the Teatro repository next to `TeatroView`:
+
+```bash
+git clone https://github.com/fountain-coach/teatro ../teatro
+```
+
+Keeping this path intact ensures Swift Package Manager can resolve the `Teatro` product.
+
 ## Contributing
 
 This project lives in the `TeatroView` directory of the `codex-deployer` monorepo. Issues and pull requests are welcome. Please keep the README updated if you change build steps or environment variables. Refer to `docs/environment_variables.md` for the full list of variables used across the project.


### PR DESCRIPTION
## Summary
- document that TeatroView and TeatroPlayground expect the Teatro repo at `../teatro`
- show how to clone Teatro if missing

## Testing
- `swift test` in `repos/TeatroView`
- `swift test` in `repos/TeatroPlayground`


------
https://chatgpt.com/codex/tasks/task_e_687db21c762c8325ad433de7ab9250bd