### PR TITLE
Fix MIDI note conversion in TeatroPlayerView

### DIFF
--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/TeatroPlayerView.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/TeatroPlayerView.swift
@@ -78,7 +78,15 @@ public struct TeatroPlayerView: View {
 
         let note = midiSequence.notes[index]
 #if canImport(AVFoundation)
-        MIDIAudioEngine.play(note: note)
+        let midi2 = MIDI2Note(
+            channel: note.channel,
+            note: note.note,
+            velocity: Float(note.velocity) / 127.0,
+            duration: note.duration
+        )
+        Task {
+            await MIDIAudioEngine.play(note: midi2)
+        }
 #endif
         let duration = note.duration
 


### PR DESCRIPTION
## Summary
- convert `MIDINote` objects to `MIDI2Note` before playback

## Testing
- `swift build` for Teatro
- `swift test -v` for Teatro
- `swift build` for TeatroPlayground
- `swift test -v` for TeatroPlayground

------
https://chatgpt.com/codex/tasks/task_e_6885f15f11d48325b26ac7811348a048