### PR TITLE
Update Teatro CLI docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Use `deploy/dispatcher_v2.py` as the default execution path under Docker or syst
 - [Code Reference](docs/handbook/code_reference.md) – links to inline API docs.
 - [History and Roadmap](docs/handbook/history.md) – how the project evolved and what's next.
 - [TeatroPlayground GUI Plan](docs/teatro_playground_gui_plan.md) – draft plan for a Teatro-based GUI.
+- [Teatro CLI Guide](repos/teatro/Docs/CLIIntegration/README.md) – how to render views from the command line.
 - [FountainAI Playground Guidelines](docs/fountainai_playground_guidelines.md) – rules for safe UI prototyping.
 - [Future Vision](docs/future_vision.md) – long-term FountainAI platform.
 
@@ -43,6 +44,6 @@ For an explanation of each variable and how to generate tokens, see the [setup g
 ## From Codex to FountainAI
 While deployment remains central, the repository now serves as the codex‑FountainAI maintainer and GPT contributor. For an overview of the broader FountainAI platform and its APIs, see [docs/future_vision.md](docs/future_vision.md).
 
-`````text
+``````text
 ©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
-`````
+``````

--- a/repos/teatro/Docs/CLIIntegration/README.md
+++ b/repos/teatro/Docs/CLIIntegration/README.md
@@ -8,7 +8,7 @@ The Teatro View Engine includes a lightweight command-line interface (CLI) imple
 
 ```swift
 public enum RenderTarget: String {
-    case html, svg, svgAnimated = "svg-animated", png, markdown, codex
+    case html, svg, png, markdown, codex, svgAnimated
 }
 ```
 
@@ -37,6 +37,23 @@ public struct RenderCLI {
             print(MarkdownRenderer.render(view))
         case .codex:
             print(CodexPreviewer.preview(view))
+        case .svgAnimated:
+            let storyboard = Storyboard {
+                Scene("One") {
+                    VStack(alignment: .center) {
+                        Text("Teatro", style: .bold)
+                        Text("SVG Animation Demo")
+                    }
+                }
+                Transition(style: .crossfade, frames: 10)
+                Scene("Two") {
+                    VStack(alignment: .center) {
+                        Text("Scene Two")
+                    }
+                }
+            }
+
+            print(SVGAnimator.renderAnimatedSVG(storyboard: storyboard))
         }
     }
 }
@@ -49,11 +66,16 @@ public struct RenderCLI {
 ```bash
 swift run RenderCLI html
 swift run RenderCLI svg
-swift run RenderCLI svg-animated
+swift run RenderCLI svgAnimated
 swift run RenderCLI png
 swift run RenderCLI markdown
 swift run RenderCLI codex
 ```
+
+If no argument is provided, the CLI defaults to the `codex` renderer.
+
+The output width and height can be adjusted through environment variables:
+`TEATRO_SVG_WIDTH`, `TEATRO_SVG_HEIGHT`, `TEATRO_IMAGE_WIDTH`, and `TEATRO_IMAGE_HEIGHT`.
 
 The `svg-animated` target converts a multi-scene `Storyboard` into a single
 animated `.svg` file. This differs from `svg` (static) and `png` (individual
@@ -70,6 +92,6 @@ This CLI is ideal for:
 Unauthorized copying or distribution is strictly prohibited.
 ```
 
-````text
+`````text
 ©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
-````
+`````


### PR DESCRIPTION
## Summary
- document `svgAnimated` target in the CLI guide
- explain default renderer and environment variables
- add link to the CLI guide in the project README

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6883a31f9a148325aa0711ed01d8818a