### PR TITLE
Implement MIDI DSL and basic player

### DIFF
--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/TeatroPlayerView.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/TeatroPlayerView.swift
@@ -1,0 +1,69 @@
+#if canImport(SwiftUI)
+import SwiftUI
+import Combine
+import Teatro
+
+/// Displays a sequence of Renderable frames and advances them using a MIDI
+/// sequence for timing.
+public struct TeatroPlayerView: View {
+    public let frames: [Renderable]
+    public let midiSequence: MIDISequence
+
+    @State private var currentIndex: Int = 0
+    @State private var timer: AnyCancellable?
+
+    public init(frames: [Renderable], midiSequence: MIDISequence) {
+        self.frames = frames
+        self.midiSequence = midiSequence
+    }
+
+    public var body: some View {
+        VStack {
+            Text(frames[currentIndex].render())
+                .font(.system(.body, design: .monospaced))
+                .padding()
+        }
+        .onAppear(perform: startPlayback)
+        .onDisappear(perform: stopPlayback)
+    }
+
+    private func startPlayback() {
+        guard frames.count > 1 else { return }
+        currentIndex = 0
+        scheduleNextFrame(at: 0)
+    }
+
+    private func scheduleNextFrame(at index: Int) {
+        guard index < midiSequence.notes.count else { return }
+        let delay = midiSequence.notes[index].duration
+        timer = Just(())
+            .delay(for: .seconds(delay), scheduler: DispatchQueue.main)
+            .sink { _ in
+                if currentIndex + 1 < frames.count {
+                    currentIndex += 1
+                    scheduleNextFrame(at: currentIndex)
+                } else {
+                    stopPlayback()
+                }
+            }
+    }
+
+    private func stopPlayback() {
+        timer?.cancel()
+        timer = nil
+    }
+}
+#else
+import Teatro
+import Combine
+
+public struct TeatroPlayerView {
+    public let frames: [Renderable]
+    public let midiSequence: MIDISequence
+
+    public init(frames: [Renderable], midiSequence: MIDISequence) {
+        self.frames = frames
+        self.midiSequence = midiSequence
+    }
+}
+#endif

--- a/repos/teatro/Sources/MIDI/MIDI.swift
+++ b/repos/teatro/Sources/MIDI/MIDI.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public struct MIDINote {
+    public let channel: Int
+    public let note: Int
+    public let velocity: Int
+    public let duration: Double
+
+    public init(channel: Int, note: Int, velocity: Int, duration: Double) {
+        self.channel = channel
+        self.note = note
+        self.velocity = velocity
+        self.duration = duration
+    }
+}
+
+@resultBuilder
+public enum NoteBuilder {
+    public static func buildBlock(_ notes: MIDINote...) -> [MIDINote] {
+        notes
+    }
+}
+
+public struct MIDISequence {
+    public let notes: [MIDINote]
+
+    public init(@NoteBuilder _ build: () -> [MIDINote]) {
+        self.notes = build()
+    }
+}
+
+public struct MIDIRenderer {
+    public static func renderToFile(_ sequence: MIDISequence, to path: String = "output.mid") {
+        let content = sequence.notes.map {
+            "NOTE(ch:\($0.channel), key:\($0.note), vel:\($0.velocity), dur:\($0.duration))"
+        }.joined(separator: "\n")
+        try? content.write(toFile: path, atomically: true, encoding: .utf8)
+    }
+}


### PR DESCRIPTION
## Summary
- add MIDI DSL implementation to Teatro
- add SwiftUI TeatroPlayerView to play Renderable frames using MIDI timing

## Testing
- `cd repos/teatro && swift build`
- `swift test`
- `cd ../TeatroPlayground && swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68836a195d5c8325ab20099a209e9db8