### PR TITLE
Add FountainAI parser overrides

### DIFF
--- a/repos/fountainai/Docs/FountainAI_Screenplay_GUI_Proposal.md
+++ b/repos/fountainai/Docs/FountainAI_Screenplay_GUI_Proposal.md
@@ -85,9 +85,19 @@ SUMMARY:
 ### Phase 1: Syntax & Schema
 
 - Define extended `.fountain` grammar for:
-  - `#corpus:` headers
-  - `> BASELINE:`, `> SSE:`, `> tool_call:` blocks
-  - `REFLECT:`, `PROMOTE:`, `SUMMARY:` tags
+- `#corpus:` headers
+- `> BASELINE:`, `> SSE:`, `> tool_call:` blocks
+- `REFLECT:`, `PROMOTE:`, `SUMMARY:` tags
+
+| Override Rule              | Status Quo Interpretation |
+|----------------------------|---------------------------|
+| `#corpus:`                 | Section heading (`#`)     |
+| `> BASELINE:`              | Transition/Action         |
+| `> SSE:`                   | Transition/Action         |
+| `> tool_call:`             | Transition/Action         |
+| `REFLECT:`                 | Action                    |
+| `PROMOTE:`                 | Action                    |
+| `SUMMARY:`                 | Action                    |
 
 ### Phase 2: Editor Integration
 

--- a/repos/teatro/Sources/ViewCore/Fountain.swift
+++ b/repos/teatro/Sources/ViewCore/Fountain.swift
@@ -26,7 +26,7 @@ public struct FountainRenderer {
             case .character: return .characterCue(node.rawText)
             case .dialogue, .dualDialogue: return .dialogue(node.rawText)
             case .transition: return .transition(node.rawText)
-            case .action, .synopsis, .centered, .lyrics, .pageBreak, .section, .note, .boneyard, .titlePageField:
+            case .action, .synopsis, .centered, .lyrics, .pageBreak, .section, .note, .boneyard, .titlePageField, .corpusHeader, .baseline, .sse, .toolCall, .reflect, .promote, .summary:
                 return .action(node.rawText)
             case .parenthetical:
                 return .dialogue(node.rawText)

--- a/repos/teatro/Sources/ViewCore/FountainParser+FountainAI.swift
+++ b/repos/teatro/Sources/ViewCore/FountainParser+FountainAI.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+extension FountainParser {
+    // MARK: - FountainAI Rule Helpers
+    func isCorpusHeader(_ line: String) -> Bool {
+        line.trimmingCharacters(in: .whitespaces).lowercased().hasPrefix("#corpus:")
+    }
+
+    func isBaseline(_ line: String) -> Bool {
+        line.trimmingCharacters(in: .whitespaces).lowercased().hasPrefix("> baseline:")
+    }
+
+    func isSSE(_ line: String) -> Bool {
+        line.trimmingCharacters(in: .whitespaces).lowercased().hasPrefix("> sse:")
+    }
+
+    func isToolCall(_ line: String) -> Bool {
+        line.trimmingCharacters(in: .whitespaces).lowercased().hasPrefix("> tool_call:")
+    }
+
+    func isReflect(_ line: String) -> Bool {
+        line.trimmingCharacters(in: .whitespaces).uppercased().hasPrefix("REFLECT:")
+    }
+
+    func isPromote(_ line: String) -> Bool {
+        line.trimmingCharacters(in: .whitespaces).uppercased().hasPrefix("PROMOTE:")
+    }
+
+    func isSummary(_ line: String) -> Bool {
+        line.trimmingCharacters(in: .whitespaces).uppercased().hasPrefix("SUMMARY:")
+    }
+}

--- a/repos/teatro/Sources/ViewCore/FountainParser.swift
+++ b/repos/teatro/Sources/ViewCore/FountainParser.swift
@@ -50,6 +50,14 @@ public enum FountainElementType: Equatable {
     case titlePageField(key: String)
     case text
     case emphasis(style: EmphasisStyle)
+    // FountainAI extensions
+    case corpusHeader
+    case baseline
+    case sse
+    case toolCall
+    case reflect
+    case promote
+    case summary
 }
 
 public struct FountainNode: Equatable {
@@ -202,6 +210,15 @@ public final class FountainParser {
     private func parseBody(line: String, previousBlank: Bool, nextBlank: Bool, lastElement: FountainElementType?) -> FountainElementType? {
         var trimmed = line.trimmingCharacters(in: .whitespaces)
         if trimmed.isEmpty { return nil }
+
+        // FountainAI overrides
+        if isCorpusHeader(trimmed) { return .corpusHeader }
+        if isBaseline(trimmed) { return .baseline }
+        if isSSE(trimmed) { return .sse }
+        if isToolCall(trimmed) { return .toolCall }
+        if isReflect(trimmed) { return .reflect }
+        if isPromote(trimmed) { return .promote }
+        if isSummary(trimmed) { return .summary }
 
         if isAction(trimmed) { return .action }
 

--- a/repos/teatro/Tests/FountainParserTests.swift
+++ b/repos/teatro/Tests/FountainParserTests.swift
@@ -132,5 +132,25 @@ EXT. CITY STREET - NIGHT
         ]
         XCTAssertEqual(types, expected)
     }
+
+    func testFountainAIRules() {
+        let script = """
+        #corpus: test-corpus
+        > BASELINE: data
+        > SSE: event
+        > tool_call: /path
+        REFLECT: note
+        PROMOTE: role
+        SUMMARY: done
+        """
+        let nodes = FountainParser().parse(script)
+        XCTAssertTrue(nodes.contains { $0.type == .corpusHeader })
+        XCTAssertTrue(nodes.contains { $0.type == .baseline })
+        XCTAssertTrue(nodes.contains { $0.type == .sse })
+        XCTAssertTrue(nodes.contains { $0.type == .toolCall })
+        XCTAssertTrue(nodes.contains { $0.type == .reflect })
+        XCTAssertTrue(nodes.contains { $0.type == .promote })
+        XCTAssertTrue(nodes.contains { $0.type == .summary })
+    }
 }
 


### PR DESCRIPTION
## Summary
- document FountainAI parser override rules
- extend FountainParser enum cases
- add FountainAI helper functions and parse overrides
- support new cases in renderer
- test new FountainAI parsing

## Testing
- `swift build`
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_68806fd7f0388325ad93dab27a4c3b07