### PR TITLE
Fix TypesenseClient build and add stubs

### DIFF
--- a/repos/TeatroView/Package.swift
+++ b/repos/TeatroView/Package.swift
@@ -15,7 +15,8 @@ let package = Package(
         .executableTarget(
             name: "TeatroView",
             dependencies: [
-                .product(name: "Teatro", package: "teatro")
+                .product(name: "Teatro", package: "teatro"),
+                "TypesenseClient"
             ],
             path: "Sources/TeatroView"
         ),

--- a/repos/TeatroView/Sources/TeatroView/Data/TypesenseService.swift
+++ b/repos/TeatroView/Sources/TeatroView/Data/TypesenseService.swift
@@ -1,4 +1,8 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import TypesenseClient
 
 /// Errors thrown by `TypesenseService` when environment configuration is incomplete.
 public enum TypesenseServiceError: LocalizedError {

--- a/repos/TeatroView/Sources/TeatroView/UI/CollectionBrowserView.swift
+++ b/repos/TeatroView/Sources/TeatroView/UI/CollectionBrowserView.swift
@@ -1,0 +1,62 @@
+import Teatro
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Displays the list of collections returned by `TypesenseService`.
+public struct CollectionBrowserView: View {
+    private let service: TypesenseService?
+    @State private var names: [String]
+    @State private var errorMessage: String?
+
+    /// Runtime initializer using the Typesense service.
+    public init(service: TypesenseService) {
+        self.service = service
+        self._names = State(initialValue: [])
+    }
+
+    /// Preview initializer using static names.
+    public init(names: [String]) {
+        self.service = nil
+        self._names = State(initialValue: names)
+    }
+
+    public var body: some View {
+        ScrollView {
+            Text(scene.render())
+                .font(.system(.body, design: .monospaced))
+                .padding()
+        }
+        .task { await loadIfNeeded() }
+    }
+
+    private func loadIfNeeded() async {
+        guard let service else { return }
+        do {
+            let collections = try await service.listCollections()
+            names = collections.map { $0.name }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private var scene: Stage {
+        Stage(title: "Collections") {
+            Text(renderedNames())
+        }
+    }
+
+    private func renderedNames() -> String {
+        if let msg = errorMessage { return msg }
+        guard !names.isEmpty else { return "No collections" }
+        return names.map { "• \($0)" }.joined(separator: "\n")
+    }
+}
+
+#if DEBUG
+struct CollectionBrowserView_Previews: PreviewProvider {
+    static var previews: some View {
+        CollectionBrowserView(names: ["books", "articles"])
+    }
+}
+#endif
+#endif

--- a/repos/TeatroView/Sources/TeatroView/UI/SchemaEditorView.swift
+++ b/repos/TeatroView/Sources/TeatroView/UI/SchemaEditorView.swift
@@ -1,0 +1,65 @@
+import Teatro
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Edits a collection schema using raw JSON and sends updates via `TypesenseService`.
+public struct SchemaEditorView: View {
+    private let service: TypesenseService?
+    private let collection: String
+    @State private var text: String
+    @State private var message: String?
+
+    /// Runtime initializer.
+    public init(collection: String, service: TypesenseService) {
+        self.collection = collection
+        self.service = service
+        self._text = State(initialValue: "{}")
+    }
+
+    /// Preview initializer with static JSON.
+    public init(collection: String, text: String) {
+        self.collection = collection
+        self.service = nil
+        self._text = State(initialValue: text)
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading) {
+            TextEditor(text: $text)
+                .font(.system(.body, design: .monospaced))
+                .border(Color.gray)
+                .frame(height: 200)
+            Button("Update") { Task { await submit() } }
+            Text(scene.render())
+                .font(.system(.body, design: .monospaced))
+                .padding(.top)
+        }
+    }
+
+    private func submit() async {
+        guard let service else { return }
+        guard let data = text.data(using: .utf8) else { return }
+        do {
+            let schema = try JSONDecoder().decode(CollectionUpdateSchema.self, from: data)
+            let resp = try await service.updateSchema(collection: collection, schema: schema)
+            message = "Updated with \(resp.fields.count) fields"
+        } catch {
+            message = error.localizedDescription
+        }
+    }
+
+    private var scene: Stage {
+        Stage(title: "Status") {
+            Text(message ?? "")
+        }
+    }
+}
+
+#if DEBUG
+struct SchemaEditorView_Previews: PreviewProvider {
+    static var previews: some View {
+        SchemaEditorView(collection: "books", text: "{\n  \"fields\": []\n}")
+    }
+}
+#endif
+#endif

--- a/repos/TeatroView/Sources/TeatroView/UI/SearchView.swift
+++ b/repos/TeatroView/Sources/TeatroView/UI/SearchView.swift
@@ -1,0 +1,74 @@
+import Teatro
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Performs a simple search against a Typesense collection and renders results.
+public struct SearchView: View {
+    private let service: TypesenseService?
+    private let collection: String
+    @State private var query: String = ""
+    @State private var results: [String]
+    @State private var errorMessage: String?
+
+    /// Runtime initializer using the service.
+    public init(collection: String, service: TypesenseService) {
+        self.collection = collection
+        self.service = service
+        self._results = State(initialValue: [])
+    }
+
+    /// Preview initializer with static results.
+    public init(collection: String, results: [String]) {
+        self.collection = collection
+        self.service = nil
+        self._results = State(initialValue: results)
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading) {
+            HStack {
+                TextField("Search", text: $query)
+                    .textFieldStyle(.roundedBorder)
+                Button("Go") { Task { await performSearch() } }
+            }
+            .padding(.bottom)
+            ScrollView {
+                Text(scene.render())
+                    .font(.system(.body, design: .monospaced))
+                    .padding()
+            }
+        }
+        .task { if results.isEmpty { await performSearch() } }
+    }
+
+    private func performSearch() async {
+        guard let service else { return }
+        do {
+            let resp = try await service.search(collection: collection, q: query, queryBy: "*")
+            results = resp.hits.map { String(describing: $0.document) }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    private var scene: Stage {
+        Stage(title: "Results") {
+            Text(renderedResults())
+        }
+    }
+
+    private func renderedResults() -> String {
+        if let msg = errorMessage { return msg }
+        guard !results.isEmpty else { return "No results" }
+        return results.map { "• \($0)" }.joined(separator: "\n")
+    }
+}
+
+#if DEBUG
+struct SearchView_Previews: PreviewProvider {
+    static var previews: some View {
+        SearchView(collection: "books", results: ["Result A", "Result B"])
+    }
+}
+#endif
+#endif

--- a/repos/TeatroView/Sources/TeatroView/main.swift
+++ b/repos/TeatroView/Sources/TeatroView/main.swift
@@ -6,6 +6,7 @@ import SwiftUI
 /// Entry point for the TeatroView package.
 #if canImport(SwiftUI)
 
+@main
 struct TeatroViewApp: App {
     var body: some Scene {
         WindowGroup {
@@ -14,10 +15,5 @@ struct TeatroViewApp: App {
     }
 }
 #else
-@main
-struct TeatroViewApp {
-    static func main() {
-        print("TeatroView requires SwiftUI and macOS to run.")
-    }
-}
+print("TeatroView requires SwiftUI and macOS to run.")
 #endif

--- a/repos/TeatroView/Sources/TypesenseClient/Models.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Models.swift
@@ -125,7 +125,7 @@ public enum DirtyValues: String, Codable {
 public enum DropTokensMode: String, Codable {
     case right_to_left
     case left_to_right
-    case both_sides:3
+    case both_sides_3 = "both_sides:3"
 }
 
 public struct FacetCounts: Codable {
@@ -520,3 +520,20 @@ public struct listStemmingDictionariesResponse: Codable {
 public struct deleteStopwordsSetResponse: Codable {
     public let id: String
 }
+
+// MARK: - Placeholder Schemas
+
+public struct CollectionResponse: Codable {}
+public struct PresetSchema: Codable {}
+public struct PresetUpsertSchema: Codable {}
+public struct AnalyticsRuleSchema: Codable {}
+public struct ApiKey: Codable {}
+public struct ConversationModelSchema: Codable {}
+public struct ConversationModelCreateSchema: Codable {}
+public struct MultiSearchCollectionParameters: Codable {}
+public struct MultiSearchResultItem: Codable {}
+public struct NLSearchModelSchema: Codable {}
+public struct NLSearchModelCreateSchema: Codable {}
+public struct NLSearchModelUpdateSchema: Codable {}
+public struct SearchOverride: Codable {}
+public struct SearchSynonym: Codable {}

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteAlias.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteAlias.swift
@@ -11,7 +11,7 @@ public struct deleteAlias: APIRequest {
     public var parameters: deleteAliasParameters
     public var path: String {
         var path = "/aliases/{aliasName}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{aliasName}", with: String(parameters.aliasname))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteAnalyticsRule.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteAnalyticsRule.swift
@@ -11,7 +11,7 @@ public struct deleteAnalyticsRule: APIRequest {
     public var parameters: deleteAnalyticsRuleParameters
     public var path: String {
         var path = "/analytics/rules/{ruleName}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{ruleName}", with: String(parameters.rulename))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteCollection.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteCollection.swift
@@ -11,7 +11,7 @@ public struct deleteCollection: APIRequest {
     public var parameters: deleteCollectionParameters
     public var path: String {
         var path = "/collections/{collectionName}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteConversationModel.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteConversationModel.swift
@@ -11,7 +11,7 @@ public struct deleteConversationModel: APIRequest {
     public var parameters: deleteConversationModelParameters
     public var path: String {
         var path = "/conversations/models/{modelId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{modelId}", with: String(parameters.modelid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteDocument.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteDocument.swift
@@ -12,7 +12,7 @@ public struct deleteDocument: APIRequest {
     public var parameters: deleteDocumentParameters
     public var path: String {
         var path = "/collections/{collectionName}/documents/{documentId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
         path = path.replacingOccurrences(of: "{documentId}", with: String(parameters.documentid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteKey.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteKey.swift
@@ -11,7 +11,7 @@ public struct deleteKey: APIRequest {
     public var parameters: deleteKeyParameters
     public var path: String {
         var path = "/keys/{keyId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{keyId}", with: String(parameters.keyid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteNLSearchModel.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteNLSearchModel.swift
@@ -11,7 +11,7 @@ public struct deleteNLSearchModel: APIRequest {
     public var parameters: deleteNLSearchModelParameters
     public var path: String {
         var path = "/nl_search_models/{modelId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{modelId}", with: String(parameters.modelid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deletePreset.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deletePreset.swift
@@ -11,7 +11,7 @@ public struct deletePreset: APIRequest {
     public var parameters: deletePresetParameters
     public var path: String {
         var path = "/presets/{presetId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{presetId}", with: String(parameters.presetid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteSearchOverride.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteSearchOverride.swift
@@ -12,7 +12,7 @@ public struct deleteSearchOverride: APIRequest {
     public var parameters: deleteSearchOverrideParameters
     public var path: String {
         var path = "/collections/{collectionName}/overrides/{overrideId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
         path = path.replacingOccurrences(of: "{overrideId}", with: String(parameters.overrideid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteSearchSynonym.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteSearchSynonym.swift
@@ -12,7 +12,7 @@ public struct deleteSearchSynonym: APIRequest {
     public var parameters: deleteSearchSynonymParameters
     public var path: String {
         var path = "/collections/{collectionName}/synonyms/{synonymId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
         path = path.replacingOccurrences(of: "{synonymId}", with: String(parameters.synonymid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/deleteStopwordsSet.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/deleteStopwordsSet.swift
@@ -11,7 +11,7 @@ public struct deleteStopwordsSet: APIRequest {
     public var parameters: deleteStopwordsSetParameters
     public var path: String {
         var path = "/stopwords/{setId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{setId}", with: String(parameters.setid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getAlias.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getAlias.swift
@@ -11,7 +11,7 @@ public struct getAlias: APIRequest {
     public var parameters: getAliasParameters
     public var path: String {
         var path = "/aliases/{aliasName}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{aliasName}", with: String(parameters.aliasname))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getCollection.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getCollection.swift
@@ -11,7 +11,7 @@ public struct getCollection: APIRequest {
     public var parameters: getCollectionParameters
     public var path: String {
         var path = "/collections/{collectionName}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getDocument.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getDocument.swift
@@ -12,7 +12,7 @@ public struct getDocument: APIRequest {
     public var parameters: getDocumentParameters
     public var path: String {
         var path = "/collections/{collectionName}/documents/{documentId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
         path = path.replacingOccurrences(of: "{documentId}", with: String(parameters.documentid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getKey.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getKey.swift
@@ -11,7 +11,7 @@ public struct getKey: APIRequest {
     public var parameters: getKeyParameters
     public var path: String {
         var path = "/keys/{keyId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{keyId}", with: String(parameters.keyid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getSearchOverride.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getSearchOverride.swift
@@ -12,7 +12,7 @@ public struct getSearchOverride: APIRequest {
     public var parameters: getSearchOverrideParameters
     public var path: String {
         var path = "/collections/{collectionName}/overrides/{overrideId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
         path = path.replacingOccurrences(of: "{overrideId}", with: String(parameters.overrideid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getSearchOverrides.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getSearchOverrides.swift
@@ -11,7 +11,7 @@ public struct getSearchOverrides: APIRequest {
     public var parameters: getSearchOverridesParameters
     public var path: String {
         var path = "/collections/{collectionName}/overrides"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getSearchSynonym.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getSearchSynonym.swift
@@ -12,7 +12,7 @@ public struct getSearchSynonym: APIRequest {
     public var parameters: getSearchSynonymParameters
     public var path: String {
         var path = "/collections/{collectionName}/synonyms/{synonymId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
         path = path.replacingOccurrences(of: "{synonymId}", with: String(parameters.synonymid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getSearchSynonyms.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getSearchSynonyms.swift
@@ -11,7 +11,7 @@ public struct getSearchSynonyms: APIRequest {
     public var parameters: getSearchSynonymsParameters
     public var path: String {
         var path = "/collections/{collectionName}/synonyms"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/getStemmingDictionary.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/getStemmingDictionary.swift
@@ -11,7 +11,7 @@ public struct getStemmingDictionary: APIRequest {
     public var parameters: getStemmingDictionaryParameters
     public var path: String {
         var path = "/stemming/dictionaries/{dictionaryId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{dictionaryId}", with: String(parameters.dictionaryid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveAnalyticsRule.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveAnalyticsRule.swift
@@ -11,7 +11,7 @@ public struct retrieveAnalyticsRule: APIRequest {
     public var parameters: retrieveAnalyticsRuleParameters
     public var path: String {
         var path = "/analytics/rules/{ruleName}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{ruleName}", with: String(parameters.rulename))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveConversationModel.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveConversationModel.swift
@@ -11,7 +11,7 @@ public struct retrieveConversationModel: APIRequest {
     public var parameters: retrieveConversationModelParameters
     public var path: String {
         var path = "/conversations/models/{modelId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{modelId}", with: String(parameters.modelid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveNLSearchModel.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveNLSearchModel.swift
@@ -11,7 +11,7 @@ public struct retrieveNLSearchModel: APIRequest {
     public var parameters: retrieveNLSearchModelParameters
     public var path: String {
         var path = "/nl_search_models/{modelId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{modelId}", with: String(parameters.modelid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrievePreset.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrievePreset.swift
@@ -11,7 +11,7 @@ public struct retrievePreset: APIRequest {
     public var parameters: retrievePresetParameters
     public var path: String {
         var path = "/presets/{presetId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{presetId}", with: String(parameters.presetid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveStopwordsSet.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/retrieveStopwordsSet.swift
@@ -11,7 +11,7 @@ public struct retrieveStopwordsSet: APIRequest {
     public var parameters: retrieveStopwordsSetParameters
     public var path: String {
         var path = "/stopwords/{setId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{setId}", with: String(parameters.setid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/updateConversationModel.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/updateConversationModel.swift
@@ -11,7 +11,7 @@ public struct updateConversationModel: APIRequest {
     public var parameters: updateConversationModelParameters
     public var path: String {
         var path = "/conversations/models/{modelId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{modelId}", with: String(parameters.modelid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/updateNLSearchModel.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/updateNLSearchModel.swift
@@ -11,7 +11,7 @@ public struct updateNLSearchModel: APIRequest {
     public var parameters: updateNLSearchModelParameters
     public var path: String {
         var path = "/nl_search_models/{modelId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{modelId}", with: String(parameters.modelid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/upsertAlias.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/upsertAlias.swift
@@ -11,7 +11,7 @@ public struct upsertAlias: APIRequest {
     public var parameters: upsertAliasParameters
     public var path: String {
         var path = "/aliases/{aliasName}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{aliasName}", with: String(parameters.aliasname))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/upsertAnalyticsRule.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/upsertAnalyticsRule.swift
@@ -11,7 +11,7 @@ public struct upsertAnalyticsRule: APIRequest {
     public var parameters: upsertAnalyticsRuleParameters
     public var path: String {
         var path = "/analytics/rules/{ruleName}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{ruleName}", with: String(parameters.rulename))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/upsertPreset.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/upsertPreset.swift
@@ -11,7 +11,7 @@ public struct upsertPreset: APIRequest {
     public var parameters: upsertPresetParameters
     public var path: String {
         var path = "/presets/{presetId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{presetId}", with: String(parameters.presetid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/upsertSearchOverride.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/upsertSearchOverride.swift
@@ -12,7 +12,7 @@ public struct upsertSearchOverride: APIRequest {
     public var parameters: upsertSearchOverrideParameters
     public var path: String {
         var path = "/collections/{collectionName}/overrides/{overrideId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
         path = path.replacingOccurrences(of: "{overrideId}", with: String(parameters.overrideid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/upsertSearchSynonym.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/upsertSearchSynonym.swift
@@ -12,7 +12,7 @@ public struct upsertSearchSynonym: APIRequest {
     public var parameters: upsertSearchSynonymParameters
     public var path: String {
         var path = "/collections/{collectionName}/synonyms/{synonymId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
         path = path.replacingOccurrences(of: "{synonymId}", with: String(parameters.synonymid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }

--- a/repos/TeatroView/Sources/TypesenseClient/Requests/upsertStopwordsSet.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Requests/upsertStopwordsSet.swift
@@ -11,7 +11,7 @@ public struct upsertStopwordsSet: APIRequest {
     public var parameters: upsertStopwordsSetParameters
     public var path: String {
         var path = "/stopwords/{setId}"
-        var query: [String] = []
+        let query: [String] = []
         path = path.replacingOccurrences(of: "{setId}", with: String(parameters.setid))
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path

--- a/repos/TeatroView/Tests/TypesenseServiceTests.swift
+++ b/repos/TeatroView/Tests/TypesenseServiceTests.swift
@@ -1,4 +1,9 @@
 import XCTest
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import TypesenseClient
 @testable import TeatroView
 
 final class TypesenseServiceTests: XCTestCase {
@@ -18,7 +23,7 @@ final class TypesenseServiceTests: XCTestCase {
     func testListCollectionsRequest() async throws {
         setenv("TYPESENSE_URL", "http://localhost:8108", 1)
         setenv("TYPESENSE_API_KEY", "abc", 1)
-        let expected = [CollectionResponse]()
+        let expected: [CollectionResponse] = []
         let data = try JSONEncoder().encode(expected)
         let session = MockSession { req in
             XCTAssertEqual(req.url?.path, "/collections")
@@ -33,7 +38,8 @@ final class TypesenseServiceTests: XCTestCase {
     func testUpdateSchema() async throws {
         setenv("TYPESENSE_URL", "http://localhost:8108", 1)
         setenv("TYPESENSE_API_KEY", "abc", 1)
-        let schema = CollectionUpdateSchema(fields: [])
+        let schemaData = "{\"fields\":[]}".data(using: .utf8)!
+        let schema = try JSONDecoder().decode(CollectionUpdateSchema.self, from: schemaData)
         let data = try JSONEncoder().encode(schema)
         var captured: URLRequest?
         let session = MockSession { req in


### PR DESCRIPTION
## Summary
- add `TypesenseClient` dependency to executable target
- stub missing Typesense models and fix `DropTokensMode` enum
- mark unused query arrays as `let`
- gate SwiftUI views behind `canImport(SwiftUI)` and update main entry
- import `TypesenseClient` and `FoundationNetworking` where needed

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_687dd2dd0b94832598a150ceedd3ee79