### PR TITLE
Add SwiftUI view tests

### DIFF
--- a/repos/fountainai/ScreenplayGUI/Tests/ScreenplayGUITests/ScreenplayGUITests.swift
+++ b/repos/fountainai/ScreenplayGUI/Tests/ScreenplayGUITests/ScreenplayGUITests.swift
@@ -20,4 +20,34 @@ final class ScreenplayGUITests: XCTestCase {
         let nodes = parser.parse(ScriptEditorStage.defaultScript)
         XCTAssertFalse(nodes.isEmpty)
     }
+
+    func testDirectiveBlockViewRendersInjectedResponse() {
+#if canImport(SwiftUI)
+        let response = "[tool output]"
+        let view = DirectiveBlockView(.injected(.toolResponse(response)))
+        let rendered = String(describing: view.body)
+        XCTAssertTrue(rendered.contains(response))
+#else
+        XCTAssertTrue(true)
+#endif
+    }
+
+    func testScreenplayMainStageUpdatesWhenBlocksInserted() async {
+#if canImport(SwiftUI)
+        let stage = ScreenplayMainStage()
+        stage.viewModel.parseAndTrigger(
+        """
+        INT. LAB - DAY
+        > tool_call: echo
+        """
+        )
+        try? await Task.sleep(nanoseconds: 200_000_000)
+        let injectedExists = stage.viewModel.blocks.contains { block in
+            if case .injected = block { return true } else { return false }
+        }
+        XCTAssertTrue(injectedExists)
+#else
+        XCTAssertTrue(true)
+#endif
+    }
 }


### PR DESCRIPTION
## Summary
- extend ScreenplayGUI tests to check injected responses
- ensure ScreenplayMainStage state updates with inserted blocks

## Testing
- `swift test -v` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6881b145bba083258f17b0fe53a33a9f