### PR TITLE
Add MIDI audio playback

### DIFF
--- a/repos/TeatroPlayground/Package.swift
+++ b/repos/TeatroPlayground/Package.swift
@@ -6,6 +6,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     products: [
         .library(name: "TeatroPlaygroundUI", targets: ["TeatroPlaygroundUI"]),
+        .library(name: "TeatroPlaygroundCore", targets: ["TeatroPlaygroundCore"]),
         .executable(name: "TeatroPlayground", targets: ["TeatroPlayground"])
     ],
     dependencies: [
@@ -13,9 +14,17 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "TeatroPlaygroundUI",
+            name: "TeatroPlaygroundCore",
             dependencies: [
                 .product(name: "Teatro", package: "teatro")
+            ],
+            path: "Sources/TeatroPlaygroundCore"
+        ),
+        .target(
+            name: "TeatroPlaygroundUI",
+            dependencies: [
+                .product(name: "Teatro", package: "teatro"),
+                "TeatroPlaygroundCore"
             ],
             path: "Sources/TeatroPlaygroundUI"
         ),

--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundCore/MIDIAudioEngine.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundCore/MIDIAudioEngine.swift
@@ -1,0 +1,47 @@
+#if canImport(AVFoundation)
+import Foundation
+import AVFoundation
+import Teatro
+
+public struct MIDIAudioEngine {
+    private static var engine: AVAudioEngine?
+    private static var sampler: AVAudioUnitSampler?
+
+    public static func start() {
+        guard engine == nil else { return }
+        let newEngine = AVAudioEngine()
+        let newSampler = AVAudioUnitSampler()
+
+        newEngine.attach(newSampler)
+        newEngine.connect(newSampler, to: newEngine.mainMixerNode, format: nil)
+
+        do {
+            try newEngine.start()
+            try newSampler.loadInstrument(at: MIDIAudioEngine.defaultSoundFontURL())
+            engine = newEngine
+            sampler = newSampler
+        } catch {
+            print("MIDI engine start failed: \(error)")
+        }
+    }
+
+    public static func play(note: MIDINote) {
+        guard let sampler else { return }
+
+        let midiNote = UInt8(note.note)
+        let velocity = UInt8(note.velocity)
+        let channel = UInt8(note.channel)
+
+        sampler.startNote(midiNote, withVelocity: velocity, onChannel: channel)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + note.duration) {
+            sampler.stopNote(midiNote, onChannel: channel)
+        }
+    }
+
+    private static func defaultSoundFontURL() throws -> URL {
+        // Replace with bundled soundfont if needed
+        return URL(fileURLWithPath: "/System/Library/Audio/Sounds/Bank.sf2")
+    }
+}
+#endif

--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/TeatroPlayerView.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/TeatroPlayerView.swift
@@ -2,6 +2,7 @@
 import SwiftUI
 import Combine
 import Teatro
+import TeatroPlaygroundCore
 
 /// Displays a sequence of Renderable frames and advances them using a MIDI
 /// sequence for timing.
@@ -62,6 +63,9 @@ public struct TeatroPlayerView: View {
 
     private func playFrom(_ index: Int) {
         guard index < midiSequence.notes.count else { return }
+#if canImport(AVFoundation)
+        MIDIAudioEngine.start()
+#endif
         isPlaying = true
         scheduleNextFrame(at: index)
     }
@@ -72,7 +76,11 @@ public struct TeatroPlayerView: View {
             return
         }
 
-        let duration = midiSequence.notes[index].duration
+        let note = midiSequence.notes[index]
+#if canImport(AVFoundation)
+        MIDIAudioEngine.play(note: note)
+#endif
+        let duration = note.duration
 
         withAnimation(.easeInOut(duration: duration)) {
             fadeIn.toggle()


### PR DESCRIPTION
## Summary
- add `MIDIAudioEngine` helper for AVFoundation based playback
- play MIDI notes from `TeatroPlayerView`
- start audio engine when playback begins
- expose new core target in package manifest

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688374a6a2cc83259e87789febe27b9f