### PR TITLE
Annotate Typesense service properties as MainActor

### DIFF
--- a/repos/TeatroView/Sources/TeatroView/UI/CollectionBrowserView.swift
+++ b/repos/TeatroView/Sources/TeatroView/UI/CollectionBrowserView.swift
@@ -5,11 +5,12 @@ import SwiftUI
 /// Displays the list of collections returned by `TypesenseService`.
 @MainActor
 public struct CollectionBrowserView: View {
-    private let service: TypesenseService?
+    @MainActor private let service: TypesenseService?
     @State private var names: [String]
     @State private var errorMessage: String?
 
     /// Runtime initializer using the Typesense service.
+    @MainActor
     public init(service: TypesenseService) {
         self.service = service
         self._names = State(initialValue: [])

--- a/repos/TeatroView/Sources/TeatroView/UI/SchemaEditorView.swift
+++ b/repos/TeatroView/Sources/TeatroView/UI/SchemaEditorView.swift
@@ -6,7 +6,7 @@ import TypesenseClient
 /// Edits a collection schema using raw JSON and sends updates via `TypesenseService`.
 @MainActor
 public struct SchemaEditorView: View {
-    private let service: TypesenseService?
+    @MainActor private let service: TypesenseService?
     private let collection: String
     @State private var text: String
     @State private var message: String?
@@ -72,9 +72,7 @@ public struct SchemaEditorView: View {
 
 #if DEBUG
 #Preview {
-    SchemaEditorView(
-        schema: CollectionUpdateSchema(from: <#any Decoder#>, name: "books", fields: [])
-    )
+    SchemaEditorView(schema: CollectionUpdateSchema(name: "test", fields: []))
 }
 #endif
 #endif

--- a/repos/TeatroView/Sources/TypesenseClient/Models.swift
+++ b/repos/TeatroView/Sources/TypesenseClient/Models.swift
@@ -102,6 +102,11 @@ public struct CollectionSchema: Codable, Sendable {
 public struct CollectionUpdateSchema: Codable, Sendable, Equatable {
     public let name: String
     public let fields: [Field]
+
+    public init(name: String, fields: [Field]) {
+        self.name = name
+        self.fields = fields
+    }
 }
 
 public struct ConversationModelUpdateSchema: Codable, Sendable {


### PR DESCRIPTION
## Summary
- prevent service access data races by isolating `service` properties to the main actor
- ensure `CollectionBrowserView` initializer runs on the main actor

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_687df864acbc832590cdcb27e944c895