### PR TITLE
Implement MIDI bridge for Csound and LilyPond

### DIFF
--- a/repos/teatro/Sources/Audio/MIDICompatibilityBridge.swift
+++ b/repos/teatro/Sources/Audio/MIDICompatibilityBridge.swift
@@ -13,12 +13,56 @@ public struct MIDICompatibilityBridge {
     }
 
     public static func toCsoundScore(_ event: MIDI2NoteEvent) -> CsoundScore {
-        let scoreLine = "i1 0 0.1 \(event.note) \(event.velocity)"
-        return CsoundScore(orchestra: "f 1 0 0 10 1", score: scoreLine)
+        let frequency = 440.0 * pow(2.0, (Double(event.pitch) - 69.0) / 12.0)
+        let amplitude = max(0.0, min(1.0, Double(event.velocity)))
+        let start = Double(event.timestamp) / 1000.0
+        let scoreLine = String(
+            format: "i1 %.3f %.3f %.3f %.3f",
+            start,
+            0.1,
+            frequency,
+            amplitude
+        )
+
+        let orchestra = """
+        f 1 0 0 10 1
+        instr 1
+            a1 oscili p4, p5, 1
+            outs a1, a1
+        endin
+        """
+
+        return CsoundScore(orchestra: orchestra, score: scoreLine)
     }
 
     public static func toLilyScore(_ event: MIDI2NoteEvent) -> LilyScore {
-        let lily = "c'" // simplified placeholder
+        let names = ["c", "cis", "d", "dis", "e", "f", "fis", "g", "gis", "a", "ais", "b"]
+        let value = Int(round(event.pitch))
+        let name = names[value % 12]
+        let octave = value / 12
+        var note = name
+        let baseOctave = 4
+        if octave > baseOctave {
+            note += String(repeating: "'", count: octave - baseOctave)
+        } else if octave < baseOctave {
+            note += String(repeating: ",", count: baseOctave - octave)
+        }
+        note += "4"
+
+        let dynamic: String
+        switch event.velocity {
+        case let v where v >= 0.9: dynamic = "\\ff"
+        case let v where v >= 0.7: dynamic = "\\f"
+        case let v where v >= 0.5: dynamic = "\\mf"
+        case let v where v >= 0.3: dynamic = "\\p"
+        default: dynamic = "\\pp"
+        }
+
+        let lily = """
+        \\version "2.24.2"
+        { \(dynamic) \(note) }
+        """
+
         return LilyScore(lily)
     }
 }

--- a/repos/teatro/Tests/SamplerTests/TeatroSamplerTests.swift
+++ b/repos/teatro/Tests/SamplerTests/TeatroSamplerTests.swift
@@ -32,4 +32,23 @@ final class TeatroSamplerTests: XCTestCase {
         XCTAssertEqual(midi1.note, 64)
         XCTAssertEqual(midi1.velocity, 127)
     }
+
+    func testCompatibilityBridgeCsound() {
+        let event = MIDI2NoteEvent(channel: 0, note: 60, velocity: 0.5,
+                                   pitch: 60, timbre: SIMD4<Float>(0,0,0,0),
+                                   articulation: "none", timestamp: 0)
+        let cs = MIDICompatibilityBridge.toCsoundScore(event)
+        let rendered = cs.render()
+        XCTAssertTrue(rendered.contains("i1"))
+        XCTAssertTrue(rendered.contains("261.626"))
+    }
+
+    func testCompatibilityBridgeLily() {
+        let event = MIDI2NoteEvent(channel: 0, note: 60, velocity: 0.8,
+                                   pitch: 60, timbre: SIMD4<Float>(0,0,0,0),
+                                   articulation: "none", timestamp: 0)
+        let lily = MIDICompatibilityBridge.toLilyScore(event)
+        let content = lily.render()
+        XCTAssertTrue(content.contains("c'4"))
+    }
 }


### PR DESCRIPTION
## Summary
- implement full conversions in `MIDICompatibilityBridge`
- add unit tests for Csound and LilyPond bridges

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_688690d6bfd083258ae5e178e8bef179