### PR TITLE
Initialize simple SwiftUI navigation shell

### DIFF
--- a/repos/TeatroView/README.md
+++ b/repos/TeatroView/README.md
@@ -17,7 +17,7 @@ export TYPESENSE_API_KEY=xyz
 swift run TeatroView
 ```
 
-The app builds with Swift Package Manager. Open the package in Xcode for SwiftUI previews or run from the command line as shown above.
+Running `swift run TeatroView` builds the executable and launches a minimal navigation interface. Open the package in Xcode for SwiftUI previews or run from the command line as shown above.
 
 ### Dependency Layout
 

--- a/repos/TeatroView/Sources/TeatroView/main.swift
+++ b/repos/TeatroView/Sources/TeatroView/main.swift
@@ -1,17 +1,36 @@
 import Teatro
 #if canImport(SwiftUI)
 import SwiftUI
-#endif
 
-/// Entry point for the TeatroView package.
-#if canImport(SwiftUI)
-
+/// Minimal entry point launching the Teatro views in a navigation layout.
 @main
 struct TeatroViewApp: App {
     var body: some Scene {
         WindowGroup {
-            Text("TeatroView Placeholder")
+            NavigationView {
+                RootView()
+            }
         }
+    }
+}
+
+/// Lists the available Teatro demo screens.
+private struct RootView: View {
+    private let service = try? TypesenseService()
+
+    var body: some View {
+        List {
+            NavigationLink("Collections") {
+                if let service { CollectionBrowserView(service: service) }
+            }
+            NavigationLink("Search") {
+                if let service { SearchView(collection: "books", service: service) }
+            }
+            NavigationLink("Edit Schema") {
+                if let service { SchemaEditorView(collection: "books", service: service) }
+            }
+        }
+        .navigationTitle("TeatroView")
     }
 }
 #else


### PR DESCRIPTION
## Summary
- create a minimal SwiftUI `App` in `TeatroView`
- hook up navigation links to Teatro demo views
- clarify launch instructions in the TeatroView README

## Testing
- `swift run TeatroView`
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_687dd820c07c8325acdaf85a7e4feb85