### PR TITLE
Deprecate Python dispatcher

### DIFF
--- a/docs/dispatcher_v2.md
+++ b/docs/dispatcher_v2.md
@@ -1,6 +1,8 @@
 # Dispatcher v2.4
 
 `dispatcher_v2.py` is the second major iteration of the Codex deployment loop.
+**Deprecated:** this Python implementation will be replaced by a Swift-based
+orchestrator loop. Keep using it only until the new loop is documented.
 Version 2.4 extends the previous release with build result checks, log rotation,
 automatic patch application, a pull request workflow, and platform-aware compilation.
 
@@ -54,3 +56,8 @@ The dispatcher runs this script so local results match CI.
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```
+
+````text
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/handbook/code_reference.md
+++ b/docs/handbook/code_reference.md
@@ -8,7 +8,7 @@ it consumes the variables listed in [../environment_variables.md](../environment
 
 ## Python Modules
 
-- [`deploy/dispatcher_v2.py`](../../deploy/dispatcher_v2.py) – main deployment loop
+- [`deploy/dispatcher_v2.py`](../../deploy/dispatcher_v2.py) – main deployment loop *(deprecated; to be replaced by the Swift orchestrator)*
 - [`analyze_swift_log.py`](../../analyze_swift_log.py) – build log analyzer
 
 View the dispatcher API with:
@@ -27,3 +27,9 @@ with `swift package generate-documentation` once the build pipeline is enabled.
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```
+
+````text
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+
+

--- a/docs/handbook/introduction.md
+++ b/docs/handbook/introduction.md
@@ -16,7 +16,7 @@ This introduction summarises the core concepts and explains how environment vari
 ## Core Concepts
 
 1. **Git as the source of truth** – All services live under `repos/` in this repository. The dispatcher pulls updates and commits any changes, so the repo history is the single point of reference.
-2. **Python dispatcher loop** – `deploy/dispatcher_v2.py` runs continuously under systemd or inside Docker. It builds services, runs tests, and writes logs under `deploy/logs/`.
+2. **Python dispatcher loop** – `deploy/dispatcher_v2.py` runs continuously under systemd or inside Docker. **Deprecated:** this loop will be replaced by a Swift orchestrator. It currently builds services, runs tests, and writes logs under `deploy/logs/`.
 3. **Semantic feedback** – After each cycle, JSON placed in `feedback/` can modify the code or restart services. This allows Codex to iterate automatically based on build results.
 4. **Cross-platform workflow** – The same loop works on macOS or Linux. Optional Docker Compose tests run when `DISPATCHER_RUN_E2E=1`.
 
@@ -57,3 +57,9 @@ The [handbook README](README.md) contains a complete table of contents with link
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```
+
+````text
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+
+

--- a/docs/mac_docker_tutorial.md
+++ b/docs/mac_docker_tutorial.md
@@ -1,6 +1,7 @@
 # Running codex-deployer locally on macOS with Docker
 
 This tutorial demonstrates how to start the deployment loop on a Mac using Docker Desktop. It mirrors the expected `/srv/deploy` layout without installing dependencies directly on your host.
+**Deprecated:** the instructions below use the Python dispatcher. A Swift orchestrator loop will replace it soon.
 For an overview of how the dispatcher adapts to macOS and Linux see the [handbook introduction](handbook/introduction.md#managing-platform-diversity).
 
 ## Prerequisites
@@ -110,3 +111,4 @@ Unauthorized copying or distribution is strictly prohibited.
 ````text
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
 ````
+

--- a/docs/mac_local_testing.md
+++ b/docs/mac_local_testing.md
@@ -2,6 +2,7 @@
 
 This guide shows how to run the Codex deployer on a Mac so you can execute service tests locally.
 It builds a small Docker image and starts `dispatcher_v2.py` with environment variables exported from `dispatcher.env`.
+**Deprecated:** this Python workflow will be replaced by a Swift orchestrator loop.
 For a broader overview of available guides see [docs/handbook](handbook/README.md).
 See [environment_variables.md](environment_variables.md) for the full list of variables.
 
@@ -76,3 +77,8 @@ Press `Ctrl-C` in the terminal running the container to stop the dispatcher.
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```
+
+````text
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/docs/managing_environment_variables.md
+++ b/docs/managing_environment_variables.md
@@ -1,6 +1,8 @@
 # Managing Environment Variables
 
 This guide explains how to configure the environment variables required by `dispatcher_v2.py`.
+**Deprecated:** the Python dispatcher is being retired. These settings remain for
+legacy deployments until the Swift orchestrator loop is documented.
 It complements [environment_variables.md](environment_variables.md) with step‑by‑step setup instructions.
 
 ## 1. Create `dispatcher.env`
@@ -103,3 +105,8 @@ Using a token avoids interactive Git prompts when cloning private repositories.
 © 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
 Unauthorized copying or distribution is strictly prohibited.
 ```
+
+````text
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+````
+

--- a/systemd/dispatcher.env
+++ b/systemd/dispatcher.env
@@ -1,4 +1,6 @@
 # Environment variables for fountain-dispatcher.service
+# DEPRECATED: These settings apply to the legacy Python dispatcher.
+# The upcoming Swift orchestrator will introduce a new configuration scheme.
 # See docs/environment_variables.md for details on each variable.
 DISPATCHER_INTERVAL=60
 DISPATCHER_USE_PRS=1
@@ -11,3 +13,6 @@ OPENAI_API_KEY=
 # Git identity for commits (defaults used if empty)
 GIT_USER_NAME=
 GIT_USER_EMAIL=
+
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+

--- a/systemd/fountain-dispatcher.service
+++ b/systemd/fountain-dispatcher.service
@@ -1,9 +1,13 @@
 [Unit]
+# DEPRECATED: Python-based dispatcher service. This unit will be removed once
+# the Swift orchestrator loop ships.
 Description=Codex FountainAI Deployment Dispatcher
 After=network.target
 
 [Service]
 EnvironmentFile=/srv/deploy/dispatcher.env
+# TODO: replace the Python entry point below with the Swift orchestrator once
+# it is available.
 ExecStart=/usr/bin/python3 /srv/deploy/deploy/dispatcher_v2.py
 WorkingDirectory=/srv/deploy
 Restart=always
@@ -11,3 +15,6 @@ User=root
 
 [Install]
 WantedBy=multi-user.target
+
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+

--- a/utils/bootstrap.sh
+++ b/utils/bootstrap.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# DEPRECATED: This script bootstraps the legacy Python dispatcher environment.
+# TODO: replace with setup steps for the Swift orchestrator loop.
 
 set -e
 
@@ -28,3 +30,7 @@ systemctl enable fountain-dispatcher
 systemctl start fountain-dispatcher
 
 echo "[BOOTSTRAP] Done. Codex deployment loop is now running."
+
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+
+

--- a/utils/deploy/dispatcher_v2.py
+++ b/utils/deploy/dispatcher_v2.py
@@ -1,6 +1,11 @@
 """Dispatcher v2.4
 ===================
 
+.. deprecated:: 2025-07-29
+   This Python dispatcher is being phased out in favour of a Swift-based
+   orchestrator loop. Keep this file only for legacy deployments.
+   TODO: remove once the Swift orchestrator ships.
+
 An improved deployment dispatcher for Codex. Version 2.4 adds
 
 basic build result checking, log rotation, automatic patch
@@ -499,4 +504,7 @@ def loop() -> None:
 
 if __name__ == "__main__":
     loop()
+
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+
 


### PR DESCRIPTION
## Summary
- note deprecation of legacy dispatcher assets
- add TODO comments on moving to Swift orchestrator
- document deprecation across tutorials

## Testing
- `python3 -m py_compile utils/deploy/dispatcher_v2.py`
- `shellcheck utils/bootstrap.sh`

------
https://chatgpt.com/codex/tasks/task_e_688892d9b75083259ea5b1b974db806d