### PR TITLE
Fix Typesense client concurrency and main entry

### DIFF
--- a/repos/TeatroView/Sources/TeatroView/UI/CollectionBrowserView.swift
+++ b/repos/TeatroView/Sources/TeatroView/UI/CollectionBrowserView.swift
@@ -3,6 +3,7 @@ import Teatro
 import SwiftUI
 
 /// Displays the list of collections returned by `TypesenseService`.
+@MainActor
 public struct CollectionBrowserView: View {
     private let service: TypesenseService?
     @State private var names: [String]

--- a/repos/TeatroView/Sources/TeatroView/UI/SchemaEditorView.swift
+++ b/repos/TeatroView/Sources/TeatroView/UI/SchemaEditorView.swift
@@ -3,6 +3,7 @@ import Teatro
 import SwiftUI
 
 /// Edits a collection schema using raw JSON and sends updates via `TypesenseService`.
+@MainActor
 public struct SchemaEditorView: View {
     private let service: TypesenseService?
     private let collection: String

--- a/repos/TeatroView/Sources/TeatroView/UI/SearchView.swift
+++ b/repos/TeatroView/Sources/TeatroView/UI/SearchView.swift
@@ -3,6 +3,7 @@ import Teatro
 import SwiftUI
 
 /// Performs a simple search against a Typesense collection and renders results.
+@MainActor
 public struct SearchView: View {
     private let service: TypesenseService?
     private let collection: String

--- a/repos/TeatroView/Sources/TeatroView/main.swift
+++ b/repos/TeatroView/Sources/TeatroView/main.swift
@@ -34,5 +34,5 @@ private struct RootView: View {
     }
 }
 #else
-print("TeatroView requires SwiftUI and macOS to run.")
+// Running outside of SwiftUI-capable platforms.
 #endif

--- a/repos/TeatroView/Sources/TypesenseClient/Models.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Models.swift
@@ -523,17 +523,19 @@ public struct deleteStopwordsSetResponse: Codable {
 
 // MARK: - Placeholder Schemas
 
-public struct CollectionResponse: Codable {}
-public struct PresetSchema: Codable {}
-public struct PresetUpsertSchema: Codable {}
-public struct AnalyticsRuleSchema: Codable {}
-public struct ApiKey: Codable {}
-public struct ConversationModelSchema: Codable {}
-public struct ConversationModelCreateSchema: Codable {}
-public struct MultiSearchCollectionParameters: Codable {}
-public struct MultiSearchResultItem: Codable {}
-public struct NLSearchModelSchema: Codable {}
-public struct NLSearchModelCreateSchema: Codable {}
-public struct NLSearchModelUpdateSchema: Codable {}
-public struct SearchOverride: Codable {}
-public struct SearchSynonym: Codable {}
+public struct CollectionResponse: Codable, Sendable {
+    public let name: String
+}
+public struct PresetSchema: Codable, Sendable {}
+public struct PresetUpsertSchema: Codable, Sendable {}
+public struct AnalyticsRuleSchema: Codable, Sendable {}
+public struct ApiKey: Codable, Sendable {}
+public struct ConversationModelSchema: Codable, Sendable {}
+public struct ConversationModelCreateSchema: Codable, Sendable {}
+public struct MultiSearchCollectionParameters: Codable, Sendable {}
+public struct MultiSearchResultItem: Codable, Sendable {}
+public struct NLSearchModelSchema: Codable, Sendable {}
+public struct NLSearchModelCreateSchema: Codable, Sendable {}
+public struct NLSearchModelUpdateSchema: Codable, Sendable {}
+public struct SearchOverride: Codable, Sendable {}
+public struct SearchSynonym: Codable, Sendable {}


### PR DESCRIPTION
## Summary
- add missing `name` field to `CollectionResponse` and mark models `Sendable`
- remove top-level code from `main.swift`
- run UI views on the main actor

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_687ddb8435c883258044c5d60b3cc78f