### PR TITLE
Resolve @main conflict in TeatroView

### DIFF
--- a/repos/TeatroView/Sources/TeatroView/main.swift
+++ b/repos/TeatroView/Sources/TeatroView/main.swift
@@ -1,7 +1,10 @@
 import Teatro
 #if canImport(SwiftUI)
 import SwiftUI
+#endif
 
+/// Entry point for the TeatroView package.
+#if canImport(SwiftUI)
 @main
 struct TeatroViewApp: App {
     var body: some Scene {
@@ -12,7 +15,7 @@ struct TeatroViewApp: App {
 }
 #else
 @main
-struct TeatroViewCLI {
+struct TeatroViewApp {
     static func main() {
         print("TeatroView requires SwiftUI and macOS to run.")
     }


### PR DESCRIPTION
## Summary
- adjust TeatroView's `main.swift` so that only one `@main` entry is compiled
- handle SwiftUI and CLI variants via conditional compilation

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_687db9e390e88325a252772583b170ad