### PR TITLE
Implement inline screenplay editor

### DIFF
--- a/repos/fountainai/Docs/FountainAI_Screenplay_GUI_Proposal.md
+++ b/repos/fountainai/Docs/FountainAI_Screenplay_GUI_Proposal.md
@@ -100,11 +100,10 @@ SUMMARY:
 | `SUMMARY:`                 | Action                    |
 
 ### Phase 2: Editor Integration
-
-- Integrate `.fountain` editor into the main GUI (macOS app or web-based).
-- Left pane: screenplay script view.
-- Right pane: live trace, Typesense inspector, or reflection thread.
-
+- Integrate `.fountain` editor into a single scrolling document.
+- Each directive becomes a block rendered by `DirectiveBlockView`.
+- Tool output is inserted inline so `viewModel.blocks` drives a `ForEach` loop.
+- No right pane – everything flows inside the script.
 ### Phase 3: Codex Integration
 
 - Implement `.fountain` → AST parser
@@ -136,6 +135,6 @@ SUMMARY:
 `.fountain`, GPT roles, screenplay editor, orchestration, semantic reasoning, tool calling, baseline, drift, reflection, function-calling, Codex, planner.
 
 ---
-````text
+`````text
 ©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
-````
+`````

--- a/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/DirectiveBlockView.swift
+++ b/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/DirectiveBlockView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+public struct DirectiveBlockView: View {
+    let block: FountainDirective
+
+    public init(block: FountainDirective) {
+        self.block = block
+    }
+
+    public var body: some View {
+        switch block {
+        case .editor(let text):
+            Text(text)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 2)
+        case .response(let text):
+            HStack {
+                Spacer()
+                Text(text)
+                    .font(.system(.body, design: .monospaced))
+            }
+            .padding(.vertical, 2)
+        }
+    }
+}
+

--- a/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/FountainDirective.swift
+++ b/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/FountainDirective.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public enum FountainDirective: Identifiable, Equatable {
+    case editor(String)
+    case response(String)
+
+    public var id: UUID {
+        UUID()
+    }
+
+    public var text: String {
+        switch self {
+        case .editor(let text):
+            return text
+        case .response(let text):
+            return text
+        }
+    }
+}
+

--- a/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/ScriptExecutionEngine.swift
+++ b/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/ScriptExecutionEngine.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public final class ScriptExecutionEngine {
+    public init() {}
+
+    public func execute(script: String) -> [FountainDirective] {
+        var blocks: [FountainDirective] = []
+        let lines = script.split(separator: "\n", omittingEmptySubsequences: false)
+        for lineSub in lines {
+            let line = String(lineSub)
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            blocks.append(.editor(line))
+            let lower = trimmed.lowercased()
+            if lower.hasPrefix("> tool_call:") {
+                let content = String(trimmed.dropFirst(11)).trimmingCharacters(in: .whitespaces)
+                let output = ">>> executed \(content)"
+                blocks.append(.response(output))
+            } else if lower.hasPrefix("> sse:") {
+                let content = String(trimmed.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+                let output = ">>> stream \(content)"
+                blocks.append(.response(output))
+            }
+        }
+        return blocks
+    }
+}
+


### PR DESCRIPTION
## Summary
- add FountainDirective and block views for inline output
- drive the screenplay through ScriptExecutionEngine
- use ScriptEditorViewModel to manage script blocks
- document the single-scroll editor design

## Testing
- `swift test --list-tests` *(fails: Another instance of SwiftPM is already running)*


------
https://chatgpt.com/codex/tasks/task_e_6880b9bbb5bc83259064ae4240f6a75c