### PR TITLE
Document GUI status and update agent

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -14,6 +14,7 @@ All contributor guides live under `docs/handbook`. Start from the
 - Reference that file in documentation and code comments when explaining
   configuration.
 - Follow the ⚖️ **Footer-Insertion Policy** when editing `.md` files.
+- Keep `docs/evaluations/llm_first_gui_status.md` up to date with the current status and next steps for the LLM-First GUI
 
 ---
 

--- a/agent.md
+++ b/agent.md
@@ -14,6 +14,7 @@ All contributor guides live under `docs/handbook`. Start from the
 - Reference that file in documentation and code comments when explaining
   configuration.
 - Follow the ⚖️ **Footer-Insertion Policy** when editing `.md` files.
+- Keep `docs/evaluations/llm_first_gui_status.md` up to date with the current status and next steps for the LLM-First GUI
 
 ---
 

--- a/docs/evaluations/llm_first_gui_status.md
+++ b/docs/evaluations/llm_first_gui_status.md
@@ -1,0 +1,23 @@
+# LLM-First GUI – Status and Next Steps
+
+This document tracks progress on the chat-centric Typesense interface proposed in [llm_first_typesense_gui.md](../llm_first_typesense_gui.md).
+
+## Current Status
+
+- `ChatWorkspaceView` sends prompts to `LLMService` and renders replies but does not stream tokens or show citations.
+- `RetrievalInspectorView` displays raw Typesense hits but is not wired into the chat workflow.
+- `PromptHistoryView`, `CollectionBrowserView`, `SchemaEditorView` and `OpsDashboardView` exist as separate views but are not combined into the dual-pane layout.
+- The Typesense client generation script in `TeatroView` works but lacks live reload hooks.
+
+## Next Steps
+
+1. Integrate `RetrievalInspectorView` with the chat pane so Typesense hits appear side by side when `typesense.search` is invoked.
+2. Extend `LLMService` to stream responses and surface citation chips in the chat UI.
+3. Expose `PromptHistoryView` and `OpsDashboardView` as tabs in `TeatroRootView`.
+4. Connect `CollectionBrowserView` and `SchemaEditorView` for in-chat corpus management.
+5. Add live reload hooks so GUI changes trigger automatic rebuilds.
+6. Document any new environment variables in [environment_variables.md](../environment_variables.md).
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````


### PR DESCRIPTION
## Summary
- track the LLM‑First GUI state in `docs/evaluations/llm_first_gui_status.md`
- instruct the agent to keep this status file updated

## Testing
- `git diff --staged --stat`


------
https://chatgpt.com/codex/tasks/task_e_687e8ec5a8b08325a5258d7196dee018