### PR TITLE
Improve Teatro docs coverage

### DIFF
--- a/repos/teatro/Docs/AnimationSystem/README.md
+++ b/repos/teatro/Docs/AnimationSystem/README.md
@@ -63,6 +63,35 @@ instead of a directory of PNG frames. Pass a `Storyboard` containing transitions
 `<animateTransform>` within the resulting SVG. This is convenient for embedding
 web previews or converting to `.gif` using rasterizers.
 
+### 5.2.1 SVG Animation Primitives
+
+The animated SVG backend is built from a few helper structs:
+
+```swift
+public struct SVGAnimate {
+    public let attributeName: String
+    public let from: String
+    public let to: String
+    public let dur: Double
+    public let repeatCount: String?
+    public func render() -> String { /* ... */ }
+}
+
+public struct SVGAnimateTransform {
+    public let type: String
+    public let from: String
+    public let to: String
+    public let dur: Double
+    public func render() -> String { /* ... */ }
+}
+
+public struct SVGDelta {
+    public let id: String
+    public let animations: [String]
+    public func render() -> String { animations.joined(separator: "\n") }
+}
+```
+
 ---
 
 This animation system works especially well for:
@@ -93,6 +122,6 @@ playback.
 Unauthorized copying or distribution is strictly prohibited.
 ```
 
-`````text
+``````text
 ©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
-`````
+``````

--- a/repos/teatro/Docs/CLIIntegration/README.md
+++ b/repos/teatro/Docs/CLIIntegration/README.md
@@ -8,7 +8,7 @@ The Teatro View Engine includes a lightweight command-line interface (CLI) imple
 
 ```swift
 public enum RenderTarget: String {
-    case html, svg, png, markdown, codex, svgAnimated
+    case html, svg, png, markdown, codex, svgAnimated, csound, ump
 }
 ```
 
@@ -54,6 +54,13 @@ public struct RenderCLI {
             }
 
             print(SVGAnimator.renderAnimatedSVG(storyboard: storyboard))
+        case .csound:
+            let cs = CsoundScore(orchestra: "f 1 0 0 10 1", score: "i1 0 1 0.5")
+            CsoundRenderer.renderToFile(cs)
+        case .ump:
+            let notes = [MIDI2Note(channel: 0, note: 60, velocity: 0.8, duration: 1.0)]
+            let packets = notes.flatMap { UMPEncoder.encode($0) }
+            print(packets)
         }
     }
 }
@@ -70,6 +77,8 @@ swift run RenderCLI svgAnimated
 swift run RenderCLI png
 swift run RenderCLI markdown
 swift run RenderCLI codex
+swift run RenderCLI csound
+swift run RenderCLI ump
 ```
 
 If no argument is provided, the CLI defaults to the `codex` renderer.
@@ -79,7 +88,9 @@ The output width and height can be adjusted through environment variables:
 
 The `svg-animated` target converts a multi-scene `Storyboard` into a single
 animated `.svg` file. This differs from `svg` (static) and `png` (individual
-frame images) by embedding `<animate>` elements directly in the output.
+frame images) by embedding `<animate>` elements directly in the output. The
+`csound` and `ump` targets output Csound score files and Universal MIDI Packets
+respectively.
 
 This CLI is ideal for:
 - Previewing scenes, tests, or examples from terminal
@@ -92,6 +103,6 @@ This CLI is ideal for:
 Unauthorized copying or distribution is strictly prohibited.
 ```
 
-`````text
+``````text
 ©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
-`````
+``````

--- a/repos/teatro/Docs/ViewTypes/README.md
+++ b/repos/teatro/Docs/ViewTypes/README.md
@@ -114,6 +114,81 @@ public struct TeatroIcon: Renderable {
 ---
 
 ```
+
+### 2.6 Panel
+
+A rectangular container specifying width, height and optional corner radius.
+
+```swift
+public struct Panel: Renderable {
+    public let width: Int
+    public let height: Int
+    public let cornerRadius: Int
+    public let content: [Renderable]
+
+    public init(width: Int, height: Int, cornerRadius: Int = 0, @ViewBuilder content: () -> [Renderable]) {
+        self.width = width
+        self.height = height
+        self.cornerRadius = cornerRadius
+        self.content = content()
+    }
+
+    public func render() -> String {
+        "[Panel \(width)x\(height) r:\(cornerRadius)]\n" + content.map { $0.render() }.joined(separator: "\n")
+    }
+}
+```
+
+### 2.7 Dot, Rule and InputCursor
+
+Utility views for simple terminal style rendering.
+
+```swift
+public struct Dot: Renderable {
+    public let color: String
+    public let diameter: Int
+    public init(color: String = "black", diameter: Int = 10) { ... }
+    public func render() -> String { "\u{25CF}" }
+}
+
+public struct Rule: Renderable {
+    public init() {}
+    public func render() -> String { String(repeating: "-", count: 10) }
+}
+
+public struct InputCursor: Renderable {
+    public init() {}
+    public func render() -> String { "|" }
+}
+```
+
+### 2.8 DispatcherPrompt
+
+An example composite view combining the basic elements into a structured layout used by the Codex deployment loop.
+
+```swift
+public struct DispatcherPrompt: Renderable {
+    public init() {}
+    public func render() -> String {
+        Stage(title: "Dispatcher") {
+            Panel(width: 640, height: 900, cornerRadius: 12) {
+                VStack(alignment: .leading) {
+                    Dot(color: "green", diameter: 10)
+                    Rule()
+                    Text("<content>")
+                    Rule()
+                    InputCursor()
+                }
+            }
+        }.render()
+    }
+}
+```
+```
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````


### PR DESCRIPTION
## Summary
- document additional Teatro view types: Panel, Dot, Rule, InputCursor and DispatcherPrompt
- update CLI documentation with `csound` and `ump` targets
- document SVG animation primitives in the animation system guide

## Testing
- `swift test -q`


------
https://chatgpt.com/codex/tasks/task_e_6884b4dc0c74832580b2a51989700c30