### PR TITLE
Add Teatro storyboard demo

### DIFF
--- a/docs/teatro_playground_gui_plan.md
+++ b/docs/teatro_playground_gui_plan.md
@@ -38,6 +38,13 @@ TeatroPlayground begins as a playground for Teatro components, but it will grow 
 3. Iterate based on feedback, expanding the UI to cover additional services as FountainAI evolves.
 4. Open `repos/TeatroPlayground/` in Xcode to preview `ContentView` and begin UI experimentation.
 
+## Storyboard DSL Demo
+
+`TeatroPlayground` now includes a **Storyboard Demo** experiment. It walks
+through defining `Scene` blocks and `Transition` steps, then generates a textual
+prompt via `CodexStoryboardPreviewer`. Use this demo to plan app states and
+iterate on transitions before implementing real views.
+
 ---
 
 By approaching Teatro with a dedicated macOS app, we lower the entry barrier for experimentation and pave the way for deeper FountainAI integrations.

--- a/repos/TeatroPlayground/README.md
+++ b/repos/TeatroPlayground/README.md
@@ -29,6 +29,11 @@ view in action.
 The latest "Renderer Showcase" experiment now presents a dedicated SwiftUI view
 that previews the Codex, HTML, SVG and PNG renderers side by side.
 
+The new **Storyboard Demo** experiment teaches how to script app states using
+the Storyboard DSL. It prints a frame-by-frame prompt via
+`CodexStoryboardPreviewer` so you can iterate on transitions before coding the
+actual UI. Select this entry from the list to explore planning with Codex.
+
 
 ````text
 ©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/Experiments.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/Experiments.swift
@@ -47,6 +47,11 @@ SCIENTIST
             title: "Renderer Showcase",
             description: "Outputs the demo view via Codex, HTML, SVG and PNG.") {
                 RendererShowcaseView()
+        },
+        Experiment(
+            title: "Storyboard Demo",
+            description: "Plan app states with the Storyboard DSL and Codex prompting.") {
+                StoryboardDemoView()
         }
     ]
 }

--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/StoryboardDemoView.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/StoryboardDemoView.swift
@@ -1,0 +1,49 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import Teatro
+
+/// Demonstrates planning app states with the Storyboard DSL.
+public struct StoryboardDemoView: View, Renderable {
+    let storyboard: Storyboard
+    public init() {
+        storyboard = Storyboard {
+            Scene("Start") {
+                Text("Welcome")
+            }
+            Transition(style: .crossfade, frames: 5)
+            Scene("End") {
+                Text("Goodbye")
+            }
+        }
+    }
+
+    public nonisolated func render() -> String {
+        CodexStoryboardPreviewer.prompt(storyboard)
+    }
+
+    public var body: some View {
+        ScrollView {
+            Text(render())
+                .font(.system(.body, design: .monospaced))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+        }
+    }
+}
+#else
+import Teatro
+
+public struct StoryboardDemoView: Renderable {
+    let storyboard: Storyboard
+    public init() {
+        storyboard = Storyboard {
+            Scene("Start") { Text("Welcome") }
+            Transition(style: .crossfade, frames: 5)
+            Scene("End") { Text("Goodbye") }
+        }
+    }
+    public func render() -> String {
+        CodexStoryboardPreviewer.prompt(storyboard)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add `StoryboardDemoView` example
- showcase the Storyboard DSL in experiment list
- document new demo in TeatroPlayground README
- mention the demo in the Teatro Playground GUI plan

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68822badfe54832585793f9f8c924905