### PR TITLE
Improve Teatro renderers

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -39,6 +39,10 @@ The token is used for cloning repositories, pushing commits, and pulling updates
 | `FUNCTIONS_CACHE_PATH` | `functions-cache.json` | Path to persist cached function definitions for the Function Caller and Tools Factory. Used by `repos/fountainai/Generated/Server/Shared/TypesenseClient.swift`. |
 | `TOOLS_FACTORY_AUTH_TOKEN` | _(none)_ | Optional bearer token required by the Tools Factory service. Used by `repos/fountainai/Generated/Server/tools-factory/HTTPKernel.swift`. |
 | `PLANNER_AUTH_TOKEN` | _(none)_ | Optional bearer token required by the Planner service. Used by `repos/fountainai/Generated/Server/planner/HTTPKernel.swift`. |
+| `TEATRO_SVG_WIDTH` | `600` | Default width for `SVGRenderer` output. |
+| `TEATRO_SVG_HEIGHT` | `400` | Default height for `SVGRenderer` output. |
+| `TEATRO_IMAGE_WIDTH` | `800` | Default width for `ImageRenderer` when Cairo is available. |
+| `TEATRO_IMAGE_HEIGHT` | `600` | Default height for `ImageRenderer` when Cairo is available. |
 
 Environment variables can be managed using **GitHub Secrets** so that sensitive values are not stored in the repository. Create a new secret in your GitHub repository settings and reference it when running the deployer:
 

--- a/repos/teatro/Sources/Animation/Animator.swift
+++ b/repos/teatro/Sources/Animation/Animator.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+@MainActor
 public struct Animator {
     public static func renderFrames(_ frames: [Renderable], baseName: String = "frame") {
         for (i, frame) in frames.enumerated() {

--- a/repos/teatro/Sources/Renderers/ImageRenderer.swift
+++ b/repos/teatro/Sources/Renderers/ImageRenderer.swift
@@ -2,10 +2,22 @@
 import Cairo
 #endif
 
+import Foundation
+
 public struct ImageRenderer {
+    // Default image width in points. Override with `TEATRO_IMAGE_WIDTH`.
+    private static var width: Int {
+        Int(ProcessInfo.processInfo.environment["TEATRO_IMAGE_WIDTH"] ?? "800") ?? 800
+    }
+
+    // Default image height in points. Override with `TEATRO_IMAGE_HEIGHT`.
+    private static var height: Int {
+        Int(ProcessInfo.processInfo.environment["TEATRO_IMAGE_HEIGHT"] ?? "600") ?? 600
+    }
+
     public static func renderToPNG(_ view: Renderable, to path: String = "output.png") {
 #if canImport(Cairo)
-        let surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, 800, 600)
+        let surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, Int32(width), Int32(height))
         let cr = cairo_create(surface)
 
         cairo_set_source_rgb(cr, 1, 1, 1)
@@ -25,8 +37,10 @@ public struct ImageRenderer {
         cairo_destroy(cr)
         cairo_surface_destroy(surface)
 #else
-        // Fallback stub for environments without Cairo
-        try? view.render().write(toFile: path + ".txt", atomically: true, encoding: .utf8)
+        // Fallback when Cairo is unavailable: generate an SVG next to the desired PNG path.
+        let svgPath = path.replacingOccurrences(of: ".png", with: ".svg")
+        let svg = SVGRenderer.render(view)
+        try? svg.write(toFile: svgPath, atomically: true, encoding: .utf8)
 #endif
     }
 }

--- a/repos/teatro/Sources/Renderers/SVGAnimation/SVGAnimator.swift
+++ b/repos/teatro/Sources/Renderers/SVGAnimation/SVGAnimator.swift
@@ -12,7 +12,11 @@ public struct SVGAnimator {
     /// subsequent scenes fade in and out on a global timeline. The `begin`
     /// attribute is used to stagger the animations according to the frame
     /// index. Every frame lasts for one second.
-    public static func renderAnimatedSVG(storyboard: Storyboard) -> String {
+    public static func renderAnimatedSVG(
+        storyboard: Storyboard,
+        fadeInDuration: Double = 1.0,
+        fadeOutDuration: Double = 0.5
+    ) -> String {
         let frames = storyboard.frames()
         var groups: [String] = []
 
@@ -26,12 +30,12 @@ public struct SVGAnimator {
 
             let fadeIn = SVGAnimate(
                 attributeName: "opacity",
-                from: "0", to: "1", dur: 1.0, repeatCount: nil
+                from: "0", to: "1", dur: fadeInDuration, repeatCount: nil
             ).render().replacingOccurrences(of: ">", with: " begin=\"\(i)s\">", options: .literal)
 
             let fadeOut = SVGAnimate(
                 attributeName: "opacity",
-                from: "1", to: "0", dur: 0.5, repeatCount: nil
+                from: "1", to: "0", dur: fadeOutDuration, repeatCount: nil
             ).render().replacingOccurrences(of: ">", with: " begin=\"\(i + 1)s\">", options: .literal)
 
             let group = """

--- a/repos/teatro/Sources/Renderers/SVGRenderer.swift
+++ b/repos/teatro/Sources/Renderers/SVGRenderer.swift
@@ -1,14 +1,50 @@
+import Foundation
+
 public struct SVGRenderer {
+    // Default canvas width in points. Override with `TEATRO_SVG_WIDTH`.
+    private static var canvasWidth: Int {
+        Int(ProcessInfo.processInfo.environment["TEATRO_SVG_WIDTH"] ?? "600") ?? 600
+    }
+
+    // Default canvas height in points. Override with `TEATRO_SVG_HEIGHT`.
+    private static var canvasHeight: Int {
+        Int(ProcessInfo.processInfo.environment["TEATRO_SVG_HEIGHT"] ?? "400") ?? 400
+    }
+
+    nonisolated(unsafe) private static var cache: [String: String] = [:]
+
     public static func render(_ view: Renderable) -> String {
-        let lines = view.render().components(separatedBy: "\n")
-        let rendered = lines.enumerated().map { idx, line in
-            "<text x=\"10\" y=\"\(20 + idx * 20)\" font-family=\"monospace\" font-size=\"14\">\(line)</text>"
+        let key = view.render()
+        if let cached = cache[key] { return cached }
+
+        var y = 20
+        let rendered = view.render().components(separatedBy: "\n").map { line -> String in
+            defer { y += 20 }
+            let styled = applyStyle(line)
+            return "<text x=\"10\" y=\"\(y)\" font-family=\"monospace\" font-size=\"14\">\(styled)</text>"
         }.joined(separator: "\n")
 
-        return """
-        <svg xmlns=\"http://www.w3.org/2000/svg\" width=\"600\" height=\"\(20 + lines.count * 20)\">
+        let svg = """
+        <svg xmlns=\"http://www.w3.org/2000/svg\" width=\"\(canvasWidth)\" height=\"\(max(canvasHeight, y))\">
         \(rendered)
         </svg>
         """
+
+        cache[key] = svg
+        return svg
+    }
+
+    private static func applyStyle(_ line: String) -> String {
+        var result = line
+        result = result.replacing("\\*\\*(.+?)\\*\\*", with: "<tspan font-weight=\"bold\">$1</tspan>")
+        result = result.replacing("\\*(.+?)\\*", with: "<tspan font-style=\"italic\">$1</tspan>")
+        result = result.replacing("_(.+?)_", with: "<tspan text-decoration=\"underline\">$1</tspan>")
+        return result
+    }
+}
+
+private extension String {
+    func replacing(_ pattern: String, with template: String) -> String {
+        replacingOccurrences(of: pattern, with: template, options: .regularExpression)
     }
 }


### PR DESCRIPTION
## Summary
- extend SVGRenderer with styling, caching and layout hints
- allow custom dimensions via environment variables
- provide Cairo-less fallback SVG export in ImageRenderer
- parameterise SVGAnimator fade timings
- document new TEATRO_* variables

## Testing
- `swift test --no-parallel`

------
https://chatgpt.com/codex/tasks/task_e_68839672a02c8325ab879f3b31c0eb3e