### PR TITLE
Generate Typesense client using FountainAI generator

### DIFF
--- a/repos/TeatroView/Package.swift
+++ b/repos/TeatroView/Package.swift
@@ -5,7 +5,8 @@ let package = Package(
     name: "TeatroView",
     platforms: [.macOS(.v14)],
     products: [
-        .executable(name: "TeatroView", targets: ["TeatroView"])
+        .executable(name: "TeatroView", targets: ["TeatroView"]),
+        .library(name: "TypesenseClient", targets: ["TypesenseClient"])
     ],
     dependencies: [
         .package(url: "https://github.com/fountain-coach/teatro.git", branch: "main")
@@ -17,6 +18,10 @@ let package = Package(
                 .product(name: "Teatro", package: "teatro")
             ],
             path: "Sources/TeatroView"
+        ),
+        .target(
+            name: "TypesenseClient",
+            path: "Sources/TypesenseClient"
         ),
         .testTarget(
             name: "TeatroViewTests",

--- a/repos/TeatroView/README.md
+++ b/repos/TeatroView/README.md
@@ -23,6 +23,16 @@ The app builds with Swift Package Manager. Open the package in Xcode for SwiftUI
 
 `Package.swift` pulls in the [Teatro](https://github.com/fountain-coach/teatro) dependency via its Git URL. Swift Package Manager will fetch it automatically when building the package.
 
+### Generating the Typesense Client
+
+The Typesense API client used by TeatroView is generated from the OpenAPI spec vendored in the monorepo. Run the script below whenever `repos/typesense-codex/openapi/openapi.yml` changes:
+
+```bash
+scripts/generate_typesense_client.sh
+```
+
+This script builds the custom Swift 6 generator from `repos/fountainai` and emits the sources under `Sources/TypesenseClient`.
+
 ## Contributing
 
 This project lives in the `TeatroView` directory of the `codex-deployer` monorepo. Issues and pull requests are welcome. Please keep the README updated if you change build steps or environment variables. Refer to `docs/environment_variables.md` for the full list of variables used across the project.

--- a/repos/TeatroView/Sources/TypesenseClient/APIClient.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/APIClient.swift
@@ -1,0 +1,46 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public protocol HTTPSession {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: HTTPSession {
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.data(for: request, delegate: nil)
+    }
+}
+
+public struct APIClient {
+    let baseURL: URL
+    let session: HTTPSession
+    let defaultHeaders: [String: String]
+
+    public init(baseURL: URL, session: HTTPSession = URLSession.shared, defaultHeaders: [String: String] = [:]) {
+        self.baseURL = baseURL
+        self.session = session
+        self.defaultHeaders = defaultHeaders
+    }
+
+    public func send<R: APIRequest>(_ request: R) async throws -> R.Response {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        for (header, value) in defaultHeaders {
+            urlRequest.setValue(value, forHTTPHeaderField: header)
+        }
+        if let body = request.body {
+            urlRequest.httpBody = try JSONEncoder().encode(body)
+            urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        let (data, _) = try await session.data(for: urlRequest)
+        return try JSONDecoder().decode(R.Response.self, from: data)
+    }
+}
+
+public extension APIClient {
+    init(baseURL: URL, bearerToken: String, session: HTTPSession = URLSession.shared) {
+        self.init(baseURL: baseURL, session: session, defaultHeaders: ["Authorization": "Bearer \(bearerToken)"])
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/APIRequest.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/APIRequest.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Empty body type used for requests without a payload.
+public struct NoBody: Codable {}
+
+public protocol APIRequest {
+    associatedtype Body: Encodable = NoBody
+    associatedtype Response: Decodable
+    var method: String { get }
+    var path: String { get }
+    var body: Body? { get }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Models.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Models.swift
@@ -1,0 +1,524 @@
+// Models for Typesense API
+
+public struct APIStatsResponse: Codable {
+    public let delete_latency_ms: String
+    public let delete_requests_per_second: String
+    public let import_latency_ms: String
+    public let import_requests_per_second: String
+    public let latency_ms: String
+    public let overloaded_requests_per_second: String
+    public let pending_write_batches: String
+    public let requests_per_second: String
+    public let search_latency_ms: String
+    public let search_requests_per_second: String
+    public let total_requests_per_second: String
+    public let write_latency_ms: String
+    public let write_requests_per_second: String
+}
+
+public struct AnalyticsEventCreateResponse: Codable {
+    public let ok: Bool
+}
+
+public struct AnalyticsEventCreateSchema: Codable {
+    public let data: String
+    public let name: String
+    public let type: String
+}
+
+public struct AnalyticsRuleDeleteResponse: Codable {
+    public let name: String
+}
+
+public struct AnalyticsRuleParameters: Codable {
+    public let destination: AnalyticsRuleParametersDestination
+    public let expand_query: Bool
+    public let limit: Int
+    public let source: AnalyticsRuleParametersSource
+}
+
+public struct AnalyticsRuleParametersDestination: Codable {
+    public let collection: String
+    public let counter_field: String
+}
+
+public struct AnalyticsRuleParametersSource: Codable {
+    public let collections: [String]
+    public let events: [String]
+}
+
+public struct AnalyticsRuleUpsertSchema: Codable {
+    public let params: AnalyticsRuleParameters
+    public let type: String
+}
+
+public struct AnalyticsRulesRetrieveSchema: Codable {
+    public let rules: [AnalyticsRuleSchema]
+}
+
+public struct ApiKeyDeleteResponse: Codable {
+    public let id: Int
+}
+
+public struct ApiKeySchema: Codable {
+    public let actions: [String]
+    public let collections: [String]
+    public let description: String
+    public let expires_at: Int
+    public let value: String
+}
+
+public struct ApiKeysResponse: Codable {
+    public let keys: [ApiKey]
+}
+
+public struct ApiResponse: Codable {
+    public let message: String
+}
+
+public struct CollectionAlias: Codable {
+    public let collection_name: String
+    public let name: String
+}
+
+public struct CollectionAliasSchema: Codable {
+    public let collection_name: String
+}
+
+public struct CollectionAliasesResponse: Codable {
+    public let aliases: [CollectionAlias]
+}
+
+public struct CollectionSchema: Codable {
+    public let default_sorting_field: String
+    public let enable_nested_fields: Bool
+    public let fields: [Field]
+    public let name: String
+    public let symbols_to_index: [String]
+    public let token_separators: [String]
+    public let voice_query_model: VoiceQueryModelCollectionConfig
+}
+
+public struct CollectionUpdateSchema: Codable {
+    public let fields: [Field]
+}
+
+public struct ConversationModelUpdateSchema: Codable {
+    public let account_id: String
+    public let api_key: String
+    public let history_collection: String
+    public let id: String
+    public let max_bytes: Int
+    public let model_name: String
+    public let system_prompt: String
+    public let ttl: Int
+    public let vllm_url: String
+}
+
+public enum DirtyValues: String, Codable {
+    case coerce_or_reject
+    case coerce_or_drop
+    case drop
+    case reject
+}
+
+public enum DropTokensMode: String, Codable {
+    case right_to_left
+    case left_to_right
+    case both_sides:3
+}
+
+public struct FacetCounts: Codable {
+    public let counts: [String]
+    public let field_name: String
+    public let stats: String
+}
+
+public struct Field: Codable {
+    public let drop: Bool
+    public let embed: String
+    public let facet: Bool
+    public let index: Bool
+    public let infix: Bool
+    public let locale: String
+    public let name: String
+    public let num_dim: Int
+    public let optional: Bool
+    public let range_index: Bool
+    public let reference: String
+    public let sort: Bool
+    public let stem: Bool
+    public let stem_dictionary: String
+    public let store: Bool
+    public let symbols_to_index: [String]
+    public let token_separators: [String]
+    public let type: String
+    public let vec_dist: String
+}
+
+public struct HealthStatus: Codable {
+    public let ok: Bool
+}
+
+public enum IndexAction: String, Codable {
+    case create
+    case update
+    case upsert
+    case emplace
+}
+
+public struct MultiSearchParameters: Codable {
+    public let cache_ttl: Int
+    public let conversation: Bool
+    public let conversation_id: String
+    public let conversation_model_id: String
+    public let drop_tokens_mode: DropTokensMode
+    public let drop_tokens_threshold: Int
+    public let enable_overrides: Bool
+    public let enable_synonyms: Bool
+    public let enable_typos_for_alpha_numerical_tokens: Bool
+    public let enable_typos_for_numerical_tokens: Bool
+    public let exclude_fields: String
+    public let exhaustive_search: Bool
+    public let facet_by: String
+    public let facet_query: String
+    public let facet_return_parent: String
+    public let facet_strategy: String
+    public let filter_by: String
+    public let filter_curated_hits: Bool
+    public let group_by: String
+    public let group_limit: Int
+    public let group_missing_values: Bool
+    public let hidden_hits: String
+    public let highlight_affix_num_tokens: Int
+    public let highlight_end_tag: String
+    public let highlight_fields: String
+    public let highlight_full_fields: String
+    public let highlight_start_tag: String
+    public let include_fields: String
+    public let infix: String
+    public let limit: Int
+    public let max_extra_prefix: Int
+    public let max_extra_suffix: Int
+    public let max_facet_values: Int
+    public let min_len_1typo: Int
+    public let min_len_2typo: Int
+    public let num_typos: String
+    public let offset: Int
+    public let override_tags: String
+    public let page: Int
+    public let per_page: Int
+    public let pinned_hits: String
+    public let pre_segmented_query: Bool
+    public let prefix: String
+    public let preset: String
+    public let prioritize_exact_match: Bool
+    public let prioritize_num_matching_fields: Bool
+    public let prioritize_token_position: Bool
+    public let q: String
+    public let query_by: String
+    public let query_by_weights: String
+    public let remote_embedding_num_tries: Int
+    public let remote_embedding_timeout_ms: Int
+    public let search_cutoff_ms: Int
+    public let snippet_threshold: Int
+    public let sort_by: String
+    public let stopwords: String
+    public let synonym_num_typos: Int
+    public let synonym_prefix: Bool
+    public let text_match_type: String
+    public let typo_tokens_threshold: Int
+    public let use_cache: Bool
+    public let vector_query: String
+    public let voice_query: String
+}
+
+public struct MultiSearchResult: Codable {
+    public let conversation: SearchResultConversation
+    public let results: [MultiSearchResultItem]
+}
+
+public struct MultiSearchSearchesParameter: Codable {
+    public let searches: [MultiSearchCollectionParameters]
+    public let union: Bool
+}
+
+public struct NLSearchModelBase: Codable {
+    public let access_token: String
+    public let account_id: String
+    public let api_key: String
+    public let api_url: String
+    public let api_version: String
+    public let client_id: String
+    public let client_secret: String
+    public let max_bytes: Int
+    public let max_output_tokens: Int
+    public let model_name: String
+    public let project_id: String
+    public let refresh_token: String
+    public let region: String
+    public let stop_sequences: [String]
+    public let system_prompt: String
+    public let temperature: String
+    public let top_k: Int
+    public let top_p: String
+}
+
+public struct NLSearchModelDeleteSchema: Codable {
+    public let id: String
+}
+
+public struct PresetDeleteSchema: Codable {
+    public let name: String
+}
+
+public struct PresetsRetrieveSchema: Codable {
+    public let presets: [PresetSchema]
+}
+
+public struct SchemaChangeStatus: Codable {
+    public let altered_docs: Int
+    public let collection: String
+    public let validated_docs: Int
+}
+
+public struct SearchGroupedHit: Codable {
+    public let found: Int
+    public let group_key: [String]
+    public let hits: [SearchResultHit]
+}
+
+public struct SearchHighlight: Codable {
+    public let field: String
+    public let indices: [Int]
+    public let matched_tokens: [String]
+    public let snippet: String
+    public let snippets: [String]
+    public let value: String
+    public let values: [String]
+}
+
+public struct SearchOverrideDeleteResponse: Codable {
+    public let id: String
+}
+
+public struct SearchOverrideExclude: Codable {
+    public let id: String
+}
+
+public struct SearchOverrideInclude: Codable {
+    public let id: String
+    public let position: Int
+}
+
+public struct SearchOverrideRule: Codable {
+    public let filter_by: String
+    public let match: String
+    public let query: String
+    public let tags: [String]
+}
+
+public struct SearchOverrideSchema: Codable {
+    public let effective_from_ts: Int
+    public let effective_to_ts: Int
+    public let excludes: [SearchOverrideExclude]
+    public let filter_by: String
+    public let filter_curated_hits: Bool
+    public let includes: [SearchOverrideInclude]
+    public let metadata: String
+    public let remove_matched_tokens: Bool
+    public let replace_query: String
+    public let rule: SearchOverrideRule
+    public let sort_by: String
+    public let stop_processing: Bool
+}
+
+public struct SearchOverridesResponse: Codable {
+    public let overrides: [SearchOverride]
+}
+
+public struct SearchParameters: Codable {
+    public let cache_ttl: Int
+    public let conversation: Bool
+    public let conversation_id: String
+    public let conversation_model_id: String
+    public let drop_tokens_mode: DropTokensMode
+    public let drop_tokens_threshold: Int
+    public let enable_highlight_v1: Bool
+    public let enable_overrides: Bool
+    public let enable_synonyms: Bool
+    public let enable_typos_for_alpha_numerical_tokens: Bool
+    public let enable_typos_for_numerical_tokens: Bool
+    public let exclude_fields: String
+    public let exhaustive_search: Bool
+    public let facet_by: String
+    public let facet_query: String
+    public let facet_return_parent: String
+    public let facet_strategy: String
+    public let filter_by: String
+    public let filter_curated_hits: Bool
+    public let group_by: String
+    public let group_limit: Int
+    public let group_missing_values: Bool
+    public let hidden_hits: String
+    public let highlight_affix_num_tokens: Int
+    public let highlight_end_tag: String
+    public let highlight_fields: String
+    public let highlight_full_fields: String
+    public let highlight_start_tag: String
+    public let include_fields: String
+    public let infix: String
+    public let limit: Int
+    public let max_candidates: Int
+    public let max_extra_prefix: Int
+    public let max_extra_suffix: Int
+    public let max_facet_values: Int
+    public let max_filter_by_candidates: Int
+    public let min_len_1typo: Int
+    public let min_len_2typo: Int
+    public let nl_model_id: String
+    public let nl_query: Bool
+    public let num_typos: String
+    public let offset: Int
+    public let override_tags: String
+    public let page: Int
+    public let per_page: Int
+    public let pinned_hits: String
+    public let pre_segmented_query: Bool
+    public let prefix: String
+    public let preset: String
+    public let prioritize_exact_match: Bool
+    public let prioritize_num_matching_fields: Bool
+    public let prioritize_token_position: Bool
+    public let q: String
+    public let query_by: String
+    public let query_by_weights: String
+    public let remote_embedding_num_tries: Int
+    public let remote_embedding_timeout_ms: Int
+    public let search_cutoff_ms: Int
+    public let snippet_threshold: Int
+    public let sort_by: String
+    public let split_join_tokens: String
+    public let stopwords: String
+    public let synonym_num_typos: Int
+    public let synonym_prefix: Bool
+    public let text_match_type: String
+    public let typo_tokens_threshold: Int
+    public let use_cache: Bool
+    public let vector_query: String
+    public let voice_query: String
+}
+
+public struct SearchResult: Codable {
+    public let conversation: SearchResultConversation
+    public let facet_counts: [FacetCounts]
+    public let found: Int
+    public let found_docs: Int
+    public let grouped_hits: [SearchGroupedHit]
+    public let hits: [SearchResultHit]
+    public let out_of: Int
+    public let page: Int
+    public let request_params: String
+    public let search_cutoff: Bool
+    public let search_time_ms: Int
+}
+
+public struct SearchResultConversation: Codable {
+    public let answer: String
+    public let conversation_history: [String]
+    public let conversation_id: String
+    public let query: String
+}
+
+public struct SearchResultHit: Codable {
+    public let document: String
+    public let geo_distance_meters: String
+    public let highlight: String
+    public let highlights: [SearchHighlight]
+    public let text_match: Int
+    public let text_match_info: String
+    public let vector_distance: String
+}
+
+public struct SearchSynonymDeleteResponse: Codable {
+    public let id: String
+}
+
+public struct SearchSynonymSchema: Codable {
+    public let locale: String
+    public let root: String
+    public let symbols_to_index: [String]
+    public let synonyms: [String]
+}
+
+public struct SearchSynonymsResponse: Codable {
+    public let synonyms: [SearchSynonym]
+}
+
+public struct StemmingDictionary: Codable {
+    public let id: String
+    public let words: [String]
+}
+
+public struct StopwordsSetRetrieveSchema: Codable {
+    public let stopwords: StopwordsSetSchema
+}
+
+public struct StopwordsSetSchema: Codable {
+    public let id: String
+    public let locale: String
+    public let stopwords: [String]
+}
+
+public struct StopwordsSetUpsertSchema: Codable {
+    public let locale: String
+    public let stopwords: [String]
+}
+
+public struct StopwordsSetsRetrieveAllSchema: Codable {
+    public let stopwords: [StopwordsSetSchema]
+}
+
+public struct SuccessStatus: Codable {
+    public let success: Bool
+}
+
+public struct VoiceQueryModelCollectionConfig: Codable {
+    public let model_name: String
+}
+
+public struct deleteStopwordsSetResponse: Codable {
+    public let id: String
+}
+
+public typealias retrieveMetricsResponse = String
+
+public typealias retrieveAllConversationModelsResponse = [ConversationModelSchema]
+
+public typealias CollectionResponse = CollectionSchema
+public typealias getCollectionsResponse = [CollectionResponse]
+
+public typealias indexDocumentRequest = String
+
+public struct deleteDocumentsResponse: Codable {
+    public let num_deleted: Int
+}
+
+public typealias getSchemaChangesResponse = [SchemaChangeStatus]
+
+public typealias retrieveAllNLSearchModelsResponse = [NLSearchModelSchema]
+
+public struct debugResponse: Codable {
+    public let version: String
+}
+
+public typealias getDocumentResponse = String
+
+public typealias deleteDocumentResponse = String
+
+public typealias importStemmingDictionaryRequest = String
+
+public struct listStemmingDictionariesResponse: Codable {
+    public let dictionaries: [String]
+}
+

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/createAnalyticsEvent.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/createAnalyticsEvent.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct createAnalyticsEvent: APIRequest {
+    public typealias Body = AnalyticsEventCreateSchema
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/analytics/events" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/createAnalyticsRule.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/createAnalyticsRule.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct createAnalyticsRule: APIRequest {
+    public typealias Body = AnalyticsRuleSchema
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/analytics/rules" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/createCollection.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/createCollection.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct createCollection: APIRequest {
+    public typealias Body = CollectionSchema
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/collections" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/createConversationModel.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/createConversationModel.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct createConversationModel: APIRequest {
+    public typealias Body = ConversationModelCreateSchema
+    public typealias Response = ConversationModelSchema
+    public var method: String { "POST" }
+    public var path: String { "/conversations/models" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/createKey.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/createKey.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct createKey: APIRequest {
+    public typealias Body = ApiKeySchema
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/keys" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/createNLSearchModel.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/createNLSearchModel.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct createNLSearchModel: APIRequest {
+    public typealias Body = NLSearchModelCreateSchema
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/nl_search_models" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/debug.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/debug.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct debug: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = debugResponse
+    public var method: String { "GET" }
+    public var path: String { "/debug" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteAlias.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteAlias.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct deleteAliasParameters: Codable {
+    public let aliasname: String
+}
+
+public struct deleteAlias: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = CollectionAlias
+    public var method: String { "DELETE" }
+    public var parameters: deleteAliasParameters
+    public var path: String {
+        var path = "/aliases/{aliasName}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{aliasName}", with: String(parameters.aliasname))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: deleteAliasParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteAnalyticsRule.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteAnalyticsRule.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct deleteAnalyticsRuleParameters: Codable {
+    public let rulename: String
+}
+
+public struct deleteAnalyticsRule: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = AnalyticsRuleDeleteResponse
+    public var method: String { "DELETE" }
+    public var parameters: deleteAnalyticsRuleParameters
+    public var path: String {
+        var path = "/analytics/rules/{ruleName}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{ruleName}", with: String(parameters.rulename))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: deleteAnalyticsRuleParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteCollection.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteCollection.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct deleteCollectionParameters: Codable {
+    public let collectionname: String
+}
+
+public struct deleteCollection: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = CollectionResponse
+    public var method: String { "DELETE" }
+    public var parameters: deleteCollectionParameters
+    public var path: String {
+        var path = "/collections/{collectionName}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: deleteCollectionParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteConversationModel.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteConversationModel.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct deleteConversationModelParameters: Codable {
+    public let modelid: String
+}
+
+public struct deleteConversationModel: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = ConversationModelSchema
+    public var method: String { "DELETE" }
+    public var parameters: deleteConversationModelParameters
+    public var path: String {
+        var path = "/conversations/models/{modelId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{modelId}", with: String(parameters.modelid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: deleteConversationModelParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteDocument.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteDocument.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct deleteDocumentParameters: Codable {
+    public let collectionname: String
+    public let documentid: String
+}
+
+public struct deleteDocument: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = deleteDocumentResponse
+    public var method: String { "DELETE" }
+    public var parameters: deleteDocumentParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/documents/{documentId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        path = path.replacingOccurrences(of: "{documentId}", with: String(parameters.documentid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: deleteDocumentParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteDocuments.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteDocuments.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct deleteDocumentsParameters: Codable {
+    public let collectionname: String
+    public var deletedocumentsparameters: String?
+}
+
+public struct deleteDocuments: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = deleteDocumentsResponse
+    public var method: String { "DELETE" }
+    public var parameters: deleteDocumentsParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/documents"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        if let value = parameters.deletedocumentsparameters { query.append("deleteDocumentsParameters=\(value)") }
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: deleteDocumentsParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteKey.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteKey.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct deleteKeyParameters: Codable {
+    public let keyid: Int
+}
+
+public struct deleteKey: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = ApiKeyDeleteResponse
+    public var method: String { "DELETE" }
+    public var parameters: deleteKeyParameters
+    public var path: String {
+        var path = "/keys/{keyId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{keyId}", with: String(parameters.keyid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: deleteKeyParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteNLSearchModel.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteNLSearchModel.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct deleteNLSearchModelParameters: Codable {
+    public let modelid: String
+}
+
+public struct deleteNLSearchModel: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = NLSearchModelDeleteSchema
+    public var method: String { "DELETE" }
+    public var parameters: deleteNLSearchModelParameters
+    public var path: String {
+        var path = "/nl_search_models/{modelId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{modelId}", with: String(parameters.modelid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: deleteNLSearchModelParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deletePreset.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deletePreset.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct deletePresetParameters: Codable {
+    public let presetid: String
+}
+
+public struct deletePreset: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = PresetDeleteSchema
+    public var method: String { "DELETE" }
+    public var parameters: deletePresetParameters
+    public var path: String {
+        var path = "/presets/{presetId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{presetId}", with: String(parameters.presetid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: deletePresetParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteSearchOverride.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteSearchOverride.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct deleteSearchOverrideParameters: Codable {
+    public let collectionname: String
+    public let overrideid: String
+}
+
+public struct deleteSearchOverride: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = SearchOverrideDeleteResponse
+    public var method: String { "DELETE" }
+    public var parameters: deleteSearchOverrideParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/overrides/{overrideId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        path = path.replacingOccurrences(of: "{overrideId}", with: String(parameters.overrideid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: deleteSearchOverrideParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteSearchSynonym.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteSearchSynonym.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct deleteSearchSynonymParameters: Codable {
+    public let collectionname: String
+    public let synonymid: String
+}
+
+public struct deleteSearchSynonym: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = SearchSynonymDeleteResponse
+    public var method: String { "DELETE" }
+    public var parameters: deleteSearchSynonymParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/synonyms/{synonymId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        path = path.replacingOccurrences(of: "{synonymId}", with: String(parameters.synonymid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: deleteSearchSynonymParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteStopwordsSet.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteStopwordsSet.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct deleteStopwordsSetParameters: Codable {
+    public let setid: String
+}
+
+public struct deleteStopwordsSet: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = deleteStopwordsSetResponse
+    public var method: String { "DELETE" }
+    public var parameters: deleteStopwordsSetParameters
+    public var path: String {
+        var path = "/stopwords/{setId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{setId}", with: String(parameters.setid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: deleteStopwordsSetParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/exportDocuments.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/exportDocuments.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct exportDocumentsParameters: Codable {
+    public let collectionname: String
+    public var exportdocumentsparameters: String?
+}
+
+public struct exportDocuments: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = Data
+    public var method: String { "GET" }
+    public var parameters: exportDocumentsParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/documents/export"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        if let value = parameters.exportdocumentsparameters { query.append("exportDocumentsParameters=\(value)") }
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: exportDocumentsParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getAlias.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getAlias.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct getAliasParameters: Codable {
+    public let aliasname: String
+}
+
+public struct getAlias: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = CollectionAlias
+    public var method: String { "GET" }
+    public var parameters: getAliasParameters
+    public var path: String {
+        var path = "/aliases/{aliasName}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{aliasName}", with: String(parameters.aliasname))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: getAliasParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getAliases.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getAliases.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct getAliases: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = CollectionAliasesResponse
+    public var method: String { "GET" }
+    public var path: String { "/aliases" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getCollection.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getCollection.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct getCollectionParameters: Codable {
+    public let collectionname: String
+}
+
+public struct getCollection: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = CollectionResponse
+    public var method: String { "GET" }
+    public var parameters: getCollectionParameters
+    public var path: String {
+        var path = "/collections/{collectionName}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: getCollectionParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getCollections.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getCollections.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct getCollections: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = getCollectionsResponse
+    public var method: String { "GET" }
+    public var path: String { "/collections" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getDocument.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getDocument.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct getDocumentParameters: Codable {
+    public let collectionname: String
+    public let documentid: String
+}
+
+public struct getDocument: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = getDocumentResponse
+    public var method: String { "GET" }
+    public var parameters: getDocumentParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/documents/{documentId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        path = path.replacingOccurrences(of: "{documentId}", with: String(parameters.documentid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: getDocumentParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getKey.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getKey.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct getKeyParameters: Codable {
+    public let keyid: Int
+}
+
+public struct getKey: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = ApiKey
+    public var method: String { "GET" }
+    public var parameters: getKeyParameters
+    public var path: String {
+        var path = "/keys/{keyId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{keyId}", with: String(parameters.keyid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: getKeyParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getKeys.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getKeys.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct getKeys: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = ApiKeysResponse
+    public var method: String { "GET" }
+    public var path: String { "/keys" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getSchemaChanges.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getSchemaChanges.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct getSchemaChanges: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = getSchemaChangesResponse
+    public var method: String { "GET" }
+    public var path: String { "/operations/schema_changes" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getSearchOverride.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getSearchOverride.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct getSearchOverrideParameters: Codable {
+    public let collectionname: String
+    public let overrideid: String
+}
+
+public struct getSearchOverride: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = SearchOverride
+    public var method: String { "GET" }
+    public var parameters: getSearchOverrideParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/overrides/{overrideId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        path = path.replacingOccurrences(of: "{overrideId}", with: String(parameters.overrideid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: getSearchOverrideParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getSearchOverrides.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getSearchOverrides.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct getSearchOverridesParameters: Codable {
+    public let collectionname: String
+}
+
+public struct getSearchOverrides: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = SearchOverridesResponse
+    public var method: String { "GET" }
+    public var parameters: getSearchOverridesParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/overrides"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: getSearchOverridesParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getSearchSynonym.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getSearchSynonym.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct getSearchSynonymParameters: Codable {
+    public let collectionname: String
+    public let synonymid: String
+}
+
+public struct getSearchSynonym: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = SearchSynonym
+    public var method: String { "GET" }
+    public var parameters: getSearchSynonymParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/synonyms/{synonymId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        path = path.replacingOccurrences(of: "{synonymId}", with: String(parameters.synonymid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: getSearchSynonymParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getSearchSynonyms.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getSearchSynonyms.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct getSearchSynonymsParameters: Codable {
+    public let collectionname: String
+}
+
+public struct getSearchSynonyms: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = SearchSynonymsResponse
+    public var method: String { "GET" }
+    public var parameters: getSearchSynonymsParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/synonyms"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: getSearchSynonymsParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getStemmingDictionary.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getStemmingDictionary.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct getStemmingDictionaryParameters: Codable {
+    public let dictionaryid: String
+}
+
+public struct getStemmingDictionary: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = StemmingDictionary
+    public var method: String { "GET" }
+    public var parameters: getStemmingDictionaryParameters
+    public var path: String {
+        var path = "/stemming/dictionaries/{dictionaryId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{dictionaryId}", with: String(parameters.dictionaryid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: getStemmingDictionaryParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/health.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/health.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct health: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = HealthStatus
+    public var method: String { "GET" }
+    public var path: String { "/health" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/importDocuments.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/importDocuments.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct importDocumentsParameters: Codable {
+    public let collectionname: String
+    public var importdocumentsparameters: String?
+}
+
+public struct importDocuments: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var parameters: importDocumentsParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/documents/import"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        if let value = parameters.importdocumentsparameters { query.append("importDocumentsParameters=\(value)") }
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: importDocumentsParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/importStemmingDictionary.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/importStemmingDictionary.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct importStemmingDictionaryParameters: Codable {
+    public let id: String
+}
+
+public struct importStemmingDictionary: APIRequest {
+    public typealias Body = importStemmingDictionaryRequest
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var parameters: importStemmingDictionaryParameters
+    public var path: String {
+        var path = "/stemming/dictionaries/import"
+        var query: [String] = []
+        query.append("id=\(parameters.id)")
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: importStemmingDictionaryParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/indexDocument.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/indexDocument.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public struct indexDocumentParameters: Codable {
+    public let collectionname: String
+    public var action: IndexAction?
+    public var dirtyValues: DirtyValues?
+}
+
+public struct indexDocument: APIRequest {
+    public typealias Body = indexDocumentRequest
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var parameters: indexDocumentParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/documents"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        if let value = parameters.action { query.append("action=\(value)") }
+        if let value = parameters.dirtyValues { query.append("dirty_values=\(value)") }
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: indexDocumentParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/listStemmingDictionaries.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/listStemmingDictionaries.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct listStemmingDictionaries: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = listStemmingDictionariesResponse
+    public var method: String { "GET" }
+    public var path: String { "/stemming/dictionaries" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/multiSearch.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/multiSearch.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct multiSearchParameters: Codable {
+    public let multisearchparameters: MultiSearchParameters
+}
+
+public struct multiSearch: APIRequest {
+    public typealias Body = MultiSearchSearchesParameter
+    public typealias Response = MultiSearchResult
+    public var method: String { "POST" }
+    public var parameters: multiSearchParameters
+    public var path: String {
+        var path = "/multi_search"
+        var query: [String] = []
+        query.append("multiSearchParameters=\(parameters.multisearchparameters)")
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: multiSearchParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveAPIStats.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveAPIStats.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct retrieveAPIStats: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = APIStatsResponse
+    public var method: String { "GET" }
+    public var path: String { "/stats.json" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveAllConversationModels.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveAllConversationModels.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct retrieveAllConversationModels: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = retrieveAllConversationModelsResponse
+    public var method: String { "GET" }
+    public var path: String { "/conversations/models" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveAllNLSearchModels.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveAllNLSearchModels.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct retrieveAllNLSearchModels: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = retrieveAllNLSearchModelsResponse
+    public var method: String { "GET" }
+    public var path: String { "/nl_search_models" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveAllPresets.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveAllPresets.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct retrieveAllPresets: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = PresetsRetrieveSchema
+    public var method: String { "GET" }
+    public var path: String { "/presets" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveAnalyticsRule.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveAnalyticsRule.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct retrieveAnalyticsRuleParameters: Codable {
+    public let rulename: String
+}
+
+public struct retrieveAnalyticsRule: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = AnalyticsRuleSchema
+    public var method: String { "GET" }
+    public var parameters: retrieveAnalyticsRuleParameters
+    public var path: String {
+        var path = "/analytics/rules/{ruleName}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{ruleName}", with: String(parameters.rulename))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: retrieveAnalyticsRuleParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveAnalyticsRules.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveAnalyticsRules.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct retrieveAnalyticsRules: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = AnalyticsRulesRetrieveSchema
+    public var method: String { "GET" }
+    public var path: String { "/analytics/rules" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveConversationModel.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveConversationModel.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct retrieveConversationModelParameters: Codable {
+    public let modelid: String
+}
+
+public struct retrieveConversationModel: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = ConversationModelSchema
+    public var method: String { "GET" }
+    public var parameters: retrieveConversationModelParameters
+    public var path: String {
+        var path = "/conversations/models/{modelId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{modelId}", with: String(parameters.modelid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: retrieveConversationModelParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveMetrics.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveMetrics.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct retrieveMetrics: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = retrieveMetricsResponse
+    public var method: String { "GET" }
+    public var path: String { "/metrics.json" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveNLSearchModel.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveNLSearchModel.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct retrieveNLSearchModelParameters: Codable {
+    public let modelid: String
+}
+
+public struct retrieveNLSearchModel: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = NLSearchModelSchema
+    public var method: String { "GET" }
+    public var parameters: retrieveNLSearchModelParameters
+    public var path: String {
+        var path = "/nl_search_models/{modelId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{modelId}", with: String(parameters.modelid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: retrieveNLSearchModelParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrievePreset.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrievePreset.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct retrievePresetParameters: Codable {
+    public let presetid: String
+}
+
+public struct retrievePreset: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = PresetSchema
+    public var method: String { "GET" }
+    public var parameters: retrievePresetParameters
+    public var path: String {
+        var path = "/presets/{presetId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{presetId}", with: String(parameters.presetid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: retrievePresetParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveStopwordsSet.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveStopwordsSet.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct retrieveStopwordsSetParameters: Codable {
+    public let setid: String
+}
+
+public struct retrieveStopwordsSet: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = StopwordsSetRetrieveSchema
+    public var method: String { "GET" }
+    public var parameters: retrieveStopwordsSetParameters
+    public var path: String {
+        var path = "/stopwords/{setId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{setId}", with: String(parameters.setid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: retrieveStopwordsSetParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveStopwordsSets.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveStopwordsSets.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct retrieveStopwordsSets: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = StopwordsSetsRetrieveAllSchema
+    public var method: String { "GET" }
+    public var path: String { "/stopwords" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/searchCollection.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/searchCollection.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct searchCollectionParameters: Codable {
+    public let collectionname: String
+    public let searchparameters: SearchParameters
+}
+
+public struct searchCollection: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = SearchResult
+    public var method: String { "GET" }
+    public var parameters: searchCollectionParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/documents/search"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        query.append("searchParameters=\(parameters.searchparameters)")
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: searchCollectionParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/takeSnapshot.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/takeSnapshot.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct takeSnapshotParameters: Codable {
+    public let snapshotPath: String
+}
+
+public struct takeSnapshot: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var parameters: takeSnapshotParameters
+    public var path: String {
+        var path = "/operations/snapshot"
+        var query: [String] = []
+        query.append("snapshot_path=\(parameters.snapshotPath)")
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: takeSnapshotParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/updateConversationModel.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/updateConversationModel.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct updateConversationModelParameters: Codable {
+    public let modelid: String
+}
+
+public struct updateConversationModel: APIRequest {
+    public typealias Body = ConversationModelUpdateSchema
+    public typealias Response = ConversationModelSchema
+    public var method: String { "PUT" }
+    public var parameters: updateConversationModelParameters
+    public var path: String {
+        var path = "/conversations/models/{modelId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{modelId}", with: String(parameters.modelid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: updateConversationModelParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/updateNLSearchModel.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/updateNLSearchModel.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct updateNLSearchModelParameters: Codable {
+    public let modelid: String
+}
+
+public struct updateNLSearchModel: APIRequest {
+    public typealias Body = NLSearchModelUpdateSchema
+    public typealias Response = NLSearchModelSchema
+    public var method: String { "PUT" }
+    public var parameters: updateNLSearchModelParameters
+    public var path: String {
+        var path = "/nl_search_models/{modelId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{modelId}", with: String(parameters.modelid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: updateNLSearchModelParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/upsertAlias.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/upsertAlias.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct upsertAliasParameters: Codable {
+    public let aliasname: String
+}
+
+public struct upsertAlias: APIRequest {
+    public typealias Body = CollectionAliasSchema
+    public typealias Response = CollectionAlias
+    public var method: String { "PUT" }
+    public var parameters: upsertAliasParameters
+    public var path: String {
+        var path = "/aliases/{aliasName}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{aliasName}", with: String(parameters.aliasname))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: upsertAliasParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/upsertAnalyticsRule.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/upsertAnalyticsRule.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct upsertAnalyticsRuleParameters: Codable {
+    public let rulename: String
+}
+
+public struct upsertAnalyticsRule: APIRequest {
+    public typealias Body = AnalyticsRuleUpsertSchema
+    public typealias Response = AnalyticsRuleSchema
+    public var method: String { "PUT" }
+    public var parameters: upsertAnalyticsRuleParameters
+    public var path: String {
+        var path = "/analytics/rules/{ruleName}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{ruleName}", with: String(parameters.rulename))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: upsertAnalyticsRuleParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/upsertPreset.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/upsertPreset.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct upsertPresetParameters: Codable {
+    public let presetid: String
+}
+
+public struct upsertPreset: APIRequest {
+    public typealias Body = PresetUpsertSchema
+    public typealias Response = PresetSchema
+    public var method: String { "PUT" }
+    public var parameters: upsertPresetParameters
+    public var path: String {
+        var path = "/presets/{presetId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{presetId}", with: String(parameters.presetid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: upsertPresetParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/upsertSearchOverride.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/upsertSearchOverride.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct upsertSearchOverrideParameters: Codable {
+    public let collectionname: String
+    public let overrideid: String
+}
+
+public struct upsertSearchOverride: APIRequest {
+    public typealias Body = SearchOverrideSchema
+    public typealias Response = SearchOverride
+    public var method: String { "PUT" }
+    public var parameters: upsertSearchOverrideParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/overrides/{overrideId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        path = path.replacingOccurrences(of: "{overrideId}", with: String(parameters.overrideid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: upsertSearchOverrideParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/upsertSearchSynonym.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/upsertSearchSynonym.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct upsertSearchSynonymParameters: Codable {
+    public let collectionname: String
+    public let synonymid: String
+}
+
+public struct upsertSearchSynonym: APIRequest {
+    public typealias Body = SearchSynonymSchema
+    public typealias Response = SearchSynonym
+    public var method: String { "PUT" }
+    public var parameters: upsertSearchSynonymParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/synonyms/{synonymId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        path = path.replacingOccurrences(of: "{synonymId}", with: String(parameters.synonymid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: upsertSearchSynonymParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/upsertStopwordsSet.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/upsertStopwordsSet.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+public struct upsertStopwordsSetParameters: Codable {
+    public let setid: String
+}
+
+public struct upsertStopwordsSet: APIRequest {
+    public typealias Body = StopwordsSetUpsertSchema
+    public typealias Response = StopwordsSetSchema
+    public var method: String { "PUT" }
+    public var parameters: upsertStopwordsSetParameters
+    public var path: String {
+        var path = "/stopwords/{setId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{setId}", with: String(parameters.setid))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: upsertStopwordsSetParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/vote.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/vote.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public struct vote: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = SuccessStatus
+    public var method: String { "POST" }
+    public var path: String { "/operations/vote" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}

--- a/repos/TeatroView/scripts/generate_typesense_client.sh
+++ b/repos/TeatroView/scripts/generate_typesense_client.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACKAGE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROOT_DIR="$(cd "$PACKAGE_DIR/../.." && pwd)"
+
+GENERATOR_DIR="$ROOT_DIR/repos/fountainai"
+SPEC_PATH="$ROOT_DIR/repos/typesense-codex/openapi/openapi.yml"
+OUTPUT_DIR="$PACKAGE_DIR/Sources/TypesenseClient"
+
+# Build the generator from the fountainai repository
+swift build -c release --product generator --package-path "$GENERATOR_DIR"
+
+# Remove any previously generated sources
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+# Generate the client using the custom Swift 6 generator
+TMP_DIR="$(mktemp -d)"
+swift run --package-path "$GENERATOR_DIR" generator --input "$SPEC_PATH" --output "$TMP_DIR"
+cp -r "$TMP_DIR/Client/." "$OUTPUT_DIR/"
+rm -rf "$TMP_DIR"


### PR DESCRIPTION
## Summary
- generate a Swift client for Typesense using the FountainAI OpenAPI generator
- expose the generated client as a SwiftPM target
- add script to regenerate the client
- document regeneration steps in the README

## Testing
- `swift build` *(fails: cannot find several schema types)*
- `swift test` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_687dbf35991c8325888e76569dab42a5