### PR TITLE
docs: mention MIDI 2 sampler in Teatro docs

### DIFF
--- a/repos/teatro/Docs/Chapters/13_Summary.md
+++ b/repos/teatro/Docs/Chapters/13_Summary.md
@@ -18,15 +18,16 @@ The **Teatro View Engine** is a modular, fully declarative view system written i
 - 🆕 **Animated SVG Export**  
   Teatro now supports generating `<svg>` files with embedded `<animate>` transitions via `SVGAnimator.renderAnimatedSVG(...)`. Ideal for previewing UI timelines, scene transitions, or GPT-driven visual reasoning.
 
-- **Music Rendering**  
+- **Music Rendering**
   - **LilyPond:** Printable PDF sheet music from `LilyScore` views.
   - **MIDI 2.0 Sandbox:** expressive sequencing via `MIDI2Note`, `MIDISequence`, `UMPEncoder`, and `CsoundScore`.
+  - **TeatroSampler:** cross-platform MIDI 2 sampler with a compatibility bridge for legacy formats.
   
   - **Screenplay Rendering**
     - `.fountain` parsing into typed screenplay elements
     - `FountainSceneView` enables GPT-authored scripts to be staged and animated
-  - 🎬 **Teatro Animation Player**  
-    Play animated sequences of Teatro views in real-time, driven by MIDI timing. Includes visual transitions, frame-level commentary, and synchronized audio via AVFoundation.
+  - 🎬 **Teatro Animation Player**
+    Play animated sequences of Teatro views in real-time, driven by MIDI timing. Includes visual transitions, frame-level commentary, and synchronized audio via `TeatroSampler`.
 
 ---
 

--- a/repos/teatro/Docs/ImplementationPlan/README.md
+++ b/repos/teatro/Docs/ImplementationPlan/README.md
@@ -8,6 +8,8 @@ This roadmap converts the critique and analysis of the Teatro View Engine into c
    - Introduce `MIDI2Note` and `UMPEncoder` to generate Universal MIDI Packets.
    - Provide a `CsoundScore` view type and `CsoundRenderer` for `.csd` output.
    - Extend `RenderCLI` with `csound` and `ump` targets and add tests for the generated files.
+   - Implement `TeatroSampler` for cross-platform MIDI 2 playback.
+   - Add `MIDICompatibilityBridge` to convert sampler events into `MIDINote`, `CsoundScore`, and `LilyScore`.
 2. **GIF Export**
    - Extend `Animator` with a helper for `.gif` generation using ImageMagick or a Swift wrapper.
    - Document required tools and provide a sample test that produces an animated gif from frame PNGs.

--- a/repos/teatro/Docs/Summary/README.md
+++ b/repos/teatro/Docs/Summary/README.md
@@ -18,15 +18,16 @@ The **Teatro View Engine** is a modular, fully declarative view system written i
 - 🆕 **Animated SVG Export**  
   Teatro now supports generating `<svg>` files with embedded `<animate>` transitions via `SVGAnimator.renderAnimatedSVG(...)`. Ideal for previewing UI timelines, scene transitions, or GPT-driven visual reasoning.
 
-- **Music Rendering**  
+- **Music Rendering**
   - **LilyPond:** Printable PDF sheet music from `LilyScore` views.
   - **MIDI 2.0 Sandbox:** expressive sequencing via `MIDI2Note`, `MIDISequence`, `UMPEncoder`, and `CsoundScore`.
+  - **TeatroSampler:** cross-platform MIDI 2 sampler with a compatibility bridge for legacy formats.
   
   - **Screenplay Rendering**
     - `.fountain` parsing into typed screenplay elements
     - `FountainSceneView` enables GPT-authored scripts to be staged and animated
-  - 🎬 **Teatro Animation Player**  
-    Play animated sequences of Teatro views in real-time, driven by MIDI timing. Includes visual transitions, frame-level commentary, and synchronized audio via AVFoundation.
+  - 🎬 **Teatro Animation Player**
+    Play animated sequences of Teatro views in real-time, driven by MIDI timing. Includes visual transitions, frame-level commentary, and synchronized audio via `TeatroSampler`.
 
 ---
 

--- a/repos/teatro/README.md
+++ b/repos/teatro/README.md
@@ -22,6 +22,7 @@ Then include `Teatro` as a dependency in your target.
 - [Animation System](Docs/AnimationSystem/README.md)
 - [LilyPond Music Rendering](Docs/LilyPondMusicRendering/README.md)
 - [MIDI 2.0 DSL](Docs/MIDI20DSL/README.md)
+- [TeatroSampler](Docs/TeatroPlayer/README.md#enabling-audio)
 - [Fountain Screenplay Engine](Docs/FountainScreenplayEngine/README.md)
 - [Fountain Parser Implementation Plan](Docs/FountainScreenplayEngine/FountainParserImplementationPlan.md)
 - [View Implementation and Testing Plan](Docs/ViewImplementationPlan/README.md)
@@ -31,6 +32,8 @@ Then include `Teatro` as a dependency in your target.
 - [Summary](Docs/Summary/README.md)
 - [Addendum: Apple Platform Compatibility](Docs/Addendum/README.md)
 - [Mastering the Teatro Prompting Language for GUI Code Generation](https://chatgpt.com/share/68826ebf-64ac-8005-9b37-40d6e7187ea3)
+
+`TeatroSampler` provides cross-platform MIDI 2 playback for the animation player and bridges events to legacy formats when needed.
 
 The new **Storyboard DSL** allows you to script view states and animated transitions in Swift.  See the guide for an example of generating a textual storyboard preview that can be sent back to Codex.
 


### PR DESCRIPTION
## Summary
- document the new TeatroSampler across the docs
- update roadmap and summary with cross-platform sampler info
- link to TeatroSampler in the repo README

## Testing
- `swift build` in `repos/teatro`
- `swift test` in `repos/teatro`


------
https://chatgpt.com/codex/tasks/task_e_688666d6e0b883258d1ff3459d3db64a