### PR TITLE
Fix Teatro dependency handling

### DIFF
--- a/repos/TeatroPlayground/Package.swift
+++ b/repos/TeatroPlayground/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .executable(name: "TeatroPlayground", targets: ["TeatroPlayground"])
     ],
     dependencies: [
-        .package(path: "../teatro")
+        .package(url: "https://github.com/fountain-coach/teatro.git", branch: "main")
     ],
     targets: [
         .target(

--- a/repos/fountainai/ScreenplayGUI/Package.swift
+++ b/repos/fountainai/ScreenplayGUI/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
     platforms: [.macOS(.v14)],
     products: products,
     dependencies: [
-        .package(path: "../../teatro")
+        .package(url: "https://github.com/fountain-coach/teatro.git", branch: "main")
     ],
     targets: targets
 )


### PR DESCRIPTION
## Summary
- use GitHub URL for Teatro dependency in `TeatroPlayground`
- use GitHub URL for Teatro dependency in `ScreenplayGUI`

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*
- `swift build` *(fails: cannot find type 'FountainElementType' in scope)*

------
https://chatgpt.com/codex/tasks/task_e_68849ee6e2c88325ace097751e887b7c