### PR TITLE
Add swift package maintenance agent

### DIFF
--- a/AGENTS/swift-package-maintenance.agent.md
+++ b/AGENTS/swift-package-maintenance.agent.md
@@ -1,0 +1,22 @@
+# Swift Package Maintenance Agent
+
+## 🧠 Purpose
+Guide Codex in fixing recurring Swift package errors documented in [docs/swift_package_error_report.md](../docs/swift_package_error_report.md).
+
+## 📋 Tasks
+- Detect missing or incorrect `library` products in `Package.swift` manifests.
+- Ensure package names remain consistent across repositories.
+- Add compile-time tests for newly added packages.
+
+## 🛠️ Prompt Instruction for Codex
+````swift
+// Codex instruction: SwiftPackageMaintenance
+// 1. Scan commit messages for patterns like "missing package product" or "compile-time errors".
+// 2. Check `Package.swift` manifests for the expected `products` definitions.
+// 3. If a package was renamed, update any dependent packages accordingly.
+// 4. Verify `swift build` and `swift test -v` succeed for all targets.
+````
+
+`````
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+`````

--- a/docs/swift_package_error_report.md
+++ b/docs/swift_package_error_report.md
@@ -1,0 +1,20 @@
+# Swift Package Error Patterns
+
+This document summarizes recurring issues related to Swift package creation identified from the commit history. Commits were scanned for messages referencing package problems such as missing products or compile-time failures. Counts reflect the number of commits mentioning each issue.
+
+## Ranked Error Categories
+
+1. **Compile-time errors in the Teatro package** – 10 commits
+   - Example commit: `ea19e51` "Fix builder usage and explicit Alignment".
+2. **Missing package product for Teatro** – 3 commits
+   - Example commit: `6764eee` "Fix TeatroView dependency".
+3. **Renaming GUITeatro package to TeatroPlayground** – 1 commit
+   - Example commit: `0dba78c` "Rename GUITeatro package to TeatroPlayground".
+4. **New package additions (ScreenplayGUI, Dispatcher Mac UI)** – 2 commits
+   - Example commits: `2ced714` "Add ScreenplayGUI package", `81c8835` "Add Dispatcher Mac UI starter package".
+
+Compile-time errors were by far the most common theme, often resolved by exporting the Teatro library product or adjusting Linux-specific code. Missing package products caused build failures until dependencies were corrected. Package renaming occurred once to align naming across the repos. Finally, new packages were added with minimal issues.
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````


### PR DESCRIPTION
## Summary
- document recurring package failures
- create an agent to help Codex maintain Package.swift files

## Testing
- `python3 -m py_compile analyze_swift_log.py`


------
https://chatgpt.com/codex/tasks/task_e_6882ee8a751883259ab54cea498a308f