### PR TITLE
Update Teatro docs for animated SVG support

### DIFF
--- a/repos/teatro/Docs/Addendum/README.md
+++ b/repos/teatro/Docs/Addendum/README.md
@@ -59,6 +59,7 @@ Yes — the **Teatro View Engine** is fully compatible with Apple platforms incl
 While Teatro is **optimized for Codex orchestration and Linux-based environments**, it is **fully portable to Apple systems**. With minor renderer adaptations and optional SwiftUI wrappers, Teatro can serve as the foundation for:
 - Native apps
 - Live previews
+- Animated SVGs can be displayed in `WKWebView` using `AnimatedSVGPreview.swift`.
 - Developer tools
 - Multimodal orchestration pipelines
 
@@ -81,3 +82,7 @@ This ensures that semantic rendering, narrative structuring, and musical composi
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````

--- a/repos/teatro/Docs/AnimationSystem/README.md
+++ b/repos/teatro/Docs/AnimationSystem/README.md
@@ -55,6 +55,14 @@ Once frames are rendered, you can use `convert` to create an animated `.gif`:
 convert -delay 50 -loop 0 Animations/timeline_*.png animated.gif
 ```
 
+### 5.2 SVG Timeline Export
+
+`SVGAnimator.renderAnimatedSVG(storyboard:)` generates a single animated SVG
+instead of a directory of PNG frames. Pass a `Storyboard` containing transitions
+(e.g. `.crossfade`) and each step is written as `<animate>` or
+`<animateTransform>` within the resulting SVG. This is convenient for embedding
+web previews or converting to `.gif` using rasterizers.
+
 ---
 
 This animation system works especially well for:
@@ -68,3 +76,7 @@ This animation system works especially well for:
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````

--- a/repos/teatro/Docs/CLIIntegration/README.md
+++ b/repos/teatro/Docs/CLIIntegration/README.md
@@ -8,7 +8,7 @@ The Teatro View Engine includes a lightweight command-line interface (CLI) imple
 
 ```swift
 public enum RenderTarget: String {
-    case html, svg, png, markdown, codex
+    case html, svg, svgAnimated = "svg-animated", png, markdown, codex
 }
 ```
 
@@ -49,10 +49,15 @@ public struct RenderCLI {
 ```bash
 swift run RenderCLI html
 swift run RenderCLI svg
+swift run RenderCLI svg-animated
 swift run RenderCLI png
 swift run RenderCLI markdown
 swift run RenderCLI codex
 ```
+
+The `svg-animated` target converts a multi-scene `Storyboard` into a single
+animated `.svg` file. This differs from `svg` (static) and `png` (individual
+frame images) by embedding `<animate>` elements directly in the output.
 
 This CLI is ideal for:
 - Previewing scenes, tests, or examples from terminal
@@ -64,3 +69,7 @@ This CLI is ideal for:
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````

--- a/repos/teatro/Docs/RenderingBackends/README.md
+++ b/repos/teatro/Docs/RenderingBackends/README.md
@@ -109,6 +109,40 @@ public struct MarkdownRenderer {
     }
 }
 ```
+
+---
+
+### 3.6 Animated SVG Renderer
+
+`SVGAnimator` exposes `renderAnimatedSVG(storyboard:)` to produce a fully
+animated SVG timeline. Pass a `Storyboard` built with the
+[`StoryboardDSL`](../StoryboardDSL) and the method returns an SVG string
+containing `<animate>` tags for each transition.
+
+```swift
+let svg = SVGAnimator.renderAnimatedSVG(storyboard: storyboard)
+print(svg)
+```
+
+Example output snippet:
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg">
+  <g id="scene0">
+    <animate attribute-name="opacity" from="1" to="0" dur="0.5s" fill="freeze" />
+  </g>
+</svg>
+```
+
+Run via the CLI:
+
+```bash
+swift run RenderCLI svg-animated
+```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````

--- a/repos/teatro/Docs/StoryboardDSL/README.md
+++ b/repos/teatro/Docs/StoryboardDSL/README.md
@@ -38,6 +38,14 @@ print(prompt)
 
 Running this code prints a multi‑line text prompt.  Each section begins with `Frame N:` followed by the rendered view.  The prompt can be fed back into Codex so the agent can reason about the sequence of states and transitions before producing a final UI or animation.
 
+The array returned by `storyboard.frames()` can now be passed to
+`SVGAnimator.renderAnimatedSVG(storyboard:)` to produce an animated vector
+timeline:
+
+```swift
+let svg = SVGAnimator.renderAnimatedSVG(storyboard: storyboard)
+```
+
 
 ````text
 ©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/repos/teatro/Docs/Summary/README.md
+++ b/repos/teatro/Docs/Summary/README.md
@@ -13,8 +13,10 @@ The **Teatro View Engine** is a modular, fully declarative view system written i
 - **CLI Integration**  
   A command-line entry point allows rendering from terminal or scriptable pipelines.
 
-- **Timeline-Based Animation**  
+- **Timeline-Based Animation**
   Frame-by-frame rendering of view sequences for semantic drift, transitions, and GPT step-wise thinking.
+- 🆕 **Animated SVG Export**  
+  Teatro now supports generating `<svg>` files with embedded `<animate>` transitions via `SVGAnimator.renderAnimatedSVG(...)`. Ideal for previewing UI timelines, scene transitions, or GPT-driven visual reasoning.
 
 - **Music Rendering**  
   - **LilyPond:** Printable PDF sheet music from `LilyScore` views.
@@ -61,3 +63,7 @@ Teatro/
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````

--- a/repos/teatro/Docs/ViewImplementationPlan/README.md
+++ b/repos/teatro/Docs/ViewImplementationPlan/README.md
@@ -37,6 +37,8 @@ Although not strictly views, renderers are important for integration testing:
 
 - Implement `HTMLRenderer`, `SVGRenderer`, `ImageRenderer`, `MarkdownRenderer`, and `CodexPreviewer` under `Sources/Renderers` exactly as shown in the docs.
 - Implement `RenderCLI` in `Sources/CLI` to wire up the renderers. Use `swift run` in tests to ensure the binary can be invoked with different targets.
+- `SVGAnimator` should be tested with sample `Storyboard`.
+- Include `svg-animated` as a CLI output target in integration tests.
 
 ### 10.5 Animation System
 Implement `Animator` under `Sources/Renderers` or a dedicated `Sources/Animation` folder. Tests should create a series of views, call `Animator.renderFrames`, and confirm that the expected `.png` files appear in `Animations/`.
@@ -48,6 +50,7 @@ Create test files in `Tests/` following SwiftPM conventions:
 - `MusicViewTests.swift` – tests `LilyScore` behaviour.
 - `FountainViewTests.swift` – tests screenplay parsing and rendering.
 - `RendererTests.swift` – verifies HTML/SVG output strings and image file creation (Cairo can be mocked if unavailable).
+- `RendererTests.swift` should include a test for `<g id="scene0">` and `<animate>` detection.
 - `CLITests.swift` – uses `Process` to run the CLI with different arguments and checks the output or generated files.
 
 Each test should clean up temporary files after execution to keep the repository tidy.
@@ -63,3 +66,7 @@ Following this implementation and testing plan will produce a fully functional T
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````


### PR DESCRIPTION
## Summary
- add animated SVG renderer documentation
- document new CLI svg-animated target
- explain SVG timeline export
- show how StoryboardDSL integrates with SVGAnimator
- update summary, implementation plan, and addendum

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_6883608027e083258c833f39cfe2dc9f