### PR TITLE
Refine TeatroRootView preview logic

### DIFF
--- a/repos/TeatroView/Sources/TeatroView/UI/TeatroRootView.swift
+++ b/repos/TeatroView/Sources/TeatroView/UI/TeatroRootView.swift
@@ -1,0 +1,23 @@
+import Teatro
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Root view replicating `TeatroApp`'s tab layout for SwiftUI previews.
+public struct TeatroRootView: View {
+    public var body: some View {
+        TabView {
+            ChatWorkspaceView()
+                .tabItem { Text("Chat") }
+
+            CollectionBrowserView(names: ["books", "articles"])
+                .tabItem { Text("Collections") }
+        }
+    }
+}
+
+#if DEBUG
+#Preview {
+    TeatroRootView()
+}
+#endif
+#endif


### PR DESCRIPTION
## Summary
- move `TeatroRootView` into the UI folder
- avoid using `.live` service in previews to prevent crashes

## Testing
- `swift build -c release`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_687e75c192fc83258fcea989df04b350