### PR TITLE
Add baseline overlay input for FountainAI

### DIFF
--- a/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/ScreenplayMainStage.swift
+++ b/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/ScreenplayMainStage.swift
@@ -4,13 +4,15 @@ import SwiftUI
 /// Root stage presenting the screenplay as a single scrolling page.
 public struct ScreenplayMainStage: View {
     @StateObject var viewModel: ScriptExecutionEngine
+    @State private var overlayText: String = ""
+    @State private var showOverlay: Bool = true
 
     public init(script: String = ScriptEditorStage.defaultScript) {
         _viewModel = StateObject(wrappedValue: ScriptExecutionEngine(script: script))
     }
 
     public var body: some View {
-        ZStack {
+        ZStack(alignment: .bottomTrailing) {
             Color(white: 0.94).ignoresSafeArea()
             ScrollView {
                 LazyVStack(alignment: .leading) {
@@ -25,9 +27,30 @@ public struct ScreenplayMainStage: View {
                 .shadow(radius: 20)
                 .padding(.vertical, 60)
             }
+
+            if showOverlay {
+                Color.black.opacity(0.4).ignoresSafeArea()
+                    .transition(.opacity)
+                StoryInputOverlay(text: $overlayText, onCommit: submit)
+                    .frame(maxWidth: 400)
+                    .transition(.scale)
+            } else {
+                StoryInputOverlay(text: $overlayText, inlineMode: true, onCommit: submit)
+                    .padding()
+            }
         }
         .font(.system(.body, design: .monospaced))
-        .onAppear { viewModel.run() }
+        .onAppear {
+            viewModel.run()
+        }
+    }
+
+    private func submit() {
+        let line = "> BASELINE: \(overlayText)"
+        viewModel.script.append("\n" + line)
+        overlayText = ""
+        viewModel.run()
+        withAnimation { showOverlay = false }
     }
 }
 

--- a/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/StoryInputOverlay.swift
+++ b/repos/fountainai/ScreenplayGUI/Sources/ScreenplayGUI/StoryInputOverlay.swift
@@ -1,0 +1,40 @@
+#if canImport(SwiftUI)
+import SwiftUI
+
+/// Text input overlay used for bootstrapping FountainAI scripts.
+public struct StoryInputOverlay: View {
+    @Binding var text: String
+    var inlineMode: Bool
+    var onCommit: () -> Void
+
+    public init(text: Binding<String>, inlineMode: Bool = false, onCommit: @escaping () -> Void) {
+        self._text = text
+        self.inlineMode = inlineMode
+        self.onCommit = onCommit
+    }
+
+    public var body: some View {
+        HStack {
+            if inlineMode {
+                Button(action: onCommit) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.title)
+                }
+                .buttonStyle(.plain)
+            } else {
+                TextField("What's your story?", text: $text, onCommit: onCommit)
+                    .textFieldStyle(.roundedBorder)
+                Button(action: onCommit) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.title)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding()
+        .background(Color.white.opacity(0.9))
+        .cornerRadius(8)
+        .shadow(radius: 10)
+    }
+}
+#endif

--- a/repos/fountainai/ScreenplayGUI/Tests/ScreenplayGUITests/ScreenplayGUITests.swift
+++ b/repos/fountainai/ScreenplayGUI/Tests/ScreenplayGUITests/ScreenplayGUITests.swift
@@ -50,4 +50,14 @@ final class ScreenplayGUITests: XCTestCase {
         XCTAssertTrue(true)
 #endif
     }
+
+    func testStoryInputOverlayDefaultPlaceholder() {
+#if canImport(SwiftUI)
+        let overlay = StoryInputOverlay(text: .constant(""), onCommit: {})
+        let rendered = String(describing: overlay.body)
+        XCTAssertTrue(rendered.contains("What's your story?"))
+#else
+        XCTAssertTrue(true)
+#endif
+    }
 }


### PR DESCRIPTION
## Summary
- add `StoryInputOverlay` for overlay text entry
- extend `ScreenplayMainStage` with overlay and submission logic
- test default placeholder text

## Testing
- `swift build -c release`
- `swift test -v` *(failed: network dependencies prevented completion)*

------
https://chatgpt.com/codex/tasks/task_e_68821466b89c8325b74f028cfb40dd27