### PR TITLE
Add element type to FountainLineBlock

### DIFF
--- a/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/DirectiveBlockView.swift
+++ b/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/DirectiveBlockView.swift
@@ -15,12 +15,35 @@ public struct DirectiveBlockView: View {
     @SwiftUI.ViewBuilder
     public var body: some View {
         switch block {
-        case .line(let text, _):
+        case .line(let text, let type, _):
+            lineView(text: text, type: type)
+        case .injected(let inj):
+            injectedView(for: inj)
+        }
+    }
+
+    @SwiftUI.ViewBuilder
+    private func lineView(text: String, type: FountainElementType) -> some View {
+        switch type {
+        case .sceneHeading:
+            Text(text.uppercased())
+                .bold()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 2)
+        case .character:
+            Text(text)
+                .bold()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 2)
+        case .action:
+            Text(text)
+                .italic()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 2)
+        default:
             Text(text)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.vertical, 2)
-        case .injected(let inj):
-            injectedView(for: inj)
         }
     }
 

--- a/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/FountainLineBlock.swift
+++ b/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/FountainLineBlock.swift
@@ -3,14 +3,14 @@ import Teatro
 
 
 public enum FountainLineBlock: Identifiable, Equatable {
-    case line(text: String, trigger: OrchestrationTrigger?)
+    case line(text: String, type: FountainElementType, trigger: OrchestrationTrigger?)
     case injected(InjectedBlock)
 
     public var id: UUID { UUID() }
 
     public var text: String {
         switch self {
-        case .line(let text, _):
+        case .line(let text, _, _):
             return text
         case .injected(let inj):
             switch inj {
@@ -22,8 +22,17 @@ public enum FountainLineBlock: Identifiable, Equatable {
 
     public var trigger: OrchestrationTrigger? {
         switch self {
-        case .line(_, let trigger):
+        case .line(_, _, let trigger):
             return trigger
+        case .injected:
+            return nil
+        }
+    }
+
+    public var elementType: FountainElementType? {
+        switch self {
+        case .line(_, let type, _):
+            return type
         case .injected:
             return nil
         }

--- a/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/ScriptExecutionEngine.swift
+++ b/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/ScriptExecutionEngine.swift
@@ -20,7 +20,7 @@ public final class ScriptExecutionEngine: ObservableObject {
         let parsed = parser.parse(script)
         blocks = []
         for (i, node) in parsed.enumerated() {
-            let block = FountainLineBlock.line(text: node.rawText, trigger: trigger(for: node))
+            let block = FountainLineBlock.line(text: node.rawText, type: node.type, trigger: trigger(for: node))
             blocks.append(block)
             if let trigger = block.trigger {
                 handle(trigger, after: i)


### PR DESCRIPTION
## Summary
- extend `FountainLineBlock` with a `FountainElementType` payload
- pipe parsed node type through `ScriptExecutionEngine`
- render screenplay lines with custom styling in `DirectiveBlockView`

## Testing
- `swift test -v` *(failed: environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_6881ab1e3c888325bdef03957a26bf07