### PR TITLE
Add TeatroSampler docs

### DIFF
--- a/repos/teatro/Docs/Chapters/16_TeatroSampler.md
+++ b/repos/teatro/Docs/Chapters/16_TeatroSampler.md
@@ -1,0 +1,27 @@
+## 16. TeatroSampler
+
+The **TeatroSampler** provides cross-platform MIDI 2 playback for the animation player. It routes `MIDI2Note` events to backend implementations and keeps audio and visuals in sync.
+
+### 16.1 Overview
+- Actor-based design conforming to `SampleSource`.
+- Built-in backends: `FluidSynthSampler` for SoundFont files and `CsoundSampler` for Csound orchestras.
+- `TeatroSamplerDemo` shows triggering notes with FluidSynth.
+
+### 16.2 Proposal vs. Implementation
+The [MIDI 2.0-Native Sampler](../Proposals/🎼%20Proposal%20MIDI%202.0-Native%20Sampler%20for%20the%20FountainAI%20Teatro.md) proposal describes a full OpenAPI service and dynamic voice actors. The current code implements the actor model and compatibility bridge but lacks the OpenAPI layer.
+
+### 16.3 Using the sampler
+```swift
+let sampler = try await TeatroSampler(backend: .fluidsynth(sf2Path: "synth.sf2"))
+await sampler.trigger(MIDI2Note(channel: 0, note: 60, velocity: 0.8, duration: 1.0))
+```
+Call `stopAll()` when playback completes.
+
+```
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````

--- a/repos/teatro/Docs/TeatroSampler/README.md
+++ b/repos/teatro/Docs/TeatroSampler/README.md
@@ -1,0 +1,27 @@
+## 16. TeatroSampler
+
+The **TeatroSampler** provides cross-platform MIDI 2 playback for the animation player. It routes `MIDI2Note` events to backend implementations and keeps audio and visuals in sync.
+
+### 16.1 Overview
+- Actor-based design conforming to `SampleSource`.
+- Built-in backends: `FluidSynthSampler` for SoundFont files and `CsoundSampler` for Csound orchestras.
+- `TeatroSamplerDemo` shows triggering notes with FluidSynth.
+
+### 16.2 Proposal vs. Implementation
+The [MIDI 2.0-Native Sampler](../Proposals/🎼%20Proposal%20MIDI%202.0-Native%20Sampler%20for%20the%20FountainAI%20Teatro.md) proposal describes a full OpenAPI service and dynamic voice actors. The current code implements the actor model and compatibility bridge but lacks the OpenAPI layer.
+
+### 16.3 Using the sampler
+```swift
+let sampler = try await TeatroSampler(backend: .fluidsynth(sf2Path: "synth.sf2"))
+await sampler.trigger(MIDI2Note(channel: 0, note: 60, velocity: 0.8, duration: 1.0))
+```
+Call `stopAll()` when playback completes.
+
+```
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```
+
+````text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````

--- a/repos/teatro/README.md
+++ b/repos/teatro/README.md
@@ -22,7 +22,7 @@ Then include `Teatro` as a dependency in your target.
 - [Animation System](Docs/AnimationSystem/README.md)
 - [LilyPond Music Rendering](Docs/LilyPondMusicRendering/README.md)
 - [MIDI 2.0 DSL](Docs/MIDI20DSL/README.md)
-- [TeatroSampler](Docs/TeatroPlayer/README.md#enabling-audio)
+- [TeatroSampler](Docs/TeatroSampler/README.md)
 - [Fountain Screenplay Engine](Docs/FountainScreenplayEngine/README.md)
 - [Fountain Parser Implementation Plan](Docs/FountainScreenplayEngine/FountainParserImplementationPlan.md)
 - [View Implementation and Testing Plan](Docs/ViewImplementationPlan/README.md)


### PR DESCRIPTION
## Summary
- document TeatroSampler in its own chapter
- link new doc from README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887a4daa11c8325bfb93c79c6dabe39