### PR TITLE
Add Vital Signs Stage animation

### DIFF
--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/Experiments.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/Experiments.swift
@@ -52,6 +52,11 @@ SCIENTIST
             title: "Storyboard Demo",
             description: "Plan app states with the Storyboard DSL and Codex prompting.") {
                 StoryboardPreviewRenderer()
+        },
+        Experiment(
+            title: "Vital Signs",
+            description: "Metrics fading in with the Animator.") {
+                VitalSignsAnimation()
         }
     ]
 }

--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/RendererShowcaseView.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/RendererShowcaseView.swift
@@ -111,7 +111,7 @@ public struct RendererShowcaseView: Renderable {
 #endif
 
 
-#if DEBUG
+#if canImport(SwiftUI) && DEBUG
 #Preview("Renderer Showcase") {
     RendererShowcaseView()
         .frame(width: 800, height: 600)

--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/StoryboardDemoView.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/StoryboardDemoView.swift
@@ -67,7 +67,7 @@ public typealias StoryboardDemoView = StoryboardPreviewRenderer
 #endif
 
 
-#if DEBUG
+#if canImport(SwiftUI) && DEBUG
 #Preview("Storyboard Preview") {
     StoryboardDemoView()
 }

--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/VitalSignsAnimation.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/VitalSignsAnimation.swift
@@ -1,0 +1,54 @@
+import Teatro
+
+/// Renders a simple metrics animation.
+public struct VitalSignsAnimation: Renderable {
+    let storyboard: Storyboard
+
+    public init() {
+        storyboard = Storyboard {
+            Scene("Metric 1") {
+                Stage(title: "Vital Signs") {
+                    VStack(alignment: .leading) {
+                        Text("Attention Drift", style: .bold)
+                    }
+                }
+            }
+            Transition(style: .crossfade, frames: 5)
+            Scene("Metric 2") {
+                Stage(title: "Vital Signs") {
+                    VStack(alignment: .leading) {
+                        Text("Attention Drift", style: .bold)
+                        Text("Cognitive Load", style: .bold)
+                    }
+                }
+            }
+            Transition(style: .crossfade, frames: 5)
+            Scene("Metric 3") {
+                Stage(title: "Vital Signs") {
+                    VStack(alignment: .leading) {
+                        Text("Attention Drift", style: .bold)
+                        Text("Cognitive Load", style: .bold)
+                        Text("Memory Use", style: .bold)
+                    }
+                }
+            }
+            Transition(style: .crossfade, frames: 5)
+            Scene("Metric 4") {
+                Stage(title: "Vital Signs") {
+                    VStack(alignment: .leading) {
+                        Text("Attention Drift", style: .bold)
+                        Text("Cognitive Load", style: .bold)
+                        Text("Memory Use", style: .bold)
+                        Text("Latency", style: .bold)
+                    }
+                }
+            }
+        }
+    }
+
+    public func render() -> String {
+        let frames = storyboard.frames()
+        Animator.renderFrames(frames, baseName: "vital_signs")
+        return CodexStoryboardPreviewer.prompt(storyboard)
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `VitalSignsAnimation` with sequential metric fade-in using `Animator`
- expose new experiment in the TeatroPlayground UI
- fix preview macros to compile on Linux

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6882f417ab188325b08a9b555af4d141