### PR TITLE
Fix RendererShowcaseView isolation

### DIFF
--- a/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/RendererShowcaseView.swift
+++ b/repos/TeatroPlayground/Sources/TeatroPlaygroundUI/RendererShowcaseView.swift
@@ -17,7 +17,7 @@ public struct RendererShowcaseView: View, Renderable {
         }
     }
 
-    public func render() -> String {
+    public nonisolated func render() -> String {
         RendererShowcase().render()
     }
 


### PR DESCRIPTION
## Summary
- mark `render()` in `RendererShowcaseView` as `nonisolated`

## Testing
- `swift build -c debug`
- `swift test -c debug`


------
https://chatgpt.com/codex/tasks/task_e_6885f3330e548325a53ccad7d5dc3259