### PR TITLE
Implement parser rules and test coverage

### DIFF
--- a/repos/teatro/Docs/FountainScreenplayEngine/README.md
+++ b/repos/teatro/Docs/FountainScreenplayEngine/README.md
@@ -121,6 +121,19 @@ CUT TO: >>
 # EXT. CITY STREET - NIGHT
 ```
 
+### Custom Rule Set Example
+
+You can adapt parsing behaviour by providing your own `RuleSet`.
+
+```swift
+let rules = RuleSet(sceneHeadingKeywords: ["INT.", "EXT.", "LOC."],
+                    enableNotes: false)
+let parser = FountainParser(rules: rules)
+let nodes = parser.parse("LOC. MARKET - DAY\n[[note]]")
+```
+
+Here the `LOC.` prefix is recognised as a scene heading while the note is treated as action because notes are disabled.
+
 ---
 
 ### Use Cases

--- a/repos/teatro/Tests/FountainParserTests.swift
+++ b/repos/teatro/Tests/FountainParserTests.swift
@@ -79,5 +79,57 @@ Hi
         let nodes = FountainParser().parse(script)
         XCTAssertTrue(nodes.contains { $0.type == .dualDialogue })
     }
+
+    func testSectionsSynopsisCenteredAndPageBreak() {
+        let script = """
+# Opening
+= A summary
+> TITLE <
+===
+"""
+        let nodes = FountainParser().parse(script)
+        XCTAssertTrue(nodes.contains { if case .section(level: 1) = $0.type { return true } else { return false } })
+        XCTAssertTrue(nodes.contains { $0.type == .synopsis })
+        XCTAssertTrue(nodes.contains { $0.type == .centered })
+        XCTAssertTrue(nodes.contains { $0.type == .pageBreak })
+    }
+
+    func testCustomRuleSet() {
+        let rules = RuleSet(sceneHeadingKeywords: ["INT.", "EXT.", "LOC."], enableNotes: false)
+        let script = """
+[[note]]
+LOC. MARKET - DAY
+"""
+        let nodes = FountainParser(rules: rules).parse(script)
+        XCTAssertEqual(nodes.first?.type, .action)
+        XCTAssertTrue(nodes.contains { $0.type == .sceneHeading && $0.rawText.contains("LOC.") })
+    }
+
+    func testEndToEndExampleScript() {
+        let script = """
+INT. LAB - NIGHT
+
+The robot assembles a memory core.
+
+ROBOT
+(to itself)
+I was not made for silence.
+
+CUT TO:
+EXT. CITY STREET - NIGHT
+"""
+        let nodes = FountainParser().parse(script)
+        let types = nodes.map { $0.type }
+        let expected: [FountainElementType] = [
+            .sceneHeading,
+            .action,
+            .character,
+            .parenthetical,
+            .dialogue,
+            .transition,
+            .sceneHeading
+        ]
+        XCTAssertEqual(types, expected)
+    }
 }
 


### PR DESCRIPTION
## Summary
- refactor FountainParser to use dedicated detection helpers
- disallow blank lines in notes
- add parser tests for sections, synopses, page breaks, centered text and custom rules
- document custom RuleSet usage

## Testing
- `swift build >/tmp/build.log`
- `swift test -v >/tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_687fa0bcceb48325926c80eb5d8dd5b4