### PR TITLE
Fix build by removing isOpaque assignment on macOS

### DIFF
--- a/repos/TeatroPreviewUI/Sources/TeatroPreviewUI/AnimatedSVGPreview.swift
+++ b/repos/TeatroPreviewUI/Sources/TeatroPreviewUI/AnimatedSVGPreview.swift
@@ -13,7 +13,6 @@ public struct AnimatedSVGPreview: NSViewRepresentable {
 
     public func makeNSView(context: Context) -> WKWebView {
         let webView = WKWebView()
-        webView.isOpaque = false
         webView.setValue(false, forKey: "drawsBackground")
         return webView
     }


### PR DESCRIPTION
## Summary
- remove unsupported assignment to `isOpaque` for macOS web view

## Testing
- `swift build`

------
https://chatgpt.com/codex/tasks/task_e_68849c036b1083258e030949271a3971