### PR TITLE
Fix SchemaEditorView preview and add CollectionUpdateSchema

### DIFF
--- a/repos/TeatroView/Sources/TeatroView/UI/SchemaEditorView.swift
+++ b/repos/TeatroView/Sources/TeatroView/UI/SchemaEditorView.swift
@@ -59,10 +59,16 @@ public struct SchemaEditorView: View {
 }
 
 #if DEBUG
-struct SchemaEditorView_Previews: PreviewProvider {
-    static var previews: some View {
-        SchemaEditorView(collection: "books", text: "{\n  \"fields\": []\n}")
-    }
+#Preview {
+    SchemaEditorView(
+        collection: "books",
+        text: """
+        {
+            \"name\": \"books\",
+            \"fields\": []
+        }
+        """
+    )
 }
 #endif
 #endif

--- a/repos/TeatroView/Sources/TypesenseClient/Models.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Models.swift
@@ -99,7 +99,8 @@ public struct CollectionSchema: Codable {
     public let voice_query_model: VoiceQueryModelCollectionConfig
 }
 
-public struct CollectionUpdateSchema: Codable, Sendable {
+public struct CollectionUpdateSchema: Codable, Sendable, Equatable {
+    public let name: String
     public let fields: [Field]
 }
 
@@ -134,7 +135,7 @@ public struct FacetCounts: Codable, Sendable {
     public let stats: [String: String]
 }
 
-public struct Field: Codable, Sendable {
+public struct Field: Codable, Sendable, Equatable {
     public let drop: Bool
     public let embed: [String: String]
     public let facet: Bool

--- a/repos/TeatroView/Tests/TypesenseServiceTests.swift
+++ b/repos/TeatroView/Tests/TypesenseServiceTests.swift
@@ -38,7 +38,7 @@ final class TypesenseServiceTests: XCTestCase {
     func testUpdateSchema() async throws {
         setenv("TYPESENSE_URL", "http://localhost:8108", 1)
         setenv("TYPESENSE_API_KEY", "abc", 1)
-        let schemaData = "{\"fields\":[]}".data(using: .utf8)!
+        let schemaData = "{\"name\":\"books\",\"fields\":[]}".data(using: .utf8)!
         let schema = try JSONDecoder().decode(CollectionUpdateSchema.self, from: schemaData)
         let data = try JSONEncoder().encode(schema)
         var captured: URLRequest?


### PR DESCRIPTION
## Summary
- declare `CollectionUpdateSchema` model
- make `Field` equatable so the new schema compiles
- update SchemaEditorView preview to use `#Preview`
- adjust tests for new schema

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_687de5038e608325b88a941ecfb0c35a