### PR TITLE
Fix orchestration enums and main actor handling

### DIFF
--- a/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/DirectiveBlockView.swift
+++ b/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/DirectiveBlockView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Teatro
 
 public struct DirectiveBlockView: View {
     let block: FountainLineBlock
@@ -20,7 +21,7 @@ public struct DirectiveBlockView: View {
     }
 
     @ViewBuilder
-    private func injectedView(for inj: FountainLineBlock.InjectedBlock) -> some View {
+    private func injectedView(for inj: InjectedBlock) -> some View {
         switch inj {
         case .toolResponse(let text):
             Text(text)

--- a/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/FountainLineBlock.swift
+++ b/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/FountainLineBlock.swift
@@ -1,24 +1,10 @@
 import Foundation
+import Teatro
 
-public enum OrchestrationTrigger: Equatable {
-    case toolCall(endpoint: String)
-    case sse(filename: String)
-    case reflect
-    case promote(role: String)
-    case summary
-}
 
 public enum FountainLineBlock: Identifiable, Equatable {
     case line(text: String, trigger: OrchestrationTrigger?)
     case injected(InjectedBlock)
-
-    public enum InjectedBlock: Equatable {
-        case toolResponse(String)
-        case reflectionReply(String)
-        case sseChunk(String)
-        case promotionConfirmation(String)
-        case summaryBlock(String)
-    }
 
     public var id: UUID { UUID() }
 

--- a/repos/teatro/Sources/ViewCore/FountainParser+FountainAI.swift
+++ b/repos/teatro/Sources/ViewCore/FountainParser+FountainAI.swift
@@ -1,5 +1,21 @@
 import Foundation
 
+public enum OrchestrationTrigger: Equatable {
+    case toolCall(endpoint: String)
+    case sse(filename: String)
+    case reflect
+    case promote(role: String)
+    case summary
+}
+
+public enum InjectedBlock: Equatable {
+    case toolResponse(String)
+    case reflectionReply(String)
+    case sseChunk(String)
+    case promotionConfirmation(String)
+    case summaryBlock(String)
+}
+
 extension FountainParser {
     // MARK: - FountainAI Rule Helpers
     func isCorpusHeader(_ line: String) -> Bool {


### PR DESCRIPTION
## Summary
- define `OrchestrationTrigger` and `InjectedBlock` in Teatro
- adjust `FountainLineBlock` to use new shared enums
- update views for new `InjectedBlock`
- mark `ScriptExecutionEngine` as `@MainActor` and use async tasks

## Testing
- `swift build` in `repos/teatro`
- `swift test -v` in `repos/teatro`
- `swift test -v` in `repos/fountainai` *(failed: dependency fetching stalled)*

------
https://chatgpt.com/codex/tasks/task_e_6880cec07bc88325bdc0118094539525