### PR TITLE
Add targeted tests for Teatro DSL and renderers

### DIFF
--- a/repos/teatro/Package.swift
+++ b/repos/teatro/Package.swift
@@ -25,7 +25,23 @@ let package = Package(
         .testTarget(
             name: "TeatroTests",
             dependencies: ["Teatro"],
-            path: "Tests"
+            path: "Tests",
+            exclude: ["StoryboardDSLTests", "MIDITests", "RendererFileTests"]
+        ),
+        .testTarget(
+            name: "StoryboardDSLTests",
+            dependencies: ["Teatro"],
+            path: "Tests/StoryboardDSLTests"
+        ),
+        .testTarget(
+            name: "MIDITests",
+            dependencies: ["Teatro"],
+            path: "Tests/MIDITests"
+        ),
+        .testTarget(
+            name: "RendererFileTests",
+            dependencies: ["Teatro"],
+            path: "Tests/RendererFileTests"
         )
     ]
 )

--- a/repos/teatro/Tests/MIDITests/MIDITests.swift
+++ b/repos/teatro/Tests/MIDITests/MIDITests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import Teatro
+
+final class MIDITests: XCTestCase {
+    func testNoteBuilderCollectsNotes() {
+        let seq = MIDISequence {
+            MIDINote(channel: 0, note: 60, velocity: 100, duration: 0.5)
+            MIDINote(channel: 0, note: 62, velocity: 100, duration: 0.5)
+        }
+        XCTAssertEqual(seq.notes.count, 2)
+    }
+
+    func testMIDIRendererOutputsFile() throws {
+        let seq = MIDISequence {
+            MIDINote(channel: 0, note: 60, velocity: 80, duration: 0.5)
+        }
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).appendingPathExtension("mid")
+        MIDIRenderer.renderToFile(seq, to: url.path)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        let content = try String(contentsOf: url)
+        XCTAssertTrue(content.contains("NOTE"))
+    }
+}

--- a/repos/teatro/Tests/RendererFileTests/RendererFileTests.swift
+++ b/repos/teatro/Tests/RendererFileTests/RendererFileTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+@testable import Teatro
+
+final class RendererFileTests: XCTestCase {
+    func testSVGRendererWritesFile() throws {
+        let view = Text("Hi")
+        let svg = SVGRenderer.render(view)
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).appendingPathExtension("svg")
+        try svg.write(to: url, atomically: true, encoding: .utf8)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
+        let content = try String(contentsOf: url)
+        XCTAssertTrue(content.contains("<svg"))
+    }
+
+    func testImageRendererProducesFile() throws {
+        let view = Text("Img")
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).appendingPathExtension("png")
+        ImageRenderer.renderToPNG(view, to: url.path)
+        if FileManager.default.fileExists(atPath: url.path) {
+            let data = try Data(contentsOf: url)
+            XCTAssertFalse(data.isEmpty)
+        } else {
+            let alt = URL(fileURLWithPath: url.path.replacingOccurrences(of: ".png", with: ".svg"))
+            XCTAssertTrue(FileManager.default.fileExists(atPath: alt.path))
+            let content = try String(contentsOf: alt)
+            XCTAssertTrue(content.contains("<svg"))
+        }
+    }
+}

--- a/repos/teatro/Tests/StoryboardDSLTests/StoryboardDSLTests.swift
+++ b/repos/teatro/Tests/StoryboardDSLTests/StoryboardDSLTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import Teatro
+
+final class StoryboardDSLTests: XCTestCase {
+    func testStoryboardBuilderCreatesSteps() {
+        let storyboard = Storyboard {
+            Scene("First") { Text("A") }
+            Transition(style: .crossfade, frames: 1)
+            Scene("Second") { Text("B") }
+        }
+        XCTAssertEqual(storyboard.steps.count, 3)
+    }
+
+    func testFramesGenerationMatchesScenesAndTransitions() {
+        let storyboard = Storyboard {
+            Scene("Start") { Text("A") }
+            Transition(style: .crossfade, frames: 1)
+            Scene("End") { Text("B") }
+        }
+        let frames = storyboard.frames()
+        XCTAssertEqual(frames.count, 3)
+        XCTAssertEqual(frames[0].render(), "A")
+        XCTAssertEqual(frames[1].render(), "A")
+        XCTAssertEqual(frames[2].render(), "B")
+    }
+}


### PR DESCRIPTION
## Summary
- add Storyboard DSL tests to exercise frames() output
- add MIDI DSL tests verifying MIDIRenderer file output
- add Renderer tests ensuring SVG and image files are produced
- include new test targets in `Package.swift`

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_68839c5107948325839c43f34a27659a