### PR TITLE
Add link to Teatro prompting guide

### DIFF
--- a/repos/teatro/README.md
+++ b/repos/teatro/README.md
@@ -16,6 +16,7 @@ This repository contains the specification for Teatro, a modular Swift 6 view en
 - [Storyboard DSL](Docs/StoryboardDSL/README.md)
 - [Summary](Docs/Summary/README.md)
 - [Addendum: Apple Platform Compatibility](Docs/Addendum/README.md)
+- [Mastering the Teatro Prompting Language for GUI Code Generation](https://chatgpt.com/share/68826ebf-64ac-8005-9b37-40d6e7187ea3)
 
 The new **Storyboard DSL** allows you to script view states and animated transitions in Swift.  See the guide for an example of generating a textual storyboard preview that can be sent back to Codex.
 


### PR DESCRIPTION
## Summary
- document the external article **Mastering the Teatro Prompting Language for GUI Code Generation** in the Teatro README

## Testing
- `swift build` in `repos/teatro`
- `swift test` in `repos/teatro`


------
https://chatgpt.com/codex/tasks/task_e_688271cdbd4c8325a7c87c52e9ec25cb