### PR TITLE
Fix MIDIAudioEngine globals main-actor isolation

### DIFF
--- a/repos/TeatroPlayground/Package.swift
+++ b/repos/TeatroPlayground/Package.swift
@@ -10,7 +10,8 @@ let package = Package(
         .executable(name: "TeatroPlayground", targets: ["TeatroPlayground"])
     ],
     dependencies: [
-        .package(url: "https://github.com/fountain-coach/teatro.git", branch: "main")
+        // Use the local Teatro package to access latest Storyboard APIs
+        .package(path: "../teatro")
     ],
     targets: [
         .target(

--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundCore/MIDIAudioEngine.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundCore/MIDIAudioEngine.swift
@@ -4,7 +4,9 @@ import AVFoundation
 import Teatro
 
 public struct MIDIAudioEngine {
+    @MainActor
     private static var engine: AVAudioEngine?
+    @MainActor
     private static var sampler: AVAudioUnitSampler?
 
     public static func start() {


### PR DESCRIPTION
## Summary
- mark global audio engine properties as `@MainActor` in `TeatroPlaygroundCore`
- use local Teatro package so Storyboard APIs compile on Linux

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6885b26aa1008325b9d48019ca352b2c