### PR TITLE
Add svg-animated target to RenderCLI

### DIFF
--- a/repos/teatro/Sources/CLI/RenderCLI.swift
+++ b/repos/teatro/Sources/CLI/RenderCLI.swift
@@ -1,6 +1,6 @@
 import Teatro
 public enum RenderTarget: String {
-    case html, svg, png, markdown, codex
+    case html, svg, png, markdown, codex, svgAnimated
 }
 
 public struct RenderCLI {
@@ -25,6 +25,23 @@ public struct RenderCLI {
             print(MarkdownRenderer.render(view))
         case .codex:
             print(CodexPreviewer.preview(view))
+        case .svgAnimated:
+            let storyboard = Storyboard {
+                Scene("One") {
+                    VStack(alignment: .center) {
+                        Text("Teatro", style: .bold)
+                        Text("SVG Animation Demo")
+                    }
+                }
+                Transition(style: .crossfade, frames: 10)
+                Scene("Two") {
+                    VStack(alignment: .center) {
+                        Text("Scene Two")
+                    }
+                }
+            }
+
+            print(SVGAnimator.renderAnimatedSVG(storyboard: storyboard))
         }
     }
 }


### PR DESCRIPTION
## Summary
- extend `RenderTarget` enum with `.svgAnimated`
- handle `.svgAnimated` in `RenderCLI`

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68835a6a244c83259f446a0d7e09eeec