### PR TITLE
Fix MIDI note type in MIDIAudioEngine

### DIFF
--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundCore/MIDIAudioEngine.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundCore/MIDIAudioEngine.swift
@@ -27,11 +27,11 @@ public struct MIDIAudioEngine {
         }
     }
 
-    public static func play(note: MIDINote) {
+    public static func play(note: MIDI2Note) {
         guard let sampler else { return }
 
         let midiNote = UInt8(note.note)
-        let velocity = UInt8(note.velocity)
+        let velocity = UInt8(max(0, min(127, Int(note.velocity * 127))))
         let channel = UInt8(note.channel)
 
         sampler.startNote(midiNote, withVelocity: velocity, onChannel: channel)


### PR DESCRIPTION
## Summary
- use `MIDI2Note` in `MIDIAudioEngine.play(note:)`
- convert `Float` velocity to UInt8

## Testing
- `swift build` in `repos/TeatroPlayground`
- `swift test` in `repos/TeatroPlayground`


------
https://chatgpt.com/codex/tasks/task_e_6885e69c3108832586388e5b0c45dcf8