### PR TITLE
Add TeatroRootView for previews

### DIFF
--- a/repos/TeatroView/Sources/TeatroView/TeatroRootView.swift
+++ b/repos/TeatroView/Sources/TeatroView/TeatroRootView.swift
@@ -1,0 +1,24 @@
+import Teatro
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Root view replicating `TeatroApp`'s tab layout so it can be previewed.
+public struct TeatroRootView: View {
+    public init() {}
+    public var body: some View {
+        TabView {
+            ChatWorkspaceView()
+                .tabItem { Text("Chat") }
+
+            CollectionBrowserView(service: .live)
+                .tabItem { Text("Collections") }
+        }
+    }
+}
+
+#if DEBUG
+#Preview {
+    TeatroRootView()
+}
+#endif
+#endif


### PR DESCRIPTION
## Summary
- add `TeatroRootView` that replicates the `TabView` layout of `TeatroApp`
- expose it behind `#if canImport(SwiftUI)` and `#if DEBUG` so it can be used in SwiftUI previews

## Testing
- `swift build -c release`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_687e75c192fc83258fcea989df04b350