### PR TITLE
Restore FountainAI OpenAPI and generated clients/servers

### DIFF
--- a/Sources/FountainOps/FountainAi/openAPI/README.md
+++ b/Sources/FountainOps/FountainAi/openAPI/README.md
@@ -1,0 +1,28 @@
+# FountainAI Service Catalog
+
+This directory contains the OpenAPI specifications for each FountainAI microservice. Specifications are grouped by API version so that multiple revisions can coexist.
+
+| Service | Entrypoint | Description | Spec |
+| --- | --- | --- | --- |
+| Baseline Awareness | http://awareness.fountain.coach/api/v1 | Manages baselines, drift, patterns, reflection data and semantic analytics. | [v1/baseline-awareness.yml](v1/baseline-awareness.yml) |
+| Bootstrap | http://bootstrap.fountain.coach/api/v1 | Initializes corpora, seeds GPT roles and adds baseline snapshots. Relies on the Awareness API to store initial artifacts. | [v1/bootstrap.yml](v1/bootstrap.yml) |
+| Function Caller | http://functions.fountain.coach/api/v1 | Maps OpenAI function-calling plans to HTTP operations. Retrieves definitions from the Tools Factory. | [v1/function-caller.yml](v1/function-caller.yml) |
+| LLM Gateway | http://llm-gateway.fountain.coach/api/v1 | Proxies requests to any LLM with function-calling support. Used by the Planner for LLM-driven tasks. | [v2/llm-gateway.yml](v2/llm-gateway.yml) |
+| Persistence | http://persist.fountain.coach/api/v1 | Typesense-backed store for baselines, drifts, reflections and registered tools. | [v1/persist.yml](v1/persist.yml) |
+| Planner | http://planner.fountain.coach/api/v1 | Orchestrates planning workflows across the LLM Gateway and Function Caller. | [v1/planner.yml](v1/planner.yml) |
+| Tools Factory | http://tools-factory.fountain.coach/api/v1 | Registers new tool definitions in the shared Typesense collection consumed by the Function Caller. | [v1/tools-factory.yml](v1/tools-factory.yml) |
+
+### Cross-service Interactions
+
+- **Bootstrap → Awareness**: bootstrap operations seed corpora and baseline snapshots by calling the Awareness API.
+- **Tools Factory → Function Caller**: the Tools Factory persists function definitions that the Function Caller dynamically invokes.
+- **Planner → LLM Gateway & Function Caller**: the Planner coordinates with the LLM Gateway for language model responses and triggers registered functions through the Function Caller.
+
+
+```
+© 2025 Contexter alias Benedikt Eickhoff, https://fountain.coach. All rights reserved.
+Unauthorized copying or distribution is strictly prohibited.
+```
+
+---
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/FountainAi/openAPI/v0/planner.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v0/planner.yml
@@ -1,0 +1,322 @@
+---
+openapi: 3.1.0
+info:
+  title: FountainAI Planner Service
+  description: >
+    Orchestrates LLM-driven planning workflows; all endpoints are
+    grouped by router tags.
+  version: 0.1.0
+servers:
+  - url: http://planner.fountain.coach/api/v1
+paths:
+  /planner/reason:
+    post:
+      tags:
+        - Planner
+      summary: Generate a plan from user objective
+      description: >
+        Accepts a high-level user objective and returns a step-by-step plan.
+      operationId: planner_reason
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserObjectiveRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlanResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /planner/execute:
+    post:
+      tags:
+        - Planner
+      summary: Execute a generated plan
+      description: >
+        Takes a plan (function-call list) and runs each step,
+        returning results.
+      operationId: planner_execute
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlanExecutionRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExecutionResult'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /planner/corpora:
+    get:
+      tags:
+        - Planner
+      summary: List available corpora
+      description: >
+        Returns the names/IDs of all corpora that the planner knows about.
+      operationId: planner_list_corpora
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                title: Response Planner List Corpora
+                items:
+                  type: string
+  /planner/reflections/{corpus_id}:
+    get:
+      tags:
+        - Reflections
+      summary: Fetch reflection history
+      description: Retrieve all stored reflections for a given corpus ID.
+      operationId: get_reflection_history
+      parameters:
+        - name: corpus_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HistoryListResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /planner/reflections/{corpus_id}/semantic-arc:
+    get:
+      tags:
+        - Reflections
+      summary: Fetch semantic arc
+      description: >
+        Retrieve the semantic arc for a given corpus ID (curated summary,
+        insights, etc.).
+      operationId: get_semantic_arc
+      parameters:
+        - name: corpus_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Get Semantic Arc
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /planner/reflections/:
+    post:
+      tags:
+        - Reflections
+      summary: Add a new reflection
+      description: Send a message to be reflected on and appended to the corpus.
+      operationId: post_reflection
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatReflectionRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReflectionItem'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    ChatReflectionRequest:
+      title: ChatReflectionRequest
+      type: object
+      required:
+        - corpus_id
+        - message
+      properties:
+        corpus_id:
+          type: string
+          title: Corpus Id
+        message:
+          type: string
+          title: Message
+    ExecutionResult:
+      title: ExecutionResult
+      description: The wrapper returned by /planner/execute.
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          title: Results
+          items:
+            $ref: '#/components/schemas/FunctionCallResult'
+    FunctionCall:
+      title: FunctionCall
+      type: object
+      required:
+        - name
+        - arguments
+      properties:
+        name:
+          type: string
+          title: Name
+        arguments:
+          type: object
+          title: Arguments
+          additionalProperties: true
+    FunctionCallResult:
+      title: FunctionCallResult
+      description: The response from executing a single FunctionCall.
+      type: object
+      required:
+        - step
+        - arguments
+        - output
+      properties:
+        step:
+          type: string
+          title: Step
+        arguments:
+          type: object
+          title: Arguments
+          additionalProperties: true
+        output:
+          title: Output
+    HTTPValidationError:
+      title: HTTPValidationError
+      type: object
+      properties:
+        detail:
+          type: array
+          title: Detail
+          items:
+            $ref: '#/components/schemas/ValidationError'
+    HistoryListResponse:
+      title: HistoryListResponse
+      type: object
+      required:
+        - reflections
+      properties:
+        reflections:
+          type: array
+          title: Reflections
+          items:
+            $ref: '#/components/schemas/ReflectionItem'
+    PlanExecutionRequest:
+      title: PlanExecutionRequest
+      description: >
+        Mirrors PlanResponse but used as the input to /planner/execute.
+      type: object
+      required:
+        - objective
+        - steps
+      properties:
+        objective:
+          type: string
+          title: Objective
+        steps:
+          type: array
+          title: Steps
+          items:
+            $ref: '#/components/schemas/FunctionCall'
+    PlanResponse:
+      title: PlanResponse
+      type: object
+      required:
+        - objective
+        - steps
+      properties:
+        objective:
+          type: string
+          title: Objective
+        steps:
+          type: array
+          title: Steps
+          items:
+            $ref: '#/components/schemas/FunctionCall'
+    ReflectionItem:
+      title: ReflectionItem
+      type: object
+      required:
+        - timestamp
+        - content
+      properties:
+        timestamp:
+          type: string
+          title: Timestamp
+        content:
+          type: string
+          title: Content
+    UserObjectiveRequest:
+      title: UserObjectiveRequest
+      type: object
+      required:
+        - objective
+      properties:
+        objective:
+          type: string
+          title: Objective
+    ValidationError:
+      title: ValidationError
+      type: object
+      required:
+        - loc
+        - msg
+        - type
+      properties:
+        loc:
+          type: array
+          title: Location
+          items:
+            anyOf:
+              - type: string
+              - type: integer
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/FountainAi/openAPI/v1/baseline-awareness.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/baseline-awareness.yml
@@ -1,0 +1,343 @@
+---
+openapi: 3.1.0
+info:
+  title: Baseline Awareness Service
+  description: >
+    Manages baselines, drift, patterns, reflection data,
+    and semantic analytics.
+  version: 1.0.0
+servers:
+  - url: http://awareness.fountain.coach/api/v1
+paths:
+  /health:
+    get:
+      summary: Health
+      operationId: health_health_get
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+  /corpus/init:
+    post:
+      summary: Initialize a new corpus
+      description: Creates a new corpus with the given corpus ID.
+      operationId: initializeCorpus
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InitIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InitOut'
+        '422':
+          description: Validation Error
+  /corpus/baseline:
+    post:
+      summary: Add Baseline
+      description: Adds a baseline text to the corpus.
+      operationId: addBaseline
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BaselineRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+        '422':
+          description: Validation Error
+  /corpus/drift:
+    post:
+      summary: Add Drift
+      description: Adds a drift document to the corpus.
+      operationId: addDrift
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DriftRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+        '422':
+          description: Validation Error
+  /corpus/patterns:
+    post:
+      summary: Add Patterns
+      description: Adds narrative patterns to the corpus.
+      operationId: addPatterns
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatternsRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+        '422':
+          description: Validation Error
+  /corpus/reflections:
+    post:
+      summary: Add Reflection
+      description: Adds a reflection item to the corpus.
+      operationId: addReflection
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReflectionRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+        '422':
+          description: Validation Error
+  /corpus/reflections/{corpus_id}:
+    get:
+      summary: List Reflections
+      description: Lists all reflections in the specified corpus.
+      operationId: listReflections
+      parameters:
+        - name: corpus_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Corpus Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReflectionSummaryResponse'
+        '422':
+          description: Validation Error
+  /corpus/history/{corpus_id}:
+    get:
+      summary: List History
+      description: Lists the change history of the specified corpus.
+      operationId: listHistory
+      parameters:
+        - name: corpus_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Corpus Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HistorySummaryResponse'
+        '422':
+          description: Validation Error
+  /corpus/summary/{corpus_id}:
+    get:
+      summary: Summarize History
+      description: Provides a semantic summary of the corpus history.
+      operationId: summarizeHistory
+      parameters:
+        - name: corpus_id
+          in: path
+          required: true
+          schema:
+            type: string
+          description: Corpus Id
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HistorySummaryResponse'
+        '422':
+          description: Validation Error
+  /corpus/history:
+    get:
+      tags:
+        - analytics
+      summary: Read History
+      description: >
+        Retrieve the timeline of all semantic entries for the given corpus.
+      operationId: listHistoryAnalytics
+      parameters:
+        - name: corpus_id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+        '422':
+          description: Validation Error
+  /corpus/semantic-arc:
+    get:
+      tags:
+        - analytics
+      summary: Read Semantic Arc
+      description: >
+        Construct and return the semantic arc based on the corpus history.
+      operationId: readSemanticArc
+      parameters:
+        - name: corpus_id
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+        '422':
+          description: Validation Error
+components:
+  schemas:
+    BaselineRequest:
+      type: object
+      title: BaselineRequest
+      required:
+        - corpusId
+        - baselineId
+        - content
+      properties:
+        corpusId:
+          type: string
+          title: Corpusid
+        baselineId:
+          type: string
+          title: Baselineid
+        content:
+          type: string
+          title: Content
+    DriftRequest:
+      type: object
+      title: DriftRequest
+      required:
+        - corpusId
+        - driftId
+        - content
+      properties:
+        corpusId:
+          type: string
+          title: Corpusid
+        driftId:
+          type: string
+          title: Driftid
+        content:
+          type: string
+          title: Content
+    HistorySummaryResponse:
+      type: object
+      title: HistorySummaryResponse
+      required:
+        - summary
+      properties:
+        summary:
+          type: string
+          title: Summary
+    InitIn:
+      type: object
+      title: InitIn
+      required:
+        - corpusId
+      properties:
+        corpusId:
+          type: string
+          title: Corpusid
+    InitOut:
+      type: object
+      title: InitOut
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          title: Message
+    PatternsRequest:
+      type: object
+      title: PatternsRequest
+      required:
+        - corpusId
+        - patternsId
+        - content
+      properties:
+        corpusId:
+          type: string
+          title: Corpusid
+        patternsId:
+          type: string
+          title: Patternsid
+        content:
+          type: string
+          title: Content
+    ReflectionRequest:
+      type: object
+      title: ReflectionRequest
+      required:
+        - corpusId
+        - reflectionId
+        - question
+        - content
+      properties:
+        corpusId:
+          type: string
+          title: Corpusid
+        reflectionId:
+          type: string
+          title: Reflectionid
+        question:
+          type: string
+          title: Question
+        content:
+          type: string
+          title: Content
+    ReflectionSummaryResponse:
+      type: object
+      title: ReflectionSummaryResponse
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          title: Message
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/FountainAi/openAPI/v1/bootstrap.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/bootstrap.yml
@@ -1,0 +1,332 @@
+---
+openapi: 3.1.0
+info:
+  title: FountainAI Bootstrap Service
+  description: Initialize corpora, seed GPT roles, and add semantic baselines.
+  version: 1.0.0
+servers:
+  - url: http://bootstrap.fountain.coach/api/v1
+paths:
+  /bootstrap/corpus/init:
+    post:
+      tags:
+        - Bootstrap
+      summary: "Bootstrap: Init Corpus + Seed Roles + Default Reflection"
+      description: |
+        1) Creates empty corpus via `/corpus-init` on Awareness.
+        2) Seeds default GPT roles via `/bootstrap/roles/seed`.
+        3) Enqueues the 'role-health-check' reflection via the Awareness
+           `/reflections` API.
+      operationId: bootstrapInitializeCorpus
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InitIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InitOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /bootstrap/roles/seed:
+    post:
+      tags:
+        - Bootstrap
+      summary: "Bootstrap: Seed GPT Roles"
+      description: >
+        Populates an existing corpus with the five default GPT role prompts.
+      operationId: bootstrapSeedRoles
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RoleInitRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoleDefaults'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /bootstrap/corpus/reflect:
+    post:
+      tags:
+        - Bootstrap
+      summary: "Bootstrap: Enqueue Default Reflection"
+      description: >
+        Enqueues the 'role-health-check' reflection into an existing corpus.
+      operationId: bootstrapEnqueueReflection
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InitIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InitOut'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /bootstrap/roles/promote:
+    post:
+      tags:
+        - Bootstrap
+      summary: "Bootstrap: Promote Reflection to Role"
+      description: >
+        Fetches the last 'role-health-check' reflection and
+        registers it as a new GPT role.
+      operationId: bootstrapPromoteReflection
+      parameters:
+        - name: corpusId
+          in: query
+          required: true
+          schema:
+            type: string
+            title: Corpusid
+        - name: roleName
+          in: query
+          required: true
+          schema:
+            type: string
+            title: Rolename
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoleInfo'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /bootstrap/baseline:
+    post:
+      tags:
+        - Bootstrap
+      summary: "Bootstrap: Add Baseline, Stream Analyses & Persist Results"
+      description: |
+        1) Stores your new baseline snapshot in the Awareness Service.
+        2) Immediately streams back two SSE channels:
+         • **drift** – your content’s drift analysis in real time,
+           then persisted as `<baselineId>-drift`.
+         • **patterns** – your narrative patterns analysis in real time,
+           then persisted as `<baselineId>-patterns`.
+        3) Once streaming finishes, fire-and-forget jobs enqueue:
+         • **history** aggregation (via `/analytics/history`)
+         • **semantic-arc** synthesis (via `/analytics/semantic-arc`)
+        All of that—live streaming, persistence of each slice, and background
+        analytics—happens in one concise call.
+      operationId: bootstrapAddBaseline
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BaselineIn'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json: {}
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /bootstrap/roles:
+    post:
+      tags:
+        - Roles
+      summary: Seed GPT Roles
+      description: >
+        Populates the specified corpus with five GPT role prompts.
+        Prerequisite: call `/corpus-init` first.
+      operationId: seedRoles
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RoleInitRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoleDefaults'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    BaselineIn:
+      type: object
+      title: BaselineIn
+      description: |
+        Request model for adding a new baseline snapshot to a corpus.
+        corpusId: Identifier of the target corpus.
+        baselineId: Unique version identifier for this baseline.
+        content: The textual or JSON content of the baseline.
+      required:
+        - corpusId
+        - baselineId
+        - content
+      properties:
+        corpusId:
+          type: string
+          title: Corpusid
+        baselineId:
+          type: string
+          title: Baselineid
+        content:
+          type: string
+          title: Content
+    HTTPValidationError:
+      type: object
+      title: HTTPValidationError
+      properties:
+        detail:
+          type: array
+          title: Detail
+          items:
+            $ref: '#/components/schemas/ValidationError'
+    InitIn:
+      type: object
+      title: InitIn
+      description: |
+        Input model for initializing a corpus.
+        corpusId: Unique identifier for the corpus to create.
+      required:
+        - corpusId
+      properties:
+        corpusId:
+          type: string
+          title: Corpusid
+    InitOut:
+      type: object
+      title: InitOut
+      description: |
+        Output model after initializing a corpus or performing other operations.
+        message: Human-readable status message.
+      required:
+        - message
+      properties:
+        message:
+          type: string
+          title: Message
+    RoleDefaults:
+      type: object
+      title: RoleDefaults
+      description: |
+        Response model containing the five default GPT role prompts.
+        drift: Prompt template for the drift analysis role.
+        semantic_arc: Prompt template for the semantic arc analysis role.
+        patterns: Prompt template for the patterns analysis role.
+        history: Prompt template for the history/reflections role.
+        view_creator: Prompt template for the view-creation agent role.
+      required:
+        - drift
+        - semantic_arc
+        - patterns
+        - history
+        - view_creator
+      properties:
+        drift:
+          type: string
+          title: Drift
+        semantic_arc:
+          type: string
+          title: Semantic Arc
+        patterns:
+          type: string
+          title: Patterns
+        history:
+          type: string
+          title: History
+        view_creator:
+          type: string
+          title: View Creator
+    RoleInfo:
+      type: object
+      title: RoleInfo
+      description: |
+        Represents a dynamically registered or promoted GPT role.
+        name: Identifier for the role (e.g., "security_audit").
+        prompt: Full system prompt text defining the role's analysis behavior.
+      required:
+        - name
+        - prompt
+      properties:
+        name:
+          type: string
+          title: Name
+        prompt:
+          type: string
+          title: Prompt
+    RoleInitRequest:
+      type: object
+      title: RoleInitRequest
+      description: |
+        Request model for seeding default GPT roles into a corpus.
+        corpusId: The target corpus identifier.
+      required:
+        - corpusId
+      properties:
+        corpusId:
+          type: string
+          title: Corpusid
+    ValidationError:
+      type: object
+      title: ValidationError
+      required:
+        - loc
+        - msg
+        - type
+      properties:
+        loc:
+          type: array
+          title: Location
+          items:
+            anyOf:
+              - type: string
+              - type: integer
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/FountainAi/openAPI/v1/function-caller.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/function-caller.yml
@@ -1,0 +1,200 @@
+---
+openapi: 3.1.0
+info:
+  title: FountainAI Function Caller Service
+  description: |
+    Service to register, manage, and invoke function calls mapped
+    from OpenAI function-calling plans.
+    It acts as a dynamic operationId-to-HTTP call mapping factory,
+    enabling LLM-driven orchestration.
+  version: 1.0.0
+servers:
+  - url: http://functions.fountain.coach/api/v1
+paths:
+  /functions:
+    get:
+      summary: List Registered Functions
+      operationId: list_functions
+      description: >
+        Retrieve a paginated list of all registered functions available for
+        invocation.
+      parameters:
+        - name: page
+          in: query
+          description: Page number for pagination
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: page_size
+          in: query
+          description: Number of functions per page
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        '200':
+          description: Successful Response with function list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  functions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/FunctionInfo'
+                  page:
+                    type: integer
+                  page_size:
+                    type: integer
+                  total:
+                    type: integer
+        '422':
+          $ref: '#/components/responses/ValidationErrorResponse'
+
+  /functions/{function_id}:
+    get:
+      summary: Get Function Details
+      operationId: get_function_details
+      description: >
+        Retrieve detailed metadata about a registered function by its ID.
+      parameters:
+        - name: function_id
+          in: path
+          required: true
+          description: Unique identifier of the function
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Function metadata retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FunctionInfo'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '422':
+          $ref: '#/components/responses/ValidationErrorResponse'
+
+  /functions/{function_id}/invoke:
+    post:
+      summary: Invoke a Registered Function
+      operationId: invoke_function
+      description: |
+        Invoke the specified function with the given input parameters.
+        The service will perform the corresponding HTTP call and
+        return the function result.
+      parameters:
+        - name: function_id
+          in: path
+          required: true
+          description: Unique identifier of the function to invoke
+          schema:
+            type: string
+      requestBody:
+        required: true
+        description: >
+          JSON object containing the input parameters for the
+          function call
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Function invoked successfully, result returned
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Invalid input parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/NotFoundResponse'
+        '422':
+          $ref: '#/components/responses/ValidationErrorResponse'
+        '500':
+          description: Internal server error during invocation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+
+components:
+  schemas:
+    FunctionInfo:
+      type: object
+      required:
+        - function_id
+        - name
+        - description
+        - http_method
+        - http_path
+      properties:
+        function_id:
+          type: string
+          description: Unique function identifier (matches operationId)
+        name:
+          type: string
+          description: Human-readable name of the function
+        description:
+          type: string
+          description: Description of the function's purpose
+        http_method:
+          type: string
+          enum: [GET, POST, PUT, PATCH, DELETE]
+          description: HTTP method used to invoke the function
+        http_path:
+          type: string
+          description: HTTP path to call for the function
+        parameters_schema:
+          type: object
+          description: JSON Schema describing input parameters for validation
+
+    ErrorResponse:
+      type: object
+      required:
+        - error_code
+        - message
+      properties:
+        error_code:
+          type: string
+          description: Machine-readable error code
+        message:
+          type: string
+          description: Human-readable error message
+
+  responses:
+    NotFoundResponse:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            not_found:
+              value:
+                error_code: not_found
+                message: The requested resource was not found
+
+    ValidationErrorResponse:
+      description: Validation error in input parameters
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            validation_error:
+              value:
+                error_code: validation_error
+                message: Invalid input parameters
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/FountainAi/openAPI/v1/persist.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/persist.yml
@@ -1,0 +1,396 @@
+---
+openapi: 3.1.0
+info:
+  title: FountainAI Persistence Service (Typesense-backed)
+  description: >
+    Persistence and semantic indexing API for FountainAI corpora and related
+    semantic artifacts (baselines, drifts, reflections, functions, history).
+  version: 1.0.0
+servers:
+  - url: http://persist.fountain.coach/api/v1
+paths:
+
+  /corpora:
+    get:
+      summary: List all corpora with pagination support
+      description: |
+        Retrieve a paginated list of all corpus identifiers
+        available in the persistence layer.
+        Useful for clients to discover existing corpora.
+      operationId: listCorpora
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of corpora to return in this response.
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+        - name: offset
+          in: query
+          description: >
+            Number of corpora to skip before starting to collect the
+            result set.
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+      responses:
+        '200':
+          description: A paginated list of corpus IDs.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+                    description: Total number of corpora stored.
+                  corpora:
+                    type: array
+                    description: Array of corpus unique identifiers.
+                    items:
+                      type: string
+
+    post:
+      summary: Create a new corpus
+      description: |
+        Initialize a new corpus that will act as a semantic container for
+        baselines, reflections, and other artifacts. Corpus IDs must be unique.
+      operationId: createCorpus
+      requestBody:
+        description: Corpus creation request payload including unique corpusId.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CorpusCreateRequest'
+      responses:
+        '201':
+          description: Corpus created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CorpusResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+
+  /corpora/{corpusId}/baselines:
+    post:
+      summary: Add a baseline snapshot to a corpus
+      description: |
+        Store a baseline snapshot within the specified corpus. Baselines
+        capture semantic state or data snapshots relevant for drift
+        analysis or reflection.
+      operationId: addBaseline
+      parameters:
+        - name: corpusId
+          in: path
+          required: true
+          description: >
+            The unique identifier of the corpus to store the baseline in.
+          schema:
+            type: string
+      requestBody:
+        description: >
+          Baseline data including unique baselineId and textual content.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Baseline'
+      responses:
+        '200':
+          description: Baseline added successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+
+  /corpora/{corpusId}/functions:
+    post:
+      summary: Add a function to a corpus
+      operationId: addFunction
+      parameters:
+        - name: corpusId
+          in: path
+          required: true
+          description: Corpus identifier to associate the function with.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Function'
+      responses:
+        '200':
+          description: Function stored successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+
+  /corpora/{corpusId}/reflections:
+    post:
+      summary: Add a reflection to a corpus
+      description: |
+        Store a GPT-generated reflection related to the specified corpus.
+        Reflections often include question and answer content useful for
+        semantic reasoning and planning.
+      operationId: addReflection
+      parameters:
+        - name: corpusId
+          in: path
+          required: true
+          description: The corpus identifier to associate this reflection with.
+          schema:
+            type: string
+      requestBody:
+        description: >
+          Reflection content including reflectionId, question, and answer.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Reflection'
+      responses:
+        '200':
+          description: Reflection added successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+
+    get:
+      summary: List reflections in a corpus, supports pagination
+      description: |
+        Retrieve reflections stored in the given corpus with pagination. Useful
+        for browsing semantic insights or planning data over time.
+      operationId: listReflections
+      parameters:
+        - name: corpusId
+          in: path
+          required: true
+          description: Corpus identifier to list reflections for.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Maximum number of reflections to return.
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+        - name: offset
+          in: query
+          description: Number of reflections to skip before returning results.
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+      responses:
+        '200':
+          description: Paginated list of reflections for the corpus.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+                    description: Total number of reflections available.
+                  reflections:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Reflection'
+
+  /functions:
+    get:
+      summary: List all registered functions with pagination
+      description: |
+        Retrieve a paginated list of all registered callable functions known to
+        the persistence layer for orchestration and invocation.
+      operationId: listFunctions
+      parameters:
+        - name: limit
+          in: query
+          description: Maximum number of functions to return.
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+        - name: offset
+          in: query
+          description: Number of functions to skip before returning results.
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+      responses:
+        '200':
+          description: Paginated list of functions.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+                    description: Total functions registered.
+                  functions:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Function'
+
+  /functions/{functionId}:
+    get:
+      summary: Get function details by ID
+      description: >
+        Retrieve detailed metadata for a registered function by its
+        identifier.
+      operationId: getFunctionDetails
+      parameters:
+        - name: functionId
+          in: path
+          required: true
+          description: Unique identifier of the function.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Function metadata retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Function'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+
+components:
+  schemas:
+    BaseEntity:
+      type: object
+      required:
+        - corpusId
+      properties:
+        corpusId:
+          type: string
+          description: Unique corpus identifier to namespace stored data.
+
+    CorpusCreateRequest:
+      type: object
+      required:
+        - corpusId
+      properties:
+        corpusId:
+          type: string
+          description: Unique identifier for the new corpus to be created.
+
+    CorpusResponse:
+      type: object
+      properties:
+        corpusId:
+          type: string
+          description: Identifier of the created corpus.
+        message:
+          type: string
+          description: Human-readable status message.
+
+    Baseline:
+      allOf:
+        - $ref: '#/components/schemas/BaseEntity'
+        - type: object
+          required:
+            - baselineId
+            - content
+          properties:
+            baselineId:
+              type: string
+              description: Unique identifier for this baseline snapshot.
+            content:
+              type: string
+              description: Textual or JSON content of the baseline snapshot.
+
+    Reflection:
+      allOf:
+        - $ref: '#/components/schemas/BaseEntity'
+        - type: object
+          required:
+            - reflectionId
+            - question
+            - content
+          properties:
+            reflectionId:
+              type: string
+              description: Unique identifier for the reflection.
+            question:
+              type: string
+              description: Reflection question or prompt.
+            content:
+              type: string
+              description: Generated response or insight from GPT.
+
+    Function:
+      type: object
+      required:
+        - functionId
+        - name
+        - description
+        - httpMethod
+        - httpPath
+      properties:
+        functionId:
+          type: string
+          description: Unique identifier for the registered function.
+        name:
+          type: string
+          description: Human-readable function name.
+        description:
+          type: string
+          description: Description of the function’s purpose.
+        httpMethod:
+          type: string
+          enum: [GET, POST, PUT, PATCH, DELETE]
+          description: HTTP method to invoke the function.
+        httpPath:
+          type: string
+          description: HTTP path used to call the function.
+
+    SuccessResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          description: Success confirmation message.
+          example: Operation successful.
+
+  responses:
+    ErrorResponse:
+      description: Standard error response.
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - code
+              - message
+            properties:
+              code:
+                type: string
+                description: Error code identifier.
+              message:
+                type: string
+                description: Human-readable error message.
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/FountainAi/openAPI/v1/planner.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/planner.yml
@@ -1,0 +1,322 @@
+---
+openapi: 3.1.0
+info:
+  title: FountainAI Planner Service
+  description: >
+    Orchestrates LLM-driven planning workflows; all endpoints are
+    grouped by router tags.
+  version: 1.0.0
+servers:
+  - url: http://planner.fountain.coach/api/v1
+paths:
+  /planner/reason:
+    post:
+      tags:
+        - Planner
+      summary: Generate a plan from user objective
+      description: >
+        Accepts a high-level user objective and returns a step-by-step plan.
+      operationId: planner_reason
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserObjectiveRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PlanResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /planner/execute:
+    post:
+      tags:
+        - Planner
+      summary: Execute a generated plan
+      description: >
+        Takes a plan (function-call list) and runs each step,
+        returning results.
+      operationId: planner_execute
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PlanExecutionRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExecutionResult'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /planner/corpora:
+    get:
+      tags:
+        - Planner
+      summary: List available corpora
+      description: >
+        Returns the names/IDs of all corpora that the planner knows about.
+      operationId: planner_list_corpora
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                title: Response Planner List Corpora
+                items:
+                  type: string
+  /planner/reflections/{corpus_id}:
+    get:
+      tags:
+        - Reflections
+      summary: Fetch reflection history
+      description: Retrieve all stored reflections for a given corpus ID.
+      operationId: get_reflection_history
+      parameters:
+        - name: corpus_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HistoryListResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /planner/reflections/{corpus_id}/semantic-arc:
+    get:
+      tags:
+        - Reflections
+      summary: Fetch semantic arc
+      description: >
+        Retrieve the semantic arc for a given corpus ID (curated summary,
+        insights, etc.).
+      operationId: get_semantic_arc
+      parameters:
+        - name: corpus_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties: true
+                title: Response Get Semantic Arc
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /planner/reflections/:
+    post:
+      tags:
+        - Reflections
+      summary: Add a new reflection
+      description: Send a message to be reflected on and appended to the corpus.
+      operationId: post_reflection
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatReflectionRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ReflectionItem'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    ChatReflectionRequest:
+      title: ChatReflectionRequest
+      type: object
+      required:
+        - corpus_id
+        - message
+      properties:
+        corpus_id:
+          type: string
+          title: Corpus Id
+        message:
+          type: string
+          title: Message
+    ExecutionResult:
+      title: ExecutionResult
+      description: The wrapper returned by /planner/execute.
+      type: object
+      required:
+        - results
+      properties:
+        results:
+          type: array
+          title: Results
+          items:
+            $ref: '#/components/schemas/FunctionCallResult'
+    FunctionCall:
+      title: FunctionCall
+      type: object
+      required:
+        - name
+        - arguments
+      properties:
+        name:
+          type: string
+          title: Name
+        arguments:
+          type: object
+          title: Arguments
+          additionalProperties: true
+    FunctionCallResult:
+      title: FunctionCallResult
+      description: The response from executing a single FunctionCall.
+      type: object
+      required:
+        - step
+        - arguments
+        - output
+      properties:
+        step:
+          type: string
+          title: Step
+        arguments:
+          type: object
+          title: Arguments
+          additionalProperties: true
+        output:
+          title: Output
+    HTTPValidationError:
+      title: HTTPValidationError
+      type: object
+      properties:
+        detail:
+          type: array
+          title: Detail
+          items:
+            $ref: '#/components/schemas/ValidationError'
+    HistoryListResponse:
+      title: HistoryListResponse
+      type: object
+      required:
+        - reflections
+      properties:
+        reflections:
+          type: array
+          title: Reflections
+          items:
+            $ref: '#/components/schemas/ReflectionItem'
+    PlanExecutionRequest:
+      title: PlanExecutionRequest
+      description: >
+        Mirrors PlanResponse but used as the input to /planner/execute.
+      type: object
+      required:
+        - objective
+        - steps
+      properties:
+        objective:
+          type: string
+          title: Objective
+        steps:
+          type: array
+          title: Steps
+          items:
+            $ref: '#/components/schemas/FunctionCall'
+    PlanResponse:
+      title: PlanResponse
+      type: object
+      required:
+        - objective
+        - steps
+      properties:
+        objective:
+          type: string
+          title: Objective
+        steps:
+          type: array
+          title: Steps
+          items:
+            $ref: '#/components/schemas/FunctionCall'
+    ReflectionItem:
+      title: ReflectionItem
+      type: object
+      required:
+        - timestamp
+        - content
+      properties:
+        timestamp:
+          type: string
+          title: Timestamp
+        content:
+          type: string
+          title: Content
+    UserObjectiveRequest:
+      title: UserObjectiveRequest
+      type: object
+      required:
+        - objective
+      properties:
+        objective:
+          type: string
+          title: Objective
+    ValidationError:
+      title: ValidationError
+      type: object
+      required:
+        - loc
+        - msg
+        - type
+      properties:
+        loc:
+          type: array
+          title: Location
+          items:
+            anyOf:
+              - type: string
+              - type: integer
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/FountainAi/openAPI/v1/tools-factory.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/tools-factory.yml
@@ -1,0 +1,150 @@
+---
+openapi: 3.1.0
+info:
+  title: FountainAI Tools Factory Service
+  description: |
+    Service that registers new tools (function definitions) and stores
+    them in the shared Typesense collection used by the Function Caller
+    Service.
+  version: 1.0.0
+servers:
+  - url: http://tools-factory.fountain.coach/api/v1
+paths:
+  /tools:
+    get:
+      summary: List Registered Tools
+      operationId: list_tools
+      description: Retrieve a paginated list of registered tools.
+      parameters:
+        - name: page
+          in: query
+          description: Page number for pagination
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: page_size
+          in: query
+          description: Number of tools per page
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FunctionListResponse'
+        '422':
+          $ref: '#/components/responses/ValidationErrorResponse'
+
+  /tools/register:
+    post:
+      summary: Register Tools from OpenAPI
+      operationId: register_openapi
+      description: |
+        Store a collection of tool definitions provided via an OpenAPI
+        document. Each operationId is mapped to a callable function.
+      parameters:
+        - name: corpusId
+          in: query
+          description: Corpus identifier to associate the tools with
+          schema:
+            type: string
+            default: default
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OpenAPIDocument'
+      responses:
+        '200':
+          description: Tools registered successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FunctionListResponse'
+        '422':
+          $ref: '#/components/responses/ValidationErrorResponse'
+
+components:
+  schemas:
+    FunctionInfo:
+      type: object
+      required:
+        - function_id
+        - name
+        - description
+        - http_method
+        - http_path
+      properties:
+        function_id:
+          type: string
+          description: Unique function identifier (matches operationId)
+        name:
+          type: string
+          description: Human-readable name of the function
+        description:
+          type: string
+          description: Description of the function's purpose
+        http_method:
+          type: string
+          enum: [GET, POST, PUT, PATCH, DELETE]
+          description: HTTP method used to invoke the function
+        http_path:
+          type: string
+          description: HTTP path to call for the function
+        parameters_schema:
+          type: object
+          description: JSON Schema describing input parameters for validation
+        openapi:
+          type: object
+          description: Full OpenAPI document defining the tool
+    FunctionListResponse:
+      type: object
+      properties:
+        functions:
+          type: array
+          items:
+            $ref: '#/components/schemas/FunctionInfo'
+        page:
+          type: integer
+        page_size:
+          type: integer
+        total:
+          type: integer
+    OpenAPIDocument:
+      description: OpenAPI specification describing one or more tools
+      type: object
+      additionalProperties: true
+    ErrorResponse:
+      type: object
+      required:
+        - error_code
+        - message
+      properties:
+        error_code:
+          type: string
+          description: Machine-readable error code
+        message:
+          type: string
+          description: Human-readable error message
+
+  responses:
+    ValidationErrorResponse:
+      description: Validation error in input parameters
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          examples:
+            validation_error:
+              value:
+                error_code: validation_error
+                message: Invalid input parameters
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/FountainAi/openAPI/v2/llm-gateway.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v2/llm-gateway.yml
@@ -1,0 +1,142 @@
+---
+openapi: 3.1.0
+info:
+  title: FountainAI LLM Gateway
+  description: Proxy to any LLM with function-calling support.
+  version: 2.0.0
+servers:
+  - url: http://llm-gateway.fountain.coach/api/v1
+paths:
+  /metrics:
+    get:
+      summary: Metrics
+      description: Endpoint that serves Prometheus metrics.
+      operationId: metrics_metrics_get
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+  /chat:
+    post:
+      tags:
+        - Chat
+      summary: Chat with Planner Objective
+      description: >
+        Receives the user's objective, loads available tools,
+        and delegates reasoning to GPT.
+      operationId: chatWithObjective
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatRequest'
+      responses:
+        "200":
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+        "422":
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    ChatRequest:
+      title: ChatRequest
+      type: object
+      required:
+        - model
+        - messages
+      properties:
+        model:
+          type: string
+          title: Model
+        messages:
+          title: Messages
+          type: array
+          items:
+            $ref: '#/components/schemas/MessageObject'
+        functions:
+          title: Functions
+          type: array
+          items:
+            $ref: '#/components/schemas/FunctionObject'
+        function_call:
+          title: Function Call
+          oneOf:
+            - type: string
+              enum: [auto]
+            - $ref: '#/components/schemas/FunctionCallObject'
+    FunctionCallObject:
+      title: FunctionCallObject
+      type: object
+      properties:
+        name:
+          type: string
+      required:
+        - name
+    MessageObject:
+      title: MessageObject
+      type: object
+      required:
+        - role
+        - content
+      properties:
+        role:
+          type: string
+          description: Role of the sender (e.g. user, assistant)
+        content:
+          type: string
+          description: Message text content
+    FunctionObject:
+      title: FunctionObject
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Name of the function
+        description:
+          type: string
+          description: Optional description of the function
+    HTTPValidationError:
+      title: HTTPValidationError
+      type: object
+      properties:
+        detail:
+          title: Detail
+          type: array
+          items:
+            $ref: '#/components/schemas/ValidationError'
+    ValidationError:
+      title: ValidationError
+      type: object
+      required:
+        - loc
+        - msg
+        - type
+      properties:
+        loc:
+          title: Location
+          type: array
+          items:
+            anyOf:
+              - type: string
+              - type: integer
+        msg:
+          title: Message
+          type: string
+        type:
+          title: Error Type
+          type: string
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/baseline-awareness/APIClient.swift
+++ b/Sources/FountainOps/Generated/Client/baseline-awareness/APIClient.swift
@@ -1,0 +1,48 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public protocol HTTPSession {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: HTTPSession {
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.data(for: request, delegate: nil)
+    }
+}
+
+public struct APIClient {
+    let baseURL: URL
+    let session: HTTPSession
+    let defaultHeaders: [String: String]
+
+    public init(baseURL: URL, session: HTTPSession = URLSession.shared, defaultHeaders: [String: String] = [:]) {
+        self.baseURL = baseURL
+        self.session = session
+        self.defaultHeaders = defaultHeaders
+    }
+
+    public func send<R: APIRequest>(_ request: R) async throws -> R.Response {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        for (header, value) in defaultHeaders {
+            urlRequest.setValue(value, forHTTPHeaderField: header)
+        }
+        if let body = request.body {
+            urlRequest.httpBody = try JSONEncoder().encode(body)
+            urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
+        let (data, _) = try await session.data(for: urlRequest)
+        return try JSONDecoder().decode(R.Response.self, from: data)
+    }
+}
+
+public extension APIClient {
+    init(baseURL: URL, bearerToken: String, session: HTTPSession = URLSession.shared) {
+        self.init(baseURL: baseURL, session: session, defaultHeaders: ["Authorization": "Bearer \(bearerToken)"])
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/baseline-awareness/APIRequest.swift
+++ b/Sources/FountainOps/Generated/Client/baseline-awareness/APIRequest.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Empty body type used for requests without a payload.
+public struct NoBody: Codable {}
+
+public protocol APIRequest {
+    associatedtype Body: Encodable = NoBody
+    associatedtype Response: Decodable
+    var method: String { get }
+    var path: String { get }
+    var body: Body? { get }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/baseline-awareness/Models.swift
+++ b/Sources/FountainOps/Generated/Client/baseline-awareness/Models.swift
@@ -1,0 +1,66 @@
+// Models for Baseline Awareness Service
+
+public struct BaselineRequest: Codable {
+    public let baselineId: String
+    public let content: String
+    public let corpusId: String
+}
+
+public struct DriftRequest: Codable {
+    public let content: String
+    public let corpusId: String
+    public let driftId: String
+}
+
+public struct HistorySummaryResponse: Codable {
+    public let summary: String
+}
+
+public struct InitIn: Codable {
+    public let corpusId: String
+}
+
+public struct InitOut: Codable {
+    public let message: String
+}
+
+public struct PatternsRequest: Codable {
+    public let content: String
+    public let corpusId: String
+    public let patternsId: String
+}
+
+public struct ReflectionRequest: Codable {
+    public let content: String
+    public let corpusId: String
+    public let question: String
+    public let reflectionId: String
+}
+
+public struct ReflectionSummaryResponse: Codable {
+    public let message: String
+}
+
+public struct HistoryAnalyticsResponse: Codable {
+    public let baselines: Int
+    public let drifts: Int
+    public let patterns: Int
+    public let reflections: Int
+}
+
+public typealias readSemanticArcResponse = String
+
+public typealias addReflectionResponse = String
+
+public typealias addDriftResponse = String
+
+public typealias listHistoryAnalyticsResponse = HistoryAnalyticsResponse
+
+public typealias addPatternsResponse = String
+
+public typealias health_health_getResponse = String
+
+public typealias addBaselineResponse = String
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/addBaseline.swift
+++ b/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/addBaseline.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct addBaseline: APIRequest {
+    public typealias Body = BaselineRequest
+    public typealias Response = addBaselineResponse
+    public var method: String { "POST" }
+    public var path: String { "/corpus/baseline" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/addDrift.swift
+++ b/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/addDrift.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct addDrift: APIRequest {
+    public typealias Body = DriftRequest
+    public typealias Response = addDriftResponse
+    public var method: String { "POST" }
+    public var path: String { "/corpus/drift" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/addPatterns.swift
+++ b/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/addPatterns.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct addPatterns: APIRequest {
+    public typealias Body = PatternsRequest
+    public typealias Response = addPatternsResponse
+    public var method: String { "POST" }
+    public var path: String { "/corpus/patterns" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/addReflection.swift
+++ b/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/addReflection.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct addReflection: APIRequest {
+    public typealias Body = ReflectionRequest
+    public typealias Response = addReflectionResponse
+    public var method: String { "POST" }
+    public var path: String { "/corpus/reflections" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/health_health_get.swift
+++ b/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/health_health_get.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct health_health_get: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = health_health_getResponse
+    public var method: String { "GET" }
+    public var path: String { "/health" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/initializeCorpus.swift
+++ b/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/initializeCorpus.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct initializeCorpus: APIRequest {
+    public typealias Body = InitIn
+    public typealias Response = InitOut
+    public var method: String { "POST" }
+    public var path: String { "/corpus/init" }
+    public var body: Body?
+
+    public init(body: Body? = nil) {
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/listHistory.swift
+++ b/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/listHistory.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct listHistoryParameters: Codable {
+    public let corpusId: String
+}
+
+public struct listHistory: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = HistorySummaryResponse
+    public var method: String { "GET" }
+    public var parameters: listHistoryParameters
+    public var path: String {
+        var path = "/corpus/history/{corpus_id}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{corpus_id}", with: String(parameters.corpusId))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: listHistoryParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/listHistoryAnalytics.swift
+++ b/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/listHistoryAnalytics.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct listHistoryAnalyticsParameters: Codable {
+    public let corpusId: String
+}
+
+public struct listHistoryAnalytics: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = listHistoryAnalyticsResponse
+    public var method: String { "GET" }
+    public var parameters: listHistoryAnalyticsParameters
+    public var path: String {
+        var path = "/corpus/history"
+        var query: [String] = []
+        query.append("corpus_id=\(parameters.corpusId)")
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: listHistoryAnalyticsParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/listReflections.swift
+++ b/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/listReflections.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct listReflectionsParameters: Codable {
+    public let corpusId: String
+}
+
+public struct listReflections: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = ReflectionSummaryResponse
+    public var method: String { "GET" }
+    public var parameters: listReflectionsParameters
+    public var path: String {
+        var path = "/corpus/reflections/{corpus_id}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{corpus_id}", with: String(parameters.corpusId))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: listReflectionsParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/readSemanticArc.swift
+++ b/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/readSemanticArc.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct readSemanticArcParameters: Codable {
+    public let corpusId: String
+}
+
+public struct readSemanticArc: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = readSemanticArcResponse
+    public var method: String { "GET" }
+    public var parameters: readSemanticArcParameters
+    public var path: String {
+        var path = "/corpus/semantic-arc"
+        var query: [String] = []
+        query.append("corpus_id=\(parameters.corpusId)")
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: readSemanticArcParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/summarizeHistory.swift
+++ b/Sources/FountainOps/Generated/Client/baseline-awareness/Requests/summarizeHistory.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct summarizeHistoryParameters: Codable {
+    public let corpusId: String
+}
+
+public struct summarizeHistory: APIRequest {
+    public typealias Body = NoBody
+    public typealias Response = HistorySummaryResponse
+    public var method: String { "GET" }
+    public var parameters: summarizeHistoryParameters
+    public var path: String {
+        var path = "/corpus/summary/{corpus_id}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{corpus_id}", with: String(parameters.corpusId))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: summarizeHistoryParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/bootstrap/APIClient.swift
+++ b/Sources/FountainOps/Generated/Client/bootstrap/APIClient.swift
@@ -1,0 +1,33 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public protocol HTTPSession {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: HTTPSession {
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.data(for: request, delegate: nil)
+    }
+}
+
+public struct APIClient {
+    let baseURL: URL
+    let session: HTTPSession
+
+    public init(baseURL: URL, session: HTTPSession = URLSession.shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    public func send<R: APIRequest>(_ request: R) async throws -> R.Response {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        let (data, _) = try await session.data(for: urlRequest)
+        return try JSONDecoder().decode(R.Response.self, from: data)
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/bootstrap/APIRequest.swift
+++ b/Sources/FountainOps/Generated/Client/bootstrap/APIRequest.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public protocol APIRequest {
+    associatedtype Response: Decodable
+    var method: String { get }
+    var path: String { get }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/bootstrap/Models.swift
+++ b/Sources/FountainOps/Generated/Client/bootstrap/Models.swift
@@ -1,0 +1,45 @@
+// Models for FountainAI Bootstrap Service
+
+public struct BaselineIn: Codable {
+    public let baselineId: String
+    public let content: String
+    public let corpusId: String
+}
+
+public struct HTTPValidationError: Codable {
+    public let detail: String
+}
+
+public struct InitIn: Codable {
+    public let corpusId: String
+}
+
+public struct InitOut: Codable {
+    public let message: String
+}
+
+public struct RoleDefaults: Codable {
+    public let drift: String
+    public let history: String
+    public let patterns: String
+    public let semantic_arc: String
+    public let view_creator: String
+}
+
+public struct RoleInfo: Codable {
+    public let name: String
+    public let prompt: String
+}
+
+public struct RoleInitRequest: Codable {
+    public let corpusId: String
+}
+
+public struct ValidationError: Codable {
+    public let loc: String
+    public let msg: String
+    public let type: String
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/bootstrap/Requests/bootstrapAddBaseline.swift
+++ b/Sources/FountainOps/Generated/Client/bootstrap/Requests/bootstrapAddBaseline.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct bootstrapAddBaseline: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/bootstrap/baseline" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/bootstrap/Requests/bootstrapEnqueueReflection.swift
+++ b/Sources/FountainOps/Generated/Client/bootstrap/Requests/bootstrapEnqueueReflection.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct bootstrapEnqueueReflection: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/bootstrap/corpus/reflect" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/bootstrap/Requests/bootstrapInitializeCorpus.swift
+++ b/Sources/FountainOps/Generated/Client/bootstrap/Requests/bootstrapInitializeCorpus.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct bootstrapInitializeCorpus: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/bootstrap/corpus/init" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/bootstrap/Requests/bootstrapPromoteReflection.swift
+++ b/Sources/FountainOps/Generated/Client/bootstrap/Requests/bootstrapPromoteReflection.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct bootstrapPromoteReflection: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/bootstrap/roles/promote" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/bootstrap/Requests/bootstrapSeedRoles.swift
+++ b/Sources/FountainOps/Generated/Client/bootstrap/Requests/bootstrapSeedRoles.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct bootstrapSeedRoles: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/bootstrap/roles/seed" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/bootstrap/Requests/seedRoles.swift
+++ b/Sources/FountainOps/Generated/Client/bootstrap/Requests/seedRoles.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct seedRoles: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/bootstrap/roles" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/function-caller/APIClient.swift
+++ b/Sources/FountainOps/Generated/Client/function-caller/APIClient.swift
@@ -1,0 +1,33 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public protocol HTTPSession {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: HTTPSession {
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.data(for: request, delegate: nil)
+    }
+}
+
+public struct APIClient {
+    let baseURL: URL
+    let session: HTTPSession
+
+    public init(baseURL: URL, session: HTTPSession = URLSession.shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    public func send<R: APIRequest>(_ request: R) async throws -> R.Response {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        let (data, _) = try await session.data(for: urlRequest)
+        return try JSONDecoder().decode(R.Response.self, from: data)
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/function-caller/APIRequest.swift
+++ b/Sources/FountainOps/Generated/Client/function-caller/APIRequest.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public protocol APIRequest {
+    associatedtype Response: Decodable
+    var method: String { get }
+    var path: String { get }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/function-caller/Models.swift
+++ b/Sources/FountainOps/Generated/Client/function-caller/Models.swift
@@ -1,0 +1,18 @@
+// Models for FountainAI Function Caller Service
+
+public struct ErrorResponse: Codable {
+    public let error_code: String
+    public let message: String
+}
+
+public struct FunctionInfo: Codable {
+    public let description: String
+    public let function_id: String
+    public let http_method: String
+    public let http_path: String
+    public let name: String
+    public let parameters_schema: String
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/function-caller/Requests/get_function_details.swift
+++ b/Sources/FountainOps/Generated/Client/function-caller/Requests/get_function_details.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct get_function_details: APIRequest {
+    public typealias Response = Data
+    public var method: String { "GET" }
+    public var path: String { "/functions/{function_id}" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/function-caller/Requests/invoke_function.swift
+++ b/Sources/FountainOps/Generated/Client/function-caller/Requests/invoke_function.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct invoke_function: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/functions/{function_id}/invoke" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/function-caller/Requests/list_functions.swift
+++ b/Sources/FountainOps/Generated/Client/function-caller/Requests/list_functions.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct list_functions: APIRequest {
+    public typealias Response = Data
+    public var method: String { "GET" }
+    public var path: String { "/functions" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/llm-gateway/APIClient.swift
+++ b/Sources/FountainOps/Generated/Client/llm-gateway/APIClient.swift
@@ -1,0 +1,33 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public protocol HTTPSession {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: HTTPSession {
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.data(for: request, delegate: nil)
+    }
+}
+
+public struct APIClient {
+    let baseURL: URL
+    let session: HTTPSession
+
+    public init(baseURL: URL, session: HTTPSession = URLSession.shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    public func send<R: APIRequest>(_ request: R) async throws -> R.Response {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        let (data, _) = try await session.data(for: urlRequest)
+        return try JSONDecoder().decode(R.Response.self, from: data)
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/llm-gateway/APIRequest.swift
+++ b/Sources/FountainOps/Generated/Client/llm-gateway/APIRequest.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public protocol APIRequest {
+    associatedtype Response: Decodable
+    var method: String { get }
+    var path: String { get }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/llm-gateway/Models.swift
+++ b/Sources/FountainOps/Generated/Client/llm-gateway/Models.swift
@@ -1,0 +1,35 @@
+// Models for FountainAI LLM Gateway
+
+public struct ChatRequest: Codable {
+    public let function_call: String
+    public let functions: String
+    public let messages: String
+    public let model: String
+}
+
+public struct FunctionCallObject: Codable {
+    public let name: String
+}
+
+public struct FunctionObject: Codable {
+    public let description: String
+    public let name: String
+}
+
+public struct HTTPValidationError: Codable {
+    public let detail: String
+}
+
+public struct MessageObject: Codable {
+    public let content: String
+    public let role: String
+}
+
+public struct ValidationError: Codable {
+    public let loc: String
+    public let msg: String
+    public let type: String
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/llm-gateway/Requests/chatWithObjective.swift
+++ b/Sources/FountainOps/Generated/Client/llm-gateway/Requests/chatWithObjective.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct chatWithObjective: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/chat" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/llm-gateway/Requests/metrics_metrics_get.swift
+++ b/Sources/FountainOps/Generated/Client/llm-gateway/Requests/metrics_metrics_get.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct metrics_metrics_get: APIRequest {
+    public typealias Response = Data
+    public var method: String { "GET" }
+    public var path: String { "/metrics" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/persist/APIClient.swift
+++ b/Sources/FountainOps/Generated/Client/persist/APIClient.swift
@@ -1,0 +1,33 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public protocol HTTPSession {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: HTTPSession {
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.data(for: request, delegate: nil)
+    }
+}
+
+public struct APIClient {
+    let baseURL: URL
+    let session: HTTPSession
+
+    public init(baseURL: URL, session: HTTPSession = URLSession.shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    public func send<R: APIRequest>(_ request: R) async throws -> R.Response {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        let (data, _) = try await session.data(for: urlRequest)
+        return try JSONDecoder().decode(R.Response.self, from: data)
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/persist/APIRequest.swift
+++ b/Sources/FountainOps/Generated/Client/persist/APIRequest.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public protocol APIRequest {
+    associatedtype Response: Decodable
+    var method: String { get }
+    var path: String { get }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/persist/Models.swift
+++ b/Sources/FountainOps/Generated/Client/persist/Models.swift
@@ -1,0 +1,29 @@
+// Models for FountainAI Persistence Service (Typesense-backed)
+
+public struct BaseEntity: Codable {
+    public let corpusId: String
+}
+
+public struct CorpusCreateRequest: Codable {
+    public let corpusId: String
+}
+
+public struct CorpusResponse: Codable {
+    public let corpusId: String
+    public let message: String
+}
+
+public struct Function: Codable {
+    public let description: String
+    public let functionId: String
+    public let httpMethod: String
+    public let httpPath: String
+    public let name: String
+}
+
+public struct SuccessResponse: Codable {
+    public let message: String
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/persist/Requests/addBaseline.swift
+++ b/Sources/FountainOps/Generated/Client/persist/Requests/addBaseline.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct addBaseline: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/corpora/{corpusId}/baselines" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/persist/Requests/addFunction.swift
+++ b/Sources/FountainOps/Generated/Client/persist/Requests/addFunction.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct addFunction: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/corpora/{corpusId}/functions" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/persist/Requests/addReflection.swift
+++ b/Sources/FountainOps/Generated/Client/persist/Requests/addReflection.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct addReflection: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/corpora/{corpusId}/reflections" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/persist/Requests/createCorpus.swift
+++ b/Sources/FountainOps/Generated/Client/persist/Requests/createCorpus.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct createCorpus: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/corpora" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/persist/Requests/getFunctionDetails.swift
+++ b/Sources/FountainOps/Generated/Client/persist/Requests/getFunctionDetails.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct getFunctionDetails: APIRequest {
+    public typealias Response = Data
+    public var method: String { "GET" }
+    public var path: String { "/functions/{functionId}" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/persist/Requests/listCorpora.swift
+++ b/Sources/FountainOps/Generated/Client/persist/Requests/listCorpora.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct listCorpora: APIRequest {
+    public typealias Response = Data
+    public var method: String { "GET" }
+    public var path: String { "/corpora" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/persist/Requests/listFunctions.swift
+++ b/Sources/FountainOps/Generated/Client/persist/Requests/listFunctions.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct listFunctions: APIRequest {
+    public typealias Response = Data
+    public var method: String { "GET" }
+    public var path: String { "/functions" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/persist/Requests/listReflections.swift
+++ b/Sources/FountainOps/Generated/Client/persist/Requests/listReflections.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct listReflections: APIRequest {
+    public typealias Response = Data
+    public var method: String { "GET" }
+    public var path: String { "/corpora/{corpusId}/reflections" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/planner/APIClient.swift
+++ b/Sources/FountainOps/Generated/Client/planner/APIClient.swift
@@ -1,0 +1,33 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public protocol HTTPSession {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: HTTPSession {
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.data(for: request, delegate: nil)
+    }
+}
+
+public struct APIClient {
+    let baseURL: URL
+    let session: HTTPSession
+
+    public init(baseURL: URL, session: HTTPSession = URLSession.shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    public func send<R: APIRequest>(_ request: R) async throws -> R.Response {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        let (data, _) = try await session.data(for: urlRequest)
+        return try JSONDecoder().decode(R.Response.self, from: data)
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/planner/APIRequest.swift
+++ b/Sources/FountainOps/Generated/Client/planner/APIRequest.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public protocol APIRequest {
+    associatedtype Response: Decodable
+    var method: String { get }
+    var path: String { get }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/planner/Models.swift
+++ b/Sources/FountainOps/Generated/Client/planner/Models.swift
@@ -1,0 +1,57 @@
+// Models for FountainAI Planner Service
+
+public struct ChatReflectionRequest: Codable {
+    public let corpus_id: String
+    public let message: String
+}
+
+public struct ExecutionResult: Codable {
+    public let results: String
+}
+
+public struct FunctionCall: Codable {
+    public let arguments: String
+    public let name: String
+}
+
+public struct FunctionCallResult: Codable {
+    public let arguments: String
+    public let output: String
+    public let step: String
+}
+
+public struct HTTPValidationError: Codable {
+    public let detail: String
+}
+
+public struct HistoryListResponse: Codable {
+    public let reflections: String
+}
+
+public struct PlanExecutionRequest: Codable {
+    public let objective: String
+    public let steps: String
+}
+
+public struct PlanResponse: Codable {
+    public let objective: String
+    public let steps: String
+}
+
+public struct ReflectionItem: Codable {
+    public let content: String
+    public let timestamp: String
+}
+
+public struct UserObjectiveRequest: Codable {
+    public let objective: String
+}
+
+public struct ValidationError: Codable {
+    public let loc: String
+    public let msg: String
+    public let type: String
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/planner/Requests/get_reflection_history.swift
+++ b/Sources/FountainOps/Generated/Client/planner/Requests/get_reflection_history.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct get_reflection_history: APIRequest {
+    public typealias Response = Data
+    public var method: String { "GET" }
+    public var path: String { "/planner/reflections/{corpus_id}" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/planner/Requests/get_semantic_arc.swift
+++ b/Sources/FountainOps/Generated/Client/planner/Requests/get_semantic_arc.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct get_semantic_arc: APIRequest {
+    public typealias Response = Data
+    public var method: String { "GET" }
+    public var path: String { "/planner/reflections/{corpus_id}/semantic-arc" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/planner/Requests/planner_execute.swift
+++ b/Sources/FountainOps/Generated/Client/planner/Requests/planner_execute.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct planner_execute: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/planner/execute" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/planner/Requests/planner_list_corpora.swift
+++ b/Sources/FountainOps/Generated/Client/planner/Requests/planner_list_corpora.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct planner_list_corpora: APIRequest {
+    public typealias Response = Data
+    public var method: String { "GET" }
+    public var path: String { "/planner/corpora" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/planner/Requests/planner_reason.swift
+++ b/Sources/FountainOps/Generated/Client/planner/Requests/planner_reason.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct planner_reason: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/planner/reason" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/planner/Requests/post_reflection.swift
+++ b/Sources/FountainOps/Generated/Client/planner/Requests/post_reflection.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct post_reflection: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/planner/reflections/" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/tools-factory/APIClient.swift
+++ b/Sources/FountainOps/Generated/Client/tools-factory/APIClient.swift
@@ -1,0 +1,33 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public protocol HTTPSession {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: HTTPSession {
+    public func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        try await self.data(for: request, delegate: nil)
+    }
+}
+
+public struct APIClient {
+    let baseURL: URL
+    let session: HTTPSession
+
+    public init(baseURL: URL, session: HTTPSession = URLSession.shared) {
+        self.baseURL = baseURL
+        self.session = session
+    }
+
+    public func send<R: APIRequest>(_ request: R) async throws -> R.Response {
+        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
+        urlRequest.httpMethod = request.method
+        let (data, _) = try await session.data(for: urlRequest)
+        return try JSONDecoder().decode(R.Response.self, from: data)
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/tools-factory/APIRequest.swift
+++ b/Sources/FountainOps/Generated/Client/tools-factory/APIRequest.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public protocol APIRequest {
+    associatedtype Response: Decodable
+    var method: String { get }
+    var path: String { get }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/tools-factory/Models.swift
+++ b/Sources/FountainOps/Generated/Client/tools-factory/Models.swift
@@ -1,0 +1,26 @@
+// Models for FountainAI Tools Factory Service
+
+public struct ErrorResponse: Codable {
+    public let error_code: String
+    public let message: String
+}
+
+public struct FunctionInfo: Codable {
+    public let description: String
+    public let function_id: String
+    public let http_method: String
+    public let http_path: String
+    public let name: String
+    public let openapi: String
+    public let parameters_schema: String
+}
+
+public struct FunctionListResponse: Codable {
+    public let functions: String
+    public let page: Int
+    public let page_size: Int
+    public let total: Int
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/tools-factory/Requests/list_tools.swift
+++ b/Sources/FountainOps/Generated/Client/tools-factory/Requests/list_tools.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct list_tools: APIRequest {
+    public typealias Response = Data
+    public var method: String { "GET" }
+    public var path: String { "/tools" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/tools-factory/Requests/register_openapi.swift
+++ b/Sources/FountainOps/Generated/Client/tools-factory/Requests/register_openapi.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public struct register_openapi: APIRequest {
+    public typealias Response = Data
+    public var method: String { "POST" }
+    public var path: String { "/tools/register" }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Models.swift
+++ b/Sources/FountainOps/Generated/Models.swift
@@ -1,0 +1,9 @@
+// Models for Sample API
+
+public struct Todo: Codable {
+    public let id: Int
+    public let name: String
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/Shared/Models.swift
+++ b/Sources/FountainOps/Generated/Server/Shared/Models.swift
@@ -1,0 +1,87 @@
+public struct CorpusResponse: Codable, Sendable {
+    public let corpusId: String
+    public let message: String
+}
+
+public struct Function: Codable, Sendable {
+    public let description: String
+    public let functionId: String
+    public let httpMethod: String
+    public let httpPath: String
+    public let name: String
+    public let parametersSchema: String?
+
+    public init(description: String, functionId: String, httpMethod: String, httpPath: String, name: String, parametersSchema: String? = nil) {
+        self.description = description
+        self.functionId = functionId
+        self.httpMethod = httpMethod
+        self.httpPath = httpPath
+        self.name = name
+        self.parametersSchema = parametersSchema
+    }
+}
+
+public struct Baseline: Codable, Sendable {
+    public let baselineId: String
+    public let content: String
+    public let corpusId: String
+
+
+    public init(baselineId: String, content: String, corpusId: String) {
+        self.baselineId = baselineId
+        self.content = content
+        self.corpusId = corpusId
+    }
+}
+
+public struct Drift: Codable, Sendable {
+    public let content: String
+    public let corpusId: String
+    public let driftId: String
+
+    public init(content: String, corpusId: String, driftId: String) {
+        self.content = content
+        self.corpusId = corpusId
+        self.driftId = driftId
+    }
+}
+
+public struct Patterns: Codable, Sendable {
+    public let content: String
+    public let corpusId: String
+    public let patternsId: String
+
+    public init(content: String, corpusId: String, patternsId: String) {
+        self.content = content
+        self.corpusId = corpusId
+        self.patternsId = patternsId
+    }
+}
+
+public struct Reflection: Codable, Sendable {
+    public let content: String
+    public let corpusId: String
+    public let question: String
+    public let reflectionId: String
+
+    public init(content: String, corpusId: String, question: String, reflectionId: String) {
+        self.content = content
+        self.corpusId = corpusId
+        self.question = question
+        self.reflectionId = reflectionId
+    }
+}
+
+public struct Role: Codable, Sendable {
+    public let name: String
+    public let prompt: String
+    public let corpusId: String
+
+    public init(name: String, prompt: String, corpusId: String) {
+        self.name = name
+        self.prompt = prompt
+        self.corpusId = corpusId
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/Shared/PrometheusAdapter.swift
+++ b/Sources/FountainOps/Generated/Server/Shared/PrometheusAdapter.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+public actor PrometheusAdapter {
+    public static let shared = PrometheusAdapter()
+
+    private var counters: [String:Int] = [:]
+    private var durations: [String:(count: Int, total: Double)] = [:]
+    private var successes: [String:Int] = [:]
+    private var failures: [String:Int] = [:]
+
+    public init() {}
+
+    public func reset() {
+        counters.removeAll()
+        durations.removeAll()
+        successes.removeAll()
+        failures.removeAll()
+    }
+
+    private func key(service: String, path: String) -> String {
+        "{service=\"\(service)\",path=\"\(path)\"}"
+    }
+
+    public func record(service: String, path: String) {
+        let k = key(service: service, path: path)
+        counters[k, default: 0] += 1
+    }
+
+    public func recordResult(service: String, path: String, success: Bool) {
+        let k = key(service: service, path: path)
+        if success {
+            successes[k, default: 0] += 1
+        } else {
+            failures[k, default: 0] += 1
+        }
+    }
+
+    public func recordDuration(service: String, path: String, duration: Double) {
+        let k = key(service: service, path: path)
+        var entry = durations[k] ?? (0, 0)
+        entry.count += 1
+        entry.total += duration
+        durations[k] = entry
+    }
+
+    public func exposition() -> String {
+        var lines = counters.map { "requests_total\($0.key) \($0.value)" }
+        for (k, v) in durations {
+            lines.append("request_duration_seconds_sum\(k) \(v.total)")
+            lines.append("request_duration_seconds_count\(k) \(v.count)")
+        }
+        for (k, v) in successes {
+            lines.append("invocation_success_total\(k) \(v)")
+        }
+        for (k, v) in failures {
+            lines.append("invocation_failure_total\(k) \(v)")
+        }
+        return lines.sorted().joined(separator: "\n") + "\n"
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/Shared/TypesenseClient.swift
+++ b/Sources/FountainOps/Generated/Server/Shared/TypesenseClient.swift
@@ -1,0 +1,316 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+private struct CorpusCreateRequest: Codable {
+    let corpusId: String
+}
+
+/// Optional remote Typesense configuration loaded from the environment.
+/// When `TYPESENSE_URL` is set the client will persist data using HTTP
+/// requests instead of the in-memory store.
+
+/// Minimal in-memory representation of a Typesense service used for testing.
+/// This allows the Persistence and Function Caller services to share state
+/// without requiring an external dependency.
+public actor TypesenseClient {
+    public static let shared = TypesenseClient()
+
+    private let baseURL: URL?
+    private let apiKey: String?
+    private let functionsCacheURL: URL?
+
+    private var corpora: Set<String> = []
+    private var functions: [String: Function] = [:]
+    private var baselines: [String: [String: Baseline]] = [:]
+    private var drifts: [String: [String: Drift]] = [:]
+    private var patterns: [String: [String: Patterns]] = [:]
+    private var reflections: [String: [String: Reflection]] = [:]
+    private var roles: [String: [String: Role]] = [:]
+
+    private func saveCache() {
+        guard let url = functionsCacheURL else { return }
+        if let data = try? JSONEncoder().encode(functions) {
+            try? data.write(to: url)
+        }
+    }
+
+    private init() {
+        if let path = ProcessInfo.processInfo.environment["FUNCTIONS_CACHE_PATH"] {
+            self.functionsCacheURL = URL(fileURLWithPath: path)
+            if let data = try? Data(contentsOf: self.functionsCacheURL!),
+               let cached = try? JSONDecoder().decode([String: Function].self, from: data) {
+                self.functions = cached
+            }
+        } else {
+            self.functionsCacheURL = URL(fileURLWithPath: "functions-cache.json")
+            if let data = try? Data(contentsOf: self.functionsCacheURL!),
+               let cached = try? JSONDecoder().decode([String: Function].self, from: data) {
+                self.functions = cached
+            }
+        }
+        if let url = ProcessInfo.processInfo.environment["TYPESENSE_URL"] {
+            self.baseURL = URL(string: url)
+            self.apiKey = ProcessInfo.processInfo.environment["TYPESENSE_API_KEY"]
+        } else {
+            self.baseURL = nil
+            self.apiKey = nil
+        }
+    }
+
+    private func request(path: String, method: String, body: Data?) async throws -> Data {
+        guard let baseURL = baseURL else { return Data() }
+        var req = URLRequest(url: baseURL.appendingPathComponent(path))
+        req.httpMethod = method
+        req.httpBody = body
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let apiKey { req.setValue(apiKey, forHTTPHeaderField: "X-API-Key") }
+        let (data, _) = try await URLSession.shared.data(for: req)
+        return data
+    }
+
+    // MARK: - Corpora
+    public func createCorpus(id: String) async -> CorpusResponse {
+        if let _ = baseURL {
+            let body = try? JSONEncoder().encode(CorpusCreateRequest(corpusId: id))
+            if let data = try? await request(path: "corpora", method: "POST", body: body),
+               let resp = try? JSONDecoder().decode(CorpusResponse.self, from: data) {
+                return resp
+            }
+            return CorpusResponse(corpusId: id, message: "created")
+        }
+        corpora.insert(id)
+        return CorpusResponse(corpusId: id, message: "created")
+    }
+
+    public func listCorpora() async -> [String] {
+        if let _ = baseURL {
+            if let data = try? await request(path: "corpora", method: "GET", body: nil),
+               let resp = try? JSONDecoder().decode([String].self, from: data) {
+                return resp
+            }
+            return []
+        }
+        return Array(corpora)
+    }
+
+    // MARK: - Functions
+    public func addFunction(_ fn: Function) async {
+        var fn = fn
+        if fn.parametersSchema == nil {
+            fn = Function(description: fn.description,
+                         functionId: fn.functionId,
+                         httpMethod: fn.httpMethod,
+                         httpPath: fn.httpPath,
+                         name: fn.name,
+                         parametersSchema: "{}")
+        }
+        if let _ = baseURL {
+            let body = try? JSONEncoder().encode(fn)
+            _ = try? await request(path: "functions", method: "POST", body: body)
+            functions[fn.functionId] = fn
+            saveCache()
+        } else {
+            functions[fn.functionId] = fn
+            saveCache()
+        }
+    }
+
+    public func listFunctions() async -> [Function] {
+        if let _ = baseURL {
+            if let data = try? await request(path: "functions", method: "GET", body: nil),
+               let resp = try? JSONDecoder().decode([Function].self, from: data) {
+                for fn in resp { functions[fn.functionId] = fn }
+                saveCache()
+                return resp
+            }
+            return []
+        }
+        return Array(functions.values)
+    }
+
+    public func functionDetails(id: String) async -> Function? {
+        if let _ = baseURL {
+            if let data = try? await request(path: "functions/\(id)", method: "GET", body: nil),
+               let fn = try? JSONDecoder().decode(Function.self, from: data) {
+                functions[id] = fn
+                saveCache()
+                return fn
+            }
+            return nil
+        }
+        return functions[id]
+    }
+
+    // MARK: - Baseline Data
+    public func addBaseline(_ baseline: Baseline) async {
+        if let _ = baseURL {
+            let body = try? JSONEncoder().encode(baseline)
+            _ = try? await request(path: "corpora/\(baseline.corpusId)/baselines", method: "POST", body: body)
+        } else {
+            var items = baselines[baseline.corpusId] ?? [:]
+            items[baseline.baselineId] = baseline
+            baselines[baseline.corpusId] = items
+        }
+    }
+
+    public func addDrift(_ drift: Drift) async {
+        if let _ = baseURL {
+            let body = try? JSONEncoder().encode(drift)
+            _ = try? await request(path: "corpora/\(drift.corpusId)/drifts", method: "POST", body: body)
+        } else {
+            var items = drifts[drift.corpusId] ?? [:]
+            items[drift.driftId] = drift
+            drifts[drift.corpusId] = items
+        }
+    }
+
+    public func addPatterns(_ patternsReq: Patterns) async {
+        if let _ = baseURL {
+            let body = try? JSONEncoder().encode(patternsReq)
+            _ = try? await request(path: "corpora/\(patternsReq.corpusId)/patterns", method: "POST", body: body)
+        } else {
+            var items = patterns[patternsReq.corpusId] ?? [:]
+            items[patternsReq.patternsId] = patternsReq
+            patterns[patternsReq.corpusId] = items
+        }
+    }
+
+    // MARK: - Roles
+    public func addRole(_ role: Role) async {
+        if let _ = baseURL {
+            let body = try? JSONEncoder().encode(role)
+            _ = try? await request(path: "corpora/\(role.corpusId)/roles", method: "POST", body: body)
+        } else {
+            var items = roles[role.corpusId] ?? [:]
+            items[role.name] = role
+            roles[role.corpusId] = items
+        }
+    }
+
+    public func listRoles(for corpusId: String) async -> [Role] {
+        if let _ = baseURL {
+            if let data = try? await request(path: "corpora/\(corpusId)/roles", method: "GET", body: nil),
+               let resp = try? JSONDecoder().decode([Role].self, from: data) {
+                return resp
+            }
+            return []
+        }
+        if let dict = roles[corpusId] {
+            return Array(dict.values)
+        }
+        return []
+    }
+
+    public func addReflection(_ reflection: Reflection) async {
+        if let _ = baseURL {
+            let body = try? JSONEncoder().encode(reflection)
+            _ = try? await request(path: "corpora/\(reflection.corpusId)/reflections", method: "POST", body: body)
+        } else {
+            var items = reflections[reflection.corpusId] ?? [:]
+            items[reflection.reflectionId] = reflection
+            reflections[reflection.corpusId] = items
+        }
+    }
+
+    public func reflectionCount(for corpusId: String) async -> Int {
+        if let _ = baseURL {
+            if let data = try? await request(path: "corpora/\(corpusId)/reflections", method: "GET", body: nil),
+               let resp = try? JSONDecoder().decode([String: Int].self, from: data),
+               let count = resp["total"] {
+                return count
+            }
+            return 0
+        }
+        return reflections[corpusId]?.count ?? 0
+    }
+
+    public func baselineCount(for corpusId: String) async -> Int {
+        if let _ = baseURL {
+            if let data = try? await request(path: "corpora/\(corpusId)/baselines", method: "GET", body: nil),
+               let resp = try? JSONDecoder().decode([String: Int].self, from: data),
+               let count = resp["total"] {
+                return count
+            }
+            return 0
+        }
+        return baselines[corpusId]?.count ?? 0
+    }
+
+    public func driftCount(for corpusId: String) async -> Int {
+        if let _ = baseURL {
+            if let data = try? await request(path: "corpora/\(corpusId)/drifts", method: "GET", body: nil),
+               let resp = try? JSONDecoder().decode([String: Int].self, from: data),
+               let count = resp["total"] {
+                return count
+            }
+            return 0
+        }
+        return drifts[corpusId]?.count ?? 0
+    }
+
+    public func patternsCount(for corpusId: String) async -> Int {
+        if let _ = baseURL {
+            if let data = try? await request(path: "corpora/\(corpusId)/patterns", method: "GET", body: nil),
+               let resp = try? JSONDecoder().decode([String: Int].self, from: data),
+               let count = resp["total"] {
+                return count
+            }
+            return 0
+        }
+        return patterns[corpusId]?.count ?? 0
+    }
+
+    public func latestReflection(for corpusId: String) async -> Reflection? {
+        if let _ = baseURL {
+            if let data = try? await request(path: "corpora/\(corpusId)/reflections", method: "GET", body: nil),
+               let items = try? JSONDecoder().decode([Reflection].self, from: data) {
+                return items.last
+            }
+            return nil
+        }
+        if let dict = reflections[corpusId] {
+            return Array(dict.values).last
+        }
+        return nil
+    }
+
+    public func historyCount(for corpusId: String) async -> Int {
+        if let _ = baseURL {
+            var total = 0
+            if let data = try? await request(path: "corpora/\(corpusId)/baselines", method: "GET", body: nil),
+               let resp = try? JSONDecoder().decode([String: Int].self, from: data),
+               let count = resp["total"] { total += count }
+            if let data = try? await request(path: "corpora/\(corpusId)/drifts", method: "GET", body: nil),
+               let resp = try? JSONDecoder().decode([String: Int].self, from: data),
+               let count = resp["total"] { total += count }
+            if let data = try? await request(path: "corpora/\(corpusId)/patterns", method: "GET", body: nil),
+               let resp = try? JSONDecoder().decode([String: Int].self, from: data),
+               let count = resp["total"] { total += count }
+            if let data = try? await request(path: "corpora/\(corpusId)/reflections", method: "GET", body: nil),
+               let resp = try? JSONDecoder().decode([String: Int].self, from: data),
+               let count = resp["total"] { total += count }
+            return total
+        }
+        let b = baselines[corpusId]?.count ?? 0
+        let d = drifts[corpusId]?.count ?? 0
+        let p = patterns[corpusId]?.count ?? 0
+        let r = reflections[corpusId]?.count ?? 0
+        return b + d + p + r
+    }
+
+    /// Clears all stored data. Tests call this to avoid state leakage.
+    public func reset() async {
+        corpora.removeAll()
+        functions.removeAll()
+        baselines.removeAll()
+        drifts.removeAll()
+        patterns.removeAll()
+        reflections.removeAll()
+        roles.removeAll()
+        saveCache()
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/baseline-awareness/BaselineStore.swift
+++ b/Sources/FountainOps/Generated/Server/baseline-awareness/BaselineStore.swift
@@ -1,0 +1,74 @@
+import Foundation
+import ServiceShared
+
+/// In-memory store used by the Baseline Awareness service during tests.
+public actor BaselineStore {
+    public static let shared = BaselineStore()
+
+    private let typesense: TypesenseClient
+
+    private init(typesense: TypesenseClient = .shared) {
+        self.typesense = typesense
+    }
+
+    // MARK: - Corpus Management
+    public func createCorpus(id: String) async -> InitOut {
+        _ = await typesense.createCorpus(id: id)
+        return InitOut(message: "created")
+    }
+
+    // MARK: - Baseline Data
+    public func addBaseline(_ baseline: BaselineRequest) async {
+        let item = Baseline(baselineId: baseline.baselineId, content: baseline.content, corpusId: baseline.corpusId)
+        await typesense.addBaseline(item)
+    }
+
+    public func addDrift(_ drift: DriftRequest) async {
+        let item = Drift(content: drift.content, corpusId: drift.corpusId, driftId: drift.driftId)
+        await typesense.addDrift(item)
+    }
+
+    public func addPatterns(_ patternsReq: PatternsRequest) async {
+        let item = Patterns(content: patternsReq.content, corpusId: patternsReq.corpusId, patternsId: patternsReq.patternsId)
+        await typesense.addPatterns(item)
+    }
+
+    public func addReflection(_ reflection: ReflectionRequest) async {
+        let item = Reflection(content: reflection.content, corpusId: reflection.corpusId, question: reflection.question, reflectionId: reflection.reflectionId)
+        await typesense.addReflection(item)
+    }
+
+    public func addRole(_ role: Role) async {
+        await typesense.addRole(role)
+    }
+
+    public func listRoles(for corpusId: String) async -> [Role] {
+        await typesense.listRoles(for: corpusId)
+    }
+
+    // MARK: - Query
+    public func reflectionSummary(for corpusId: String) async -> ReflectionSummaryResponse {
+        let count = await typesense.reflectionCount(for: corpusId)
+        return ReflectionSummaryResponse(message: "\(count) reflections")
+    }
+
+    public func historySummary(for corpusId: String) async -> HistorySummaryResponse {
+        let count = await typesense.historyCount(for: corpusId)
+        return HistorySummaryResponse(summary: "items: \(count)")
+    }
+
+    public func latestReflection(for corpusId: String) async -> Reflection? {
+        await typesense.latestReflection(for: corpusId)
+    }
+
+    public func historyAnalytics(for corpusId: String) async -> HistoryAnalyticsResponse {
+        async let b = typesense.baselineCount(for: corpusId)
+        async let d = typesense.driftCount(for: corpusId)
+        async let p = typesense.patternsCount(for: corpusId)
+        async let r = typesense.reflectionCount(for: corpusId)
+        return await HistoryAnalyticsResponse(baselines: b, drifts: d, patterns: p, reflections: r)
+    }
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/baseline-awareness/Dockerfile
+++ b/Sources/FountainOps/Generated/Server/baseline-awareness/Dockerfile
@@ -1,0 +1,11 @@
+# baseline-awareness server container
+FROM swift:6.1-jammy AS build
+WORKDIR /src
+COPY . .
+RUN swift build -c release --product baseline-awareness-server
+
+FROM ubuntu:22.04
+COPY --from=build /src/.build/release/baseline-awareness-server /server
+CMD ["/server"]
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/baseline-awareness/HTTPKernel.swift
+++ b/Sources/FountainOps/Generated/Server/baseline-awareness/HTTPKernel.swift
@@ -1,0 +1,30 @@
+import Foundation
+import ServiceShared
+
+/// Baseline Awareness service kernel. Requires a bearer token when
+/// `BASELINE_AUTH_TOKEN` is set. See `docs/environment_variables.md`.
+
+public struct HTTPKernel: @unchecked Sendable {
+    let router: Router
+
+    public init(handlers: Handlers = Handlers()) {
+        self.router = Router(handlers: handlers)
+    }
+
+    public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
+        if let token = ProcessInfo.processInfo.environment["BASELINE_AUTH_TOKEN"] {
+            let expected = "Bearer \(token)"
+            if request.headers["Authorization"] != expected {
+                return HTTPResponse(status: 401)
+            }
+        }
+        let start = Date()
+        let resp = try await router.route(request)
+        let duration = Date().timeIntervalSince(start)
+        await PrometheusAdapter.shared.record(service: "baseline-awareness", path: request.path)
+        await PrometheusAdapter.shared.recordDuration(service: "baseline-awareness", path: request.path, duration: duration)
+        return resp
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/baseline-awareness/HTTPRequest.swift
+++ b/Sources/FountainOps/Generated/Server/baseline-awareness/HTTPRequest.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct NoBody: Codable {}
+
+public struct HTTPRequest: @unchecked Sendable {
+    public let method: String
+    public let path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/baseline-awareness/HTTPResponse.swift
+++ b/Sources/FountainOps/Generated/Server/baseline-awareness/HTTPResponse.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct HTTPResponse: @unchecked Sendable {
+    public var status: Int
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(status: Int = 200, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/baseline-awareness/HTTPServer.swift
+++ b/Sources/FountainOps/Generated/Server/baseline-awareness/HTTPServer.swift
@@ -1,0 +1,61 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import BaselineAwarenessService
+
+/// Simple URLProtocol based HTTP server used for integration tests.
+@preconcurrency public class HTTPServer: URLProtocol {
+    /// Shared kernel used to handle HTTP requests.
+    nonisolated(unsafe) static var kernel: HTTPKernel?
+
+    /// Register the kernel that will handle incoming requests.
+    public static func register(kernel: HTTPKernel) {
+        self.kernel = kernel
+        // Silence warning about unused return value.
+        _ = URLProtocol.registerClass(HTTPServer.self)
+    }
+
+    public override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "localhost"
+    }
+
+    public override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override public func startLoading() {
+        guard let kernel = HTTPServer.kernel, let url = self.request.url else {
+            self.client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        let req = HTTPRequest(
+            method: self.request.httpMethod ?? "GET",
+            path: url.path,
+            headers: self.request.allHTTPHeaderFields ?? [:],
+            body: self.request.httpBody ?? Data()
+        )
+        let client = self.client
+        let strongSelf = self
+        Task { @Sendable in
+            do {
+                let resp = try await kernel.handle(req)
+                let httpResponse = HTTPURLResponse(
+                    url: url,
+                    statusCode: resp.status,
+                    httpVersion: "HTTP/1.1",
+                    headerFields: resp.headers
+                )!
+                client?.urlProtocol(strongSelf, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
+                client?.urlProtocol(strongSelf, didLoad: resp.body)
+                client?.urlProtocolDidFinishLoading(strongSelf)
+            } catch {
+                client?.urlProtocol(strongSelf, didFailWithError: error)
+            }
+        }
+    }
+
+    override public func stopLoading() {}
+}
+
+extension HTTPServer: @unchecked Sendable {}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/baseline-awareness/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/baseline-awareness/Handlers.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Service handlers backed by an in-memory ``BaselineStore``.
+public struct Handlers {
+    let store: BaselineStore
+
+    public init(store: BaselineStore = .shared) {
+        self.store = store
+    }
+
+    public func readsemanticarc(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
+        let comps = URLComponents(string: request.path)
+        let corpusId = comps?.queryItems?.first(where: { $0.name == "corpus_id" })?.value
+        guard let id = corpusId else {
+            return HTTPResponse(status: 400)
+        }
+        let data = Data("arc for \(id)".utf8)
+        return HTTPResponse(body: data)
+    }
+
+    public func summarizehistory(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
+        guard let corpusId = request.path.split(separator: "/").last else {
+            return HTTPResponse(status: 404)
+        }
+        let summary = await store.historySummary(for: String(corpusId))
+        let data = try JSONEncoder().encode(summary)
+        return HTTPResponse(body: data)
+    }
+
+    public func addreflection(_ request: HTTPRequest, body: ReflectionRequest?) async throws -> HTTPResponse {
+        guard let model = body else { return HTTPResponse(status: 400) }
+        await store.addReflection(model)
+        let data = Data("\"ok\"".utf8)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+    }
+
+    public func listhistory(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
+        guard let corpusId = request.path.split(separator: "/").last else {
+            return HTTPResponse(status: 404)
+        }
+        let summary = await store.historySummary(for: String(corpusId))
+        let data = try JSONEncoder().encode(summary)
+        return HTTPResponse(body: data)
+    }
+
+    public func adddrift(_ request: HTTPRequest, body: DriftRequest?) async throws -> HTTPResponse {
+        guard let drift = body else { return HTTPResponse(status: 400) }
+        await store.addDrift(drift)
+        let data = Data("\"ok\"".utf8)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+    }
+
+    public func listhistoryanalytics(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
+        let comps = URLComponents(string: request.path)
+        let corpusId = comps?.queryItems?.first(where: { $0.name == "corpus_id" })?.value
+        guard let id = corpusId else {
+            return HTTPResponse(status: 400)
+        }
+        let analytics = await store.historyAnalytics(for: id)
+        let data = try JSONEncoder().encode(analytics)
+        return HTTPResponse(body: data)
+    }
+
+    public func streamhistoryanalytics(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
+        let comps = URLComponents(string: request.path)
+        let corpusId = comps?.queryItems?.first(where: { $0.name == "corpus_id" })?.value
+        guard let id = corpusId else {
+            return HTTPResponse(status: 400)
+        }
+        let analytics = await store.historyAnalytics(for: id)
+        let data = try JSONEncoder().encode(analytics)
+        let json = String(data: data, encoding: .utf8) ?? "{}"
+        let bodyText = "event: analytics\ndata: \(json)\n\n"
+        return HTTPResponse(status: 200, headers: ["Content-Type": "text/event-stream"], body: Data(bodyText.utf8))
+    }
+
+    public func addpatterns(_ request: HTTPRequest, body: PatternsRequest?) async throws -> HTTPResponse {
+        guard let patterns = body else { return HTTPResponse(status: 400) }
+        await store.addPatterns(patterns)
+        let data = Data("\"ok\"".utf8)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+    }
+
+    public func healthHealthGet(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
+        let json = try JSONEncoder().encode(["status": "ok"])
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: json)
+    }
+
+    public func listreflections(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
+        guard let corpusId = request.path.split(separator: "/").last else {
+            return HTTPResponse(status: 404)
+        }
+        let summary = await store.reflectionSummary(for: String(corpusId))
+        let data = try JSONEncoder().encode(summary)
+        return HTTPResponse(body: data)
+    }
+
+    public func initializecorpus(_ request: HTTPRequest, body: InitIn?) async throws -> HTTPResponse {
+        guard let initReq = body else { return HTTPResponse(status: 400) }
+        let resp = await store.createCorpus(id: initReq.corpusId)
+        let data = try JSONEncoder().encode(resp)
+        return HTTPResponse(body: data)
+    }
+
+    public func addbaseline(_ request: HTTPRequest, body: BaselineRequest?) async throws -> HTTPResponse {
+        guard let baseline = body else { return HTTPResponse(status: 400) }
+        await store.addBaseline(baseline)
+        let data = Data("\"ok\"".utf8)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/baseline-awareness/Models.swift
+++ b/Sources/FountainOps/Generated/Server/baseline-awareness/Models.swift
@@ -1,0 +1,91 @@
+// Models for Baseline Awareness Service
+
+public struct BaselineRequest: Codable, Sendable {
+    public let baselineId: String
+    public let content: String
+    public let corpusId: String
+
+    public init(baselineId: String, content: String, corpusId: String) {
+        self.baselineId = baselineId
+        self.content = content
+        self.corpusId = corpusId
+    }
+}
+
+public struct DriftRequest: Codable, Sendable {
+    public let content: String
+    public let corpusId: String
+    public let driftId: String
+
+    public init(content: String, corpusId: String, driftId: String) {
+        self.content = content
+        self.corpusId = corpusId
+        self.driftId = driftId
+    }
+}
+
+public struct HistorySummaryResponse: Codable, Sendable {
+    public let summary: String
+}
+
+public struct InitIn: Codable, Sendable {
+    public let corpusId: String
+}
+
+public struct InitOut: Codable, Sendable {
+    public let message: String
+}
+
+public struct PatternsRequest: Codable, Sendable {
+    public let content: String
+    public let corpusId: String
+    public let patternsId: String
+
+    public init(content: String, corpusId: String, patternsId: String) {
+        self.content = content
+        self.corpusId = corpusId
+        self.patternsId = patternsId
+    }
+}
+
+public struct ReflectionRequest: Codable, Sendable {
+    public let content: String
+    public let corpusId: String
+    public let question: String
+    public let reflectionId: String
+
+    public init(content: String, corpusId: String, question: String, reflectionId: String) {
+        self.content = content
+        self.corpusId = corpusId
+        self.question = question
+        self.reflectionId = reflectionId
+    }
+}
+
+public struct ReflectionSummaryResponse: Codable, Sendable {
+    public let message: String
+}
+
+public struct HistoryAnalyticsResponse: Codable, Sendable {
+    public let baselines: Int
+    public let drifts: Int
+    public let patterns: Int
+    public let reflections: Int
+}
+
+public typealias readSemanticArcResponse = String
+
+public typealias addReflectionResponse = String
+
+public typealias addDriftResponse = String
+
+public typealias listHistoryAnalyticsResponse = HistoryAnalyticsResponse
+
+public typealias addPatternsResponse = String
+
+public typealias health_health_getResponse = String
+
+public typealias addBaselineResponse = String
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/baseline-awareness/Router.swift
+++ b/Sources/FountainOps/Generated/Server/baseline-awareness/Router.swift
@@ -1,0 +1,61 @@
+/// Routes HTTP requests to service handlers.
+/// Documentation lives in `docs/handbook/code_reference.md`.
+import Foundation
+import ServiceShared
+
+public struct Router {
+    public var handlers: Handlers
+
+    public init(handlers: Handlers = Handlers()) {
+        self.handlers = handlers
+    }
+
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let path = request.path.split(separator: "?").first.map(String.init) ?? request.path
+        switch (request.method, path) {
+        case ("GET", "/corpus/semantic-arc"):
+            let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
+            return try await handlers.readsemanticarc(request, body: body)
+        case ("GET", "/corpus/summary/{corpus_id}"):
+            let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
+            return try await handlers.summarizehistory(request, body: body)
+        case ("POST", "/corpus/reflections"):
+            let body = try? JSONDecoder().decode(ReflectionRequest.self, from: request.body)
+            return try await handlers.addreflection(request, body: body)
+        case ("GET", "/corpus/history/{corpus_id}"):
+            let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
+            return try await handlers.listhistory(request, body: body)
+        case ("POST", "/corpus/drift"):
+            let body = try? JSONDecoder().decode(DriftRequest.self, from: request.body)
+            return try await handlers.adddrift(request, body: body)
+        case ("GET", "/corpus/history"):
+            let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
+            return try await handlers.listhistoryanalytics(request, body: body)
+        case ("POST", "/corpus/patterns"):
+            let body = try? JSONDecoder().decode(PatternsRequest.self, from: request.body)
+            return try await handlers.addpatterns(request, body: body)
+        case ("GET", "/health"):
+            let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
+            return try await handlers.healthHealthGet(request, body: body)
+        case ("GET", "/metrics"):
+            let text = await PrometheusAdapter.shared.exposition()
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data(text.utf8))
+        case ("GET", "/corpus/history/stream"):
+            let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
+            return try await handlers.streamhistoryanalytics(request, body: body)
+        case ("GET", "/corpus/reflections/{corpus_id}"):
+            let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
+            return try await handlers.listreflections(request, body: body)
+        case ("POST", "/corpus/init"):
+            let body = try? JSONDecoder().decode(InitIn.self, from: request.body)
+            return try await handlers.initializecorpus(request, body: body)
+        case ("POST", "/corpus/baseline"):
+            let body = try? JSONDecoder().decode(BaselineRequest.self, from: request.body)
+            return try await handlers.addbaseline(request, body: body)
+        default:
+            return HTTPResponse(status: 404)
+        }
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/baseline-awareness/main.swift
+++ b/Sources/FountainOps/Generated/Server/baseline-awareness/main.swift
@@ -1,0 +1,120 @@
+/// Entry point for the Baseline Awareness server.
+/// See `docs/handbook/code_reference.md` for documentation and
+/// `docs/environment_variables.md` for configuration.
+import Foundation
+import Dispatch
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+import BaselineAwarenessService
+
+final class SimpleHTTPRuntime: @unchecked Sendable {
+    enum RuntimeError: Error { case socket, bind, listen }
+    let kernel: HTTPKernel
+    let port: Int32
+    private var serverFD: Int32 = -1
+
+    init(kernel: HTTPKernel, port: Int32 = 8080) {
+        self.kernel = kernel
+        self.port = port
+    }
+
+    func start() throws {
+        #if os(Linux)
+        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        #else
+        serverFD = socket(AF_INET, SOCK_STREAM, 0)
+        #endif
+        guard serverFD >= 0 else { throw RuntimeError.socket }
+        var opt: Int32 = 1
+        setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = in_port_t(UInt16(port).bigEndian)
+        addr.sin_addr = in_addr(s_addr: in_addr_t(0))
+        let bindResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { ptr in
+                bind(serverFD, ptr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult >= 0 else { throw RuntimeError.bind }
+        guard listen(serverFD, 16) >= 0 else { throw RuntimeError.listen }
+        DispatchQueue.global().async { [weak self] in self?.acceptLoop() }
+    }
+
+    private func acceptLoop() {
+        while true {
+            var addr = sockaddr()
+            var len: socklen_t = socklen_t(MemoryLayout<sockaddr>.size)
+            let fd = accept(serverFD, &addr, &len)
+            if fd >= 0 {
+                DispatchQueue.global().async {
+                    self.handle(fd: fd)
+                }
+            }
+        }
+    }
+
+    private func handle(fd: Int32) {
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        let n = read(fd, &buffer, buffer.count)
+        guard n > 0 else { close(fd); return }
+        let data = Data(buffer[0..<n])
+        guard let request = parseRequest(data) else { close(fd); return }
+        Task {
+            let resp = try await kernel.handle(request)
+            let respData = serialize(resp)
+            respData.withUnsafeBytes { _ = write(fd, $0.baseAddress!, respData.count) }
+            close(fd)
+        }
+    }
+
+    private func parseRequest(_ data: Data) -> HTTPRequest? {
+        guard let headerRange = data.range(of: Data("\r\n\r\n".utf8)) else { return nil }
+        let headerData = data[..<headerRange.lowerBound]
+        let bodyData = data[headerRange.upperBound...]
+        guard let headerString = String(data: headerData, encoding: .utf8) else { return nil }
+        let headerLines = headerString.split(separator: "\r\n")
+        guard let requestLine = headerLines.first else { return nil }
+        let tokens = requestLine.split(separator: " ")
+        guard tokens.count >= 2 else { return nil }
+        let method = String(tokens[0])
+        let path = String(tokens[1])
+        var headers: [String: String] = [:]
+        for line in headerLines.dropFirst() {
+            let parts = line.split(separator: ":", maxSplits: 1)
+            if parts.count == 2 {
+                let name = parts[0].trimmingCharacters(in: .whitespaces)
+                let value = parts[1].trimmingCharacters(in: .whitespaces)
+                headers[String(name)] = String(value)
+            }
+        }
+        return HTTPRequest(method: method, path: path, headers: headers, body: Data(bodyData))
+    }
+
+    private func serialize(_ resp: HTTPResponse) -> Data {
+        var text = "HTTP/1.1 \(resp.status) OK\r\n"
+        for (k, v) in resp.headers { text += "\(k): \(v)\r\n" }
+        text += "Content-Length: \(resp.body.count)\r\n"
+        text += "\r\n"
+        var data = Data(text.utf8)
+        data.append(resp.body)
+        return data
+    }
+}
+
+let kernel = HTTPKernel()
+
+do {
+    let runtime = SimpleHTTPRuntime(kernel: kernel, port: 8080)
+    try runtime.start()
+    print("baseline-awareness server listening on port 8080")
+    dispatchMain()
+} catch {
+    print("Failed to start server: \(error)")
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/bootstrap/Dockerfile
+++ b/Sources/FountainOps/Generated/Server/bootstrap/Dockerfile
@@ -1,0 +1,11 @@
+# bootstrap server container
+FROM swift:6.1-jammy AS build
+WORKDIR /src
+COPY . .
+RUN swift build -c release --product bootstrap-server
+
+FROM ubuntu:22.04
+COPY --from=build /src/.build/release/bootstrap-server /server
+CMD ["/server"]
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/bootstrap/HTTPKernel.swift
+++ b/Sources/FountainOps/Generated/Server/bootstrap/HTTPKernel.swift
@@ -1,0 +1,26 @@
+import Foundation
+import ServiceShared
+
+/// Bootstrap service kernel. Requires a bearer token when
+/// `BOOTSTRAP_AUTH_TOKEN` is set. See `docs/environment_variables.md`.
+public struct HTTPKernel {
+    let router: Router
+
+    public init(handlers: Handlers = Handlers()) {
+        self.router = Router(handlers: handlers)
+    }
+
+    public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
+        if let token = ProcessInfo.processInfo.environment["BOOTSTRAP_AUTH_TOKEN"] {
+            let expected = "Bearer \(token)"
+            if request.headers["Authorization"] != expected {
+                return HTTPResponse(status: 401)
+            }
+        }
+        let resp = try await router.route(request)
+        await PrometheusAdapter.shared.record(service: "bootstrap", path: request.path)
+        return resp
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/bootstrap/HTTPRequest.swift
+++ b/Sources/FountainOps/Generated/Server/bootstrap/HTTPRequest.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct HTTPRequest {
+    public let method: String
+    public let path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/bootstrap/HTTPResponse.swift
+++ b/Sources/FountainOps/Generated/Server/bootstrap/HTTPResponse.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct HTTPResponse {
+    public var status: Int
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(status: Int = 200, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/bootstrap/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/bootstrap/Handlers.swift
@@ -1,0 +1,101 @@
+import Foundation
+import BaselineAwarenessService
+import ServiceShared
+
+/// Service handlers that persist data via `BaselineStore`.
+public struct Handlers {
+    let store: BaselineStore
+
+    public init(store: BaselineStore = .shared) {
+        self.store = store
+    }
+
+    /// Enqueue the default reflection for the corpus.
+    public func bootstrapenqueuereflection(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let model = try? JSONDecoder().decode(InitIn.self, from: request.body) else {
+            return HTTPResponse(status: 400)
+        }
+        let reflection = ReflectionRequest(content: "role-health-check", corpusId: model.corpusId, question: "health", reflectionId: "role-health-check")
+        await store.addReflection(reflection)
+        let resp = InitOut(message: "queued")
+        let data = try JSONEncoder().encode(resp)
+        return HTTPResponse(body: data)
+    }
+
+    /// Initialize a new corpus and seed default roles.
+    public func bootstrapinitializecorpus(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let initReq = try? JSONDecoder().decode(InitIn.self, from: request.body) else {
+            return HTTPResponse(status: 400)
+        }
+        _ = await store.createCorpus(id: initReq.corpusId)
+        _ = try await bootstrapseedroles(request)
+        let reflection = ReflectionRequest(content: "role-health-check", corpusId: initReq.corpusId, question: "health", reflectionId: "role-health-check")
+        await store.addReflection(reflection)
+        let out = InitOut(message: "created")
+        let data = try JSONEncoder().encode(out)
+        return HTTPResponse(body: data)
+    }
+
+    public func bootstrappromotereflection(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let comps = URLComponents(string: request.path)
+        let corpusId = comps?.queryItems?.first(where: { $0.name == "corpusId" })?.value
+        let roleName = comps?.queryItems?.first(where: { $0.name == "roleName" })?.value
+        guard let cid = corpusId, let name = roleName else {
+            return HTTPResponse(status: 400)
+        }
+        guard let reflection = await store.latestReflection(for: cid) else {
+            return HTTPResponse(status: 404)
+        }
+        let info = RoleInfo(name: name, prompt: reflection.content)
+        let role = Role(name: name, prompt: reflection.content, corpusId: cid)
+        await store.addRole(role)
+        let data = try JSONEncoder().encode(info)
+        return HTTPResponse(body: data)
+    }
+
+    /// Seed default GPT role prompts.
+    public func bootstrapseedroles(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let _ = try? JSONDecoder().decode(RoleInitRequest.self, from: request.body) else {
+            return HTTPResponse(status: 400)
+        }
+        let data = try JSONEncoder().encode(defaultRoles())
+        return HTTPResponse(body: data)
+    }
+
+    /// Seed default GPT role prompts.
+    public func seedroles(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let _ = try? JSONDecoder().decode(RoleInitRequest.self, from: request.body) else {
+            return HTTPResponse(status: 400)
+        }
+        let data = try JSONEncoder().encode(defaultRoles())
+        return HTTPResponse(body: data)
+    }
+
+    /// Store a new baseline snapshot via the Awareness API.
+    public func bootstrapaddbaseline(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let baseline = try? JSONDecoder().decode(BaselineIn.self, from: request.body) else {
+            return HTTPResponse(status: 400)
+        }
+        let req = BaselineRequest(baselineId: baseline.baselineId, content: baseline.content, corpusId: baseline.corpusId)
+        await store.addBaseline(req)
+        let drift = DriftRequest(content: "drift for \(baseline.baselineId)", corpusId: baseline.corpusId, driftId: "\(baseline.baselineId)-drift")
+        await store.addDrift(drift)
+        let patterns = PatternsRequest(content: "patterns for \(baseline.baselineId)", corpusId: baseline.corpusId, patternsId: "\(baseline.baselineId)-patterns")
+        await store.addPatterns(patterns)
+        let bodyText = "event: drift\ndata: \(drift.content)\n\nevent: patterns\ndata: \(patterns.content)\n\n"
+        let data = Data(bodyText.utf8)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "text/event-stream"], body: data)
+    }
+
+    private func defaultRoles() -> RoleDefaults {
+        RoleDefaults(
+            drift: "Analyze drift",
+            history: "Summarize history",
+            patterns: "Detect patterns",
+            semantic_arc: "Synthesize semantic arc",
+            view_creator: "Create view"
+        )
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/bootstrap/Models.swift
+++ b/Sources/FountainOps/Generated/Server/bootstrap/Models.swift
@@ -1,0 +1,45 @@
+// Models for FountainAI Bootstrap Service
+
+public struct BaselineIn: Codable {
+    public let baselineId: String
+    public let content: String
+    public let corpusId: String
+}
+
+public struct HTTPValidationError: Codable {
+    public let detail: String
+}
+
+public struct InitIn: Codable {
+    public let corpusId: String
+}
+
+public struct InitOut: Codable {
+    public let message: String
+}
+
+public struct RoleDefaults: Codable {
+    public let drift: String
+    public let history: String
+    public let patterns: String
+    public let semantic_arc: String
+    public let view_creator: String
+}
+
+public struct RoleInfo: Codable {
+    public let name: String
+    public let prompt: String
+}
+
+public struct RoleInitRequest: Codable {
+    public let corpusId: String
+}
+
+public struct ValidationError: Codable {
+    public let loc: String
+    public let msg: String
+    public let type: String
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/bootstrap/Router.swift
+++ b/Sources/FountainOps/Generated/Server/bootstrap/Router.swift
@@ -1,0 +1,35 @@
+import Foundation
+import ServiceShared
+
+public struct Router {
+    public var handlers: Handlers
+
+    public init(handlers: Handlers = Handlers()) {
+        self.handlers = handlers
+    }
+
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let path = request.path.split(separator: "?").first.map(String.init) ?? request.path
+        switch (request.method, path) {
+        case ("POST", "/bootstrap/corpus/reflect"):
+            return try await handlers.bootstrapenqueuereflection(request)
+        case ("POST", "/bootstrap/corpus/init"):
+            return try await handlers.bootstrapinitializecorpus(request)
+        case ("POST", "/bootstrap/roles/promote"):
+            return try await handlers.bootstrappromotereflection(request)
+        case ("POST", "/bootstrap/roles/seed"):
+            return try await handlers.bootstrapseedroles(request)
+        case ("POST", "/bootstrap/roles"):
+            return try await handlers.seedroles(request)
+        case ("POST", "/bootstrap/baseline"):
+            return try await handlers.bootstrapaddbaseline(request)
+        case ("GET", "/metrics"):
+            let text = await PrometheusAdapter.shared.exposition()
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data(text.utf8))
+        default:
+            return HTTPResponse(status: 404)
+        }
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/bootstrap/main.swift
+++ b/Sources/FountainOps/Generated/Server/bootstrap/main.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Dispatch
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+import BootstrapService
+
+final class SimpleHTTPRuntime: @unchecked Sendable {
+    enum RuntimeError: Error { case socket, bind, listen }
+    let kernel: HTTPKernel
+    let port: Int32
+    private var serverFD: Int32 = -1
+
+    init(kernel: HTTPKernel, port: Int32 = 8080) {
+        self.kernel = kernel
+        self.port = port
+    }
+
+    func start() throws {
+        #if os(Linux)
+        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        #else
+        serverFD = socket(AF_INET, SOCK_STREAM, 0)
+        #endif
+        guard serverFD >= 0 else { throw RuntimeError.socket }
+        var opt: Int32 = 1
+        setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = in_port_t(UInt16(port).bigEndian)
+        addr.sin_addr = in_addr(s_addr: in_addr_t(0))
+        let bindResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { ptr in
+                bind(serverFD, ptr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult >= 0 else { throw RuntimeError.bind }
+        guard listen(serverFD, 16) >= 0 else { throw RuntimeError.listen }
+        DispatchQueue.global().async { [weak self] in self?.acceptLoop() }
+    }
+
+    private func acceptLoop() {
+        while true {
+            var addr = sockaddr()
+            var len: socklen_t = socklen_t(MemoryLayout<sockaddr>.size)
+            let fd = accept(serverFD, &addr, &len)
+            if fd >= 0 {
+                DispatchQueue.global().async {
+                    self.handle(fd: fd)
+                }
+            }
+        }
+    }
+
+    private func handle(fd: Int32) {
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        let n = read(fd, &buffer, buffer.count)
+        guard n > 0 else { close(fd); return }
+        let data = Data(buffer[0..<n])
+        guard let request = parseRequest(data) else { close(fd); return }
+        Task {
+            let resp = try await kernel.handle(request)
+            let respData = serialize(resp)
+            respData.withUnsafeBytes { _ = write(fd, $0.baseAddress!, respData.count) }
+            close(fd)
+        }
+    }
+
+    private func parseRequest(_ data: Data) -> HTTPRequest? {
+        guard let string = String(data: data, encoding: .utf8) else { return nil }
+        let parts = string.components(separatedBy: "\r\n\r\n")
+        let headerLines = parts[0].split(separator: "\r\n")
+        guard let requestLine = headerLines.first else { return nil }
+        let tokens = requestLine.split(separator: " ")
+        guard tokens.count >= 2 else { return nil }
+        let method = String(tokens[0])
+        let path = String(tokens[1])
+        return HTTPRequest(method: method, path: path)
+    }
+
+    private func serialize(_ resp: HTTPResponse) -> Data {
+        var text = "HTTP/1.1 \(resp.status) OK\r\n"
+        text += "Content-Length: \(resp.body.count)\r\n"
+        text += "\r\n"
+        var data = Data(text.utf8)
+        data.append(resp.body)
+        return data
+    }
+}
+
+let kernel = HTTPKernel()
+do {
+    let runtime = SimpleHTTPRuntime(kernel: kernel, port: 8080)
+    try runtime.start()
+    print("bootstrap server listening on port 8080")
+    dispatchMain()
+} catch {
+    print("Failed to start server: \(error)")
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/function-caller/Dispatcher.swift
+++ b/Sources/FountainOps/Generated/Server/function-caller/Dispatcher.swift
@@ -1,0 +1,43 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import ServiceShared
+import Parser
+
+/// Dispatches registered functions by looking them up from the shared
+/// TypesenseClient and performing a simple URLSession call.
+struct FunctionDispatcher {
+    enum DispatchError: Error { case notFound, invalidParams, server(Int) }
+
+    func invoke(functionId: String, payload: Data) async throws -> Data {
+        guard let fn = await TypesenseClient.shared.functionDetails(id: functionId) else {
+            throw DispatchError.notFound
+        }
+        if let schemaString = fn.parametersSchema,
+           let schemaData = schemaString.data(using: .utf8),
+           let schema = try? JSONDecoder().decode(OpenAPISpec.Schema.self, from: schemaData) {
+            guard let json = try? JSONSerialization.jsonObject(with: payload) as? [String: Any] else {
+                throw DispatchError.invalidParams
+            }
+            if let props = schema.properties {
+                for key in props.keys where json[key] == nil {
+                    throw DispatchError.invalidParams
+                }
+            }
+        }
+        guard let url = URL(string: fn.httpPath) else {
+            throw DispatchError.notFound
+        }
+        var req = URLRequest(url: url)
+        req.httpMethod = fn.httpMethod
+        req.httpBody = payload
+        let (data, resp) = try await URLSession.shared.data(for: req)
+        if let http = resp as? HTTPURLResponse, http.statusCode >= 400 {
+            throw DispatchError.server(http.statusCode)
+        }
+        return data
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/function-caller/Dockerfile
+++ b/Sources/FountainOps/Generated/Server/function-caller/Dockerfile
@@ -1,0 +1,11 @@
+# function-caller server container
+FROM swift:6.1-jammy AS build
+WORKDIR /src
+COPY . .
+RUN swift build -c release --product function-caller-server
+
+FROM ubuntu:22.04
+COPY --from=build /src/.build/release/function-caller-server /server
+CMD ["/server"]
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/function-caller/HTTPKernel.swift
+++ b/Sources/FountainOps/Generated/Server/function-caller/HTTPKernel.swift
@@ -1,0 +1,30 @@
+import Foundation
+import ServiceShared
+
+/// Function Caller service kernel. Requires a bearer token when
+/// `FUNCTION_CALLER_AUTH_TOKEN` is set. See `docs/environment_variables.md`.
+
+public struct HTTPKernel {
+    let router: Router
+
+    public init(handlers: Handlers = Handlers()) {
+        self.router = Router(handlers: handlers)
+    }
+
+    public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
+        if let token = ProcessInfo.processInfo.environment["FUNCTION_CALLER_AUTH_TOKEN"] {
+            let expected = "Bearer \(token)"
+            if request.headers["Authorization"] != expected { return HTTPResponse(status: 401) }
+        }
+        let start = Date()
+        let resp = try await router.route(request)
+        let duration = Date().timeIntervalSince(start)
+        await PrometheusAdapter.shared.record(service: "function-caller", path: request.path)
+        await PrometheusAdapter.shared.recordDuration(service: "function-caller", path: request.path, duration: duration)
+        await PrometheusAdapter.shared.recordResult(service: "function-caller", path: request.path, success: resp.status < 400)
+        Logger.logRequest(method: request.method, path: request.path, status: resp.status, duration: duration)
+        return resp
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/function-caller/HTTPRequest.swift
+++ b/Sources/FountainOps/Generated/Server/function-caller/HTTPRequest.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct HTTPRequest {
+    public let method: String
+    public let path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/function-caller/HTTPResponse.swift
+++ b/Sources/FountainOps/Generated/Server/function-caller/HTTPResponse.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct HTTPResponse {
+    public var status: Int
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(status: Int = 200, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/function-caller/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/function-caller/Handlers.swift
@@ -1,0 +1,55 @@
+import Foundation
+import ServiceShared
+
+/// Implements the Function Caller dispatch mechanism. Registered functions are
+/// looked up from the shared TypesenseClient and invoked via URLSession.
+public struct Handlers {
+    let dispatcher = FunctionDispatcher()
+
+    public init() {}
+
+    public func getFunctionDetails(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let id = request.path.split(separator: "/").last else {
+            return HTTPResponse(status: 404)
+        }
+        guard let fn = await TypesenseClient.shared.functionDetails(id: String(id)) else {
+            return HTTPResponse(status: 404)
+        }
+        let enc = JSONEncoder()
+        enc.keyEncodingStrategy = .convertToSnakeCase
+        let data = try enc.encode(fn)
+        return HTTPResponse(body: data)
+    }
+
+    public func listFunctions(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let fns = await TypesenseClient.shared.listFunctions()
+        let enc = JSONEncoder()
+        enc.keyEncodingStrategy = .convertToSnakeCase
+        let data = try enc.encode(fns)
+        return HTTPResponse(body: data)
+    }
+
+    public func invokeFunction(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let id = request.path.split(separator: "/").dropLast().last else {
+            return HTTPResponse(status: 404)
+        }
+        do {
+            let result = try await dispatcher.invoke(functionId: String(id), payload: request.body)
+            return HTTPResponse(body: result)
+        } catch FunctionDispatcher.DispatchError.notFound {
+            let data = try JSONEncoder().encode(ErrorResponse(error_code: "not_found", message: "Function not found"))
+            return HTTPResponse(status: 404, body: data)
+        } catch FunctionDispatcher.DispatchError.invalidParams {
+            let data = try JSONEncoder().encode(ErrorResponse(error_code: "validation_error", message: "Invalid parameters"))
+            return HTTPResponse(status: 400, body: data)
+        } catch FunctionDispatcher.DispatchError.server(let code) {
+            let data = try JSONEncoder().encode(ErrorResponse(error_code: "dispatch_error", message: "Remote error"))
+            return HTTPResponse(status: code, body: data)
+        } catch {
+            let data = try JSONEncoder().encode(ErrorResponse(error_code: "internal_error", message: error.localizedDescription))
+            return HTTPResponse(status: 500, body: data)
+        }
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/function-caller/Logger.swift
+++ b/Sources/FountainOps/Generated/Server/function-caller/Logger.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct Logger {
+    static func logRequest(method: String, path: String, status: Int, duration: Double) {
+        let entry: [String: Any] = [
+            "timestamp": ISO8601DateFormatter().string(from: Date()),
+            "method": method,
+            "path": path,
+            "status": status,
+            "duration_ms": Int(duration * 1000)
+        ]
+        if let data = try? JSONSerialization.data(withJSONObject: entry),
+           let text = String(data: data, encoding: .utf8) {
+            print(text)
+        }
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/function-caller/Models.swift
+++ b/Sources/FountainOps/Generated/Server/function-caller/Models.swift
@@ -1,0 +1,18 @@
+// Models for FountainAI Function Caller Service
+
+public struct ErrorResponse: Codable {
+    public let error_code: String
+    public let message: String
+}
+
+public struct FunctionInfo: Codable {
+    public let description: String
+    public let function_id: String
+    public let http_method: String
+    public let http_path: String
+    public let name: String
+    public let parameters_schema: String
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/function-caller/Router.swift
+++ b/Sources/FountainOps/Generated/Server/function-caller/Router.swift
@@ -1,0 +1,28 @@
+import Foundation
+import ServiceShared
+
+public struct Router {
+    public var handlers: Handlers
+
+    public init(handlers: Handlers = Handlers()) {
+        self.handlers = handlers
+    }
+
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
+        switch (request.method, request.path) {
+        case ("GET", "/functions/{function_id}"):
+            return try await handlers.getFunctionDetails(request)
+        case ("GET", "/functions"):
+            return try await handlers.listFunctions(request)
+        case ("POST", "/functions/{function_id}/invoke"):
+            return try await handlers.invokeFunction(request)
+        case ("GET", "/metrics"):
+            let text = await PrometheusAdapter.shared.exposition()
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data(text.utf8))
+        default:
+            return HTTPResponse(status: 404)
+        }
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/function-caller/main.swift
+++ b/Sources/FountainOps/Generated/Server/function-caller/main.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Dispatch
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+import FunctionCallerService
+
+final class SimpleHTTPRuntime: @unchecked Sendable {
+    enum RuntimeError: Error { case socket, bind, listen }
+    let kernel: HTTPKernel
+    let port: Int32
+    private var serverFD: Int32 = -1
+
+    init(kernel: HTTPKernel, port: Int32 = 8080) {
+        self.kernel = kernel
+        self.port = port
+    }
+
+    func start() throws {
+        #if os(Linux)
+        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        #else
+        serverFD = socket(AF_INET, SOCK_STREAM, 0)
+        #endif
+        guard serverFD >= 0 else { throw RuntimeError.socket }
+        var opt: Int32 = 1
+        setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = in_port_t(UInt16(port).bigEndian)
+        addr.sin_addr = in_addr(s_addr: in_addr_t(0))
+        let bindResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { ptr in
+                bind(serverFD, ptr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult >= 0 else { throw RuntimeError.bind }
+        guard listen(serverFD, 16) >= 0 else { throw RuntimeError.listen }
+        DispatchQueue.global().async { [weak self] in self?.acceptLoop() }
+    }
+
+    private func acceptLoop() {
+        while true {
+            var addr = sockaddr()
+            var len: socklen_t = socklen_t(MemoryLayout<sockaddr>.size)
+            let fd = accept(serverFD, &addr, &len)
+            if fd >= 0 {
+                DispatchQueue.global().async {
+                    self.handle(fd: fd)
+                }
+            }
+        }
+    }
+
+    private func handle(fd: Int32) {
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        let n = read(fd, &buffer, buffer.count)
+        guard n > 0 else { close(fd); return }
+        let data = Data(buffer[0..<n])
+        guard let request = parseRequest(data) else { close(fd); return }
+        Task {
+            let resp = try await kernel.handle(request)
+            let respData = serialize(resp)
+            respData.withUnsafeBytes { _ = write(fd, $0.baseAddress!, respData.count) }
+            close(fd)
+        }
+    }
+
+    private func parseRequest(_ data: Data) -> HTTPRequest? {
+        guard let string = String(data: data, encoding: .utf8) else { return nil }
+        let parts = string.components(separatedBy: "\r\n\r\n")
+        let headerLines = parts[0].split(separator: "\r\n")
+        guard let requestLine = headerLines.first else { return nil }
+        let tokens = requestLine.split(separator: " ")
+        guard tokens.count >= 2 else { return nil }
+        let method = String(tokens[0])
+        let path = String(tokens[1])
+        return HTTPRequest(method: method, path: path)
+    }
+
+    private func serialize(_ resp: HTTPResponse) -> Data {
+        var text = "HTTP/1.1 \(resp.status) OK\r\n"
+        text += "Content-Length: \(resp.body.count)\r\n"
+        text += "\r\n"
+        var data = Data(text.utf8)
+        data.append(resp.body)
+        return data
+    }
+}
+
+let kernel = HTTPKernel()
+do {
+    let runtime = SimpleHTTPRuntime(kernel: kernel, port: 8080)
+    try runtime.start()
+    print("function-caller server listening on port 8080")
+    dispatchMain()
+} catch {
+    print("Failed to start server: \(error)")
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/llm-gateway/Dockerfile
+++ b/Sources/FountainOps/Generated/Server/llm-gateway/Dockerfile
@@ -1,0 +1,11 @@
+# llm-gateway server container
+FROM swift:6.1-jammy AS build
+WORKDIR /src
+COPY . .
+RUN swift build -c release --product llm-gateway-server
+
+FROM ubuntu:22.04
+COPY --from=build /src/.build/release/llm-gateway-server /server
+CMD ["/server"]
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/llm-gateway/HTTPKernel.swift
+++ b/Sources/FountainOps/Generated/Server/llm-gateway/HTTPKernel.swift
@@ -1,0 +1,18 @@
+import Foundation
+import ServiceShared
+
+public struct HTTPKernel {
+    let router: Router
+
+    public init(handlers: Handlers = Handlers()) {
+        self.router = Router(handlers: handlers)
+    }
+
+    public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let resp = try await router.route(request)
+        await PrometheusAdapter.shared.record(service: "llm-gateway", path: request.path)
+        return resp
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/llm-gateway/HTTPRequest.swift
+++ b/Sources/FountainOps/Generated/Server/llm-gateway/HTTPRequest.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct HTTPRequest {
+    public let method: String
+    public let path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/llm-gateway/HTTPResponse.swift
+++ b/Sources/FountainOps/Generated/Server/llm-gateway/HTTPResponse.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct HTTPResponse {
+    public var status: Int
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(status: Int = 200, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/llm-gateway/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/llm-gateway/Handlers.swift
@@ -1,0 +1,28 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import ServiceShared
+
+public struct Handlers {
+    public init() {}
+    public func chatwithobjective(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let apiKey = ProcessInfo.processInfo.environment["OPENAI_API_KEY"] else {
+            return HTTPResponse(status: 500)
+        }
+        let base = ProcessInfo.processInfo.environment["OPENAI_API_BASE"] ?? "https://api.openai.com/v1/chat/completions"
+        var urlRequest = URLRequest(url: URL(string: base)!)
+        urlRequest.httpMethod = "POST"
+        urlRequest.httpBody = request.body
+        urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        let (data, _) = try await URLSession.shared.data(for: urlRequest)
+        return HTTPResponse(body: data)
+    }
+    public func metricsMetricsGet(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let text = await PrometheusAdapter.shared.exposition()
+        return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data(text.utf8))
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/llm-gateway/Models.swift
+++ b/Sources/FountainOps/Generated/Server/llm-gateway/Models.swift
@@ -1,0 +1,35 @@
+// Models for FountainAI LLM Gateway
+
+public struct ChatRequest: Codable {
+    public let function_call: String
+    public let functions: String
+    public let messages: String
+    public let model: String
+}
+
+public struct FunctionCallObject: Codable {
+    public let name: String
+}
+
+public struct FunctionObject: Codable {
+    public let description: String
+    public let name: String
+}
+
+public struct HTTPValidationError: Codable {
+    public let detail: String
+}
+
+public struct MessageObject: Codable {
+    public let content: String
+    public let role: String
+}
+
+public struct ValidationError: Codable {
+    public let loc: String
+    public let msg: String
+    public let type: String
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/llm-gateway/Router.swift
+++ b/Sources/FountainOps/Generated/Server/llm-gateway/Router.swift
@@ -1,0 +1,23 @@
+import Foundation
+import ServiceShared
+
+public struct Router {
+    public var handlers: Handlers
+
+    public init(handlers: Handlers = Handlers()) {
+        self.handlers = handlers
+    }
+
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
+        switch (request.method, request.path) {
+        case ("POST", "/chat"):
+            return try await handlers.chatwithobjective(request)
+        case ("GET", "/metrics"):
+            return try await handlers.metricsMetricsGet(request)
+        default:
+            return HTTPResponse(status: 404)
+        }
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/llm-gateway/main.swift
+++ b/Sources/FountainOps/Generated/Server/llm-gateway/main.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Dispatch
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+import LLMGatewayService
+
+final class SimpleHTTPRuntime: @unchecked Sendable {
+    enum RuntimeError: Error { case socket, bind, listen }
+    let kernel: HTTPKernel
+    let port: Int32
+    private var serverFD: Int32 = -1
+
+    init(kernel: HTTPKernel, port: Int32 = 8080) {
+        self.kernel = kernel
+        self.port = port
+    }
+
+    func start() throws {
+        #if os(Linux)
+        let socketType: Int32 = Int32(SOCK_STREAM.rawValue)
+        #else
+        let socketType: Int32 = SOCK_STREAM
+        #endif
+
+        serverFD = socket(AF_INET, socketType, 0)
+        guard serverFD >= 0 else { throw RuntimeError.socket }
+        var opt: Int32 = 1
+        setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = in_port_t(UInt16(port).bigEndian)
+        addr.sin_addr = in_addr(s_addr: in_addr_t(0))
+        let bindResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { ptr in
+                bind(serverFD, ptr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult >= 0 else { throw RuntimeError.bind }
+        guard listen(serverFD, 16) >= 0 else { throw RuntimeError.listen }
+        DispatchQueue.global().async { [weak self] in self?.acceptLoop() }
+    }
+
+    private func acceptLoop() {
+        while true {
+            var addr = sockaddr()
+            var len: socklen_t = socklen_t(MemoryLayout<sockaddr>.size)
+            let fd = accept(serverFD, &addr, &len)
+            if fd >= 0 {
+                DispatchQueue.global().async {
+                    self.handle(fd: fd)
+                }
+            }
+        }
+    }
+
+    private func handle(fd: Int32) {
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        let n = read(fd, &buffer, buffer.count)
+        guard n > 0 else { close(fd); return }
+        let data = Data(buffer[0..<n])
+        guard let request = parseRequest(data) else { close(fd); return }
+        Task {
+            let resp = try await kernel.handle(request)
+            let respData = serialize(resp)
+            respData.withUnsafeBytes { _ = write(fd, $0.baseAddress!, respData.count) }
+            close(fd)
+        }
+    }
+
+    private func parseRequest(_ data: Data) -> HTTPRequest? {
+        guard let string = String(data: data, encoding: .utf8) else { return nil }
+        let parts = string.components(separatedBy: "\r\n\r\n")
+        let headerLines = parts[0].split(separator: "\r\n")
+        guard let requestLine = headerLines.first else { return nil }
+        let tokens = requestLine.split(separator: " ")
+        guard tokens.count >= 2 else { return nil }
+        let method = String(tokens[0])
+        let path = String(tokens[1])
+        return HTTPRequest(method: method, path: path)
+    }
+
+    private func serialize(_ resp: HTTPResponse) -> Data {
+        var text = "HTTP/1.1 \(resp.status) OK\r\n"
+        text += "Content-Length: \(resp.body.count)\r\n"
+        text += "\r\n"
+        var data = Data(text.utf8)
+        data.append(resp.body)
+        return data
+    }
+}
+
+let kernel = HTTPKernel()
+do {
+    let runtime = SimpleHTTPRuntime(kernel: kernel, port: 8080)
+    try runtime.start()
+    print("llm-gateway server listening on port 8080")
+    dispatchMain()
+} catch {
+    print("Failed to start server: \(error)")
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/persist/Dockerfile
+++ b/Sources/FountainOps/Generated/Server/persist/Dockerfile
@@ -1,0 +1,11 @@
+# persist server container
+FROM swift:6.1-jammy AS build
+WORKDIR /src
+COPY . .
+RUN swift build -c release --product persist-server
+
+FROM ubuntu:22.04
+COPY --from=build /src/.build/release/persist-server /server
+CMD ["/server"]
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/persist/HTTPKernel.swift
+++ b/Sources/FountainOps/Generated/Server/persist/HTTPKernel.swift
@@ -1,0 +1,18 @@
+import Foundation
+import ServiceShared
+
+public struct HTTPKernel {
+    let router: Router
+
+    public init(handlers: Handlers = Handlers()) {
+        self.router = Router(handlers: handlers)
+    }
+
+    public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let resp = try await router.route(request)
+        await PrometheusAdapter.shared.record(service: "persist", path: request.path)
+        return resp
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/persist/HTTPRequest.swift
+++ b/Sources/FountainOps/Generated/Server/persist/HTTPRequest.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct HTTPRequest {
+    public let method: String
+    public let path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/persist/HTTPResponse.swift
+++ b/Sources/FountainOps/Generated/Server/persist/HTTPResponse.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct HTTPResponse {
+    public var status: Int
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(status: Int = 200, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/persist/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/persist/Handlers.swift
@@ -1,0 +1,84 @@
+import Foundation
+import ServiceShared
+
+/// Persistence handlers wired to an in-memory Typesense client. This mimics the
+/// real Typesense-backed service without requiring the dependency during tests.
+
+public struct Handlers {
+    let typesense: TypesenseClient
+
+    public init(typesense: TypesenseClient = .shared) {
+        self.typesense = typesense
+    }
+    public func addbaseline(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard request.path.split(separator: "/").dropFirst(2).first != nil,
+              let model = try? JSONDecoder().decode(Baseline.self, from: request.body) else {
+            return HTTPResponse(status: 400)
+        }
+        await typesense.addBaseline(model)
+        let data = try JSONEncoder().encode(SuccessResponse(message: "stored"))
+        return HTTPResponse(body: data)
+    }
+
+    public func listreflections(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let corpusId = request.path.split(separator: "/").dropFirst(2).first else {
+            return HTTPResponse(status: 400)
+        }
+        let count = await typesense.reflectionCount(for: String(corpusId))
+        let data = try JSONEncoder().encode(["count": count])
+        return HTTPResponse(body: data)
+    }
+
+    public func addreflection(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard request.path.split(separator: "/").dropFirst(2).first != nil,
+              let reflection = try? JSONDecoder().decode(Reflection.self, from: request.body) else {
+            return HTTPResponse(status: 400)
+        }
+        await typesense.addReflection(reflection)
+        let data = try JSONEncoder().encode(SuccessResponse(message: "stored"))
+        return HTTPResponse(body: data)
+    }
+    public func listcorpora(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let ids = await typesense.listCorpora()
+        let data = try JSONEncoder().encode(ids)
+        return HTTPResponse(body: data)
+    }
+
+    public func createcorpus(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let model = try? JSONDecoder().decode(CorpusCreateRequest.self, from: request.body) else {
+            return HTTPResponse(status: 400)
+        }
+        let resp = await typesense.createCorpus(id: model.corpusId)
+        let data = try JSONEncoder().encode(resp)
+        return HTTPResponse(body: data)
+    }
+
+    public func listfunctions(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let items = await typesense.listFunctions()
+        let data = try JSONEncoder().encode(items)
+        return HTTPResponse(body: data)
+    }
+
+    public func addfunction(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let function = try? JSONDecoder().decode(ServiceShared.Function.self, from: request.body) else {
+            return HTTPResponse(status: 400)
+        }
+        await typesense.addFunction(function)
+        let resp = SuccessResponse(message: "stored")
+        let data = try JSONEncoder().encode(resp)
+        return HTTPResponse(body: data)
+    }
+
+    public func getfunctiondetails(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let id = request.path.split(separator: "/").last else {
+            return HTTPResponse(status: 404)
+        }
+        guard let fn = await typesense.functionDetails(id: String(id)) else {
+            return HTTPResponse(status: 404)
+        }
+        let data = try JSONEncoder().encode(fn)
+        return HTTPResponse(body: data)
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/persist/Models.swift
+++ b/Sources/FountainOps/Generated/Server/persist/Models.swift
@@ -1,0 +1,29 @@
+// Models for FountainAI Persistence Service (Typesense-backed)
+
+public struct BaseEntity: Codable {
+    public let corpusId: String
+}
+
+public struct CorpusCreateRequest: Codable {
+    public let corpusId: String
+}
+
+public struct CorpusResponse: Codable {
+    public let corpusId: String
+    public let message: String
+}
+
+public struct Function: Codable {
+    public let description: String
+    public let functionId: String
+    public let httpMethod: String
+    public let httpPath: String
+    public let name: String
+}
+
+public struct SuccessResponse: Codable {
+    public let message: String
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/persist/Router.swift
+++ b/Sources/FountainOps/Generated/Server/persist/Router.swift
@@ -1,0 +1,38 @@
+import Foundation
+import ServiceShared
+
+public struct Router {
+    public var handlers: Handlers
+
+    public init(handlers: Handlers = Handlers()) {
+        self.handlers = handlers
+    }
+
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
+        switch (request.method, request.path) {
+        case ("POST", "/corpora/{corpusId}/baselines"):
+            return try await handlers.addbaseline(request)
+        case ("GET", "/corpora/{corpusId}/reflections"):
+            return try await handlers.listreflections(request)
+        case ("POST", "/corpora/{corpusId}/reflections"):
+            return try await handlers.addreflection(request)
+        case ("GET", "/corpora"):
+            return try await handlers.listcorpora(request)
+        case ("POST", "/corpora"):
+            return try await handlers.createcorpus(request)
+        case ("GET", "/functions"):
+            return try await handlers.listfunctions(request)
+        case ("POST", "/corpora/{corpusId}/functions"):
+            return try await handlers.addfunction(request)
+        case ("GET", "/functions/{functionId}"):
+            return try await handlers.getfunctiondetails(request)
+        case ("GET", "/metrics"):
+            let text = await PrometheusAdapter.shared.exposition()
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data(text.utf8))
+        default:
+            return HTTPResponse(status: 404)
+        }
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/persist/main.swift
+++ b/Sources/FountainOps/Generated/Server/persist/main.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Dispatch
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+import PersistService
+
+final class SimpleHTTPRuntime: @unchecked Sendable {
+    enum RuntimeError: Error { case socket, bind, listen }
+    let kernel: HTTPKernel
+    let port: Int32
+    private var serverFD: Int32 = -1
+
+    init(kernel: HTTPKernel, port: Int32 = 8080) {
+        self.kernel = kernel
+        self.port = port
+    }
+
+    func start() throws {
+        #if os(Linux)
+        let socketType: Int32 = Int32(SOCK_STREAM.rawValue)
+        #else
+        let socketType: Int32 = SOCK_STREAM
+        #endif
+
+        serverFD = socket(AF_INET, socketType, 0)
+        guard serverFD >= 0 else { throw RuntimeError.socket }
+        var opt: Int32 = 1
+        setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = in_port_t(UInt16(port).bigEndian)
+        addr.sin_addr = in_addr(s_addr: in_addr_t(0))
+        let bindResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { ptr in
+                bind(serverFD, ptr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult >= 0 else { throw RuntimeError.bind }
+        guard listen(serverFD, 16) >= 0 else { throw RuntimeError.listen }
+        DispatchQueue.global().async { [weak self] in self?.acceptLoop() }
+    }
+
+    private func acceptLoop() {
+        while true {
+            var addr = sockaddr()
+            var len: socklen_t = socklen_t(MemoryLayout<sockaddr>.size)
+            let fd = accept(serverFD, &addr, &len)
+            if fd >= 0 {
+                DispatchQueue.global().async {
+                    self.handle(fd: fd)
+                }
+            }
+        }
+    }
+
+    private func handle(fd: Int32) {
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        let n = read(fd, &buffer, buffer.count)
+        guard n > 0 else { close(fd); return }
+        let data = Data(buffer[0..<n])
+        guard let request = parseRequest(data) else { close(fd); return }
+        Task {
+            let resp = try await kernel.handle(request)
+            let respData = serialize(resp)
+            respData.withUnsafeBytes { _ = write(fd, $0.baseAddress!, respData.count) }
+            close(fd)
+        }
+    }
+
+    private func parseRequest(_ data: Data) -> HTTPRequest? {
+        guard let string = String(data: data, encoding: .utf8) else { return nil }
+        let parts = string.components(separatedBy: "\r\n\r\n")
+        let headerLines = parts[0].split(separator: "\r\n")
+        guard let requestLine = headerLines.first else { return nil }
+        let tokens = requestLine.split(separator: " ")
+        guard tokens.count >= 2 else { return nil }
+        let method = String(tokens[0])
+        let path = String(tokens[1])
+        return HTTPRequest(method: method, path: path)
+    }
+
+    private func serialize(_ resp: HTTPResponse) -> Data {
+        var text = "HTTP/1.1 \(resp.status) OK\r\n"
+        text += "Content-Length: \(resp.body.count)\r\n"
+        text += "\r\n"
+        var data = Data(text.utf8)
+        data.append(resp.body)
+        return data
+    }
+}
+
+let kernel = HTTPKernel()
+do {
+    let runtime = SimpleHTTPRuntime(kernel: kernel, port: 8080)
+    try runtime.start()
+    print("persist server listening on port 8080")
+    dispatchMain()
+} catch {
+    print("Failed to start server: \(error)")
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/planner/Dockerfile
+++ b/Sources/FountainOps/Generated/Server/planner/Dockerfile
@@ -1,0 +1,11 @@
+# planner server container
+FROM swift:6.1-jammy AS build
+WORKDIR /src
+COPY . .
+RUN swift build -c release --product planner-server
+
+FROM ubuntu:22.04
+COPY --from=build /src/.build/release/planner-server /server
+CMD ["/server"]
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/planner/HTTPKernel.swift
+++ b/Sources/FountainOps/Generated/Server/planner/HTTPKernel.swift
@@ -1,0 +1,26 @@
+import Foundation
+import ServiceShared
+
+/// Planner service kernel. Requires a bearer token when
+/// `PLANNER_AUTH_TOKEN` is set. See `docs/environment_variables.md`.
+public struct HTTPKernel {
+    let router: Router
+
+    public init(handlers: Handlers = Handlers()) {
+        self.router = Router(handlers: handlers)
+    }
+
+    public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
+        if let token = ProcessInfo.processInfo.environment["PLANNER_AUTH_TOKEN"] {
+            let expected = "Bearer \(token)"
+            if request.headers["Authorization"] != expected {
+                return HTTPResponse(status: 401)
+            }
+        }
+        let resp = try await router.route(request)
+        await PrometheusAdapter.shared.record(service: "planner", path: request.path)
+        return resp
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/planner/HTTPRequest.swift
+++ b/Sources/FountainOps/Generated/Server/planner/HTTPRequest.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct HTTPRequest {
+    public let method: String
+    public let path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/planner/HTTPResponse.swift
+++ b/Sources/FountainOps/Generated/Server/planner/HTTPResponse.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct HTTPResponse {
+    public var status: Int
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(status: Int = 200, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/planner/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/planner/Handlers.swift
@@ -1,0 +1,67 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import ServiceShared
+
+/// Planner handlers orchestrating requests to the LLM Gateway and Function
+/// Caller services.
+
+public struct Handlers {
+    let llm = LLMGatewayClient()
+    let functions = LocalFunctionCallerClient()
+
+    public init() {}
+
+    public func plannerReason(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let objective = try? JSONDecoder().decode(UserObjectiveRequest.self, from: request.body).objective else {
+            return HTTPResponse(status: 400)
+        }
+        let steps = try await llm.chat(objective: objective)
+        let data = try JSONEncoder().encode(PlanResponse(objective: objective, steps: steps))
+        return HTTPResponse(body: data)
+    }
+
+    public func getSemanticArc(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let id = request.path.split(separator: "/").dropLast().last else {
+            return HTTPResponse(status: 404)
+        }
+        let count = await TypesenseClient.shared.historyCount(for: String(id))
+        let data = try JSONEncoder().encode(["summary": "items: \(count)"])
+        return HTTPResponse(body: data)
+    }
+    public func plannerListCorpora(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let ids = await TypesenseClient.shared.listCorpora()
+        let data = try JSONEncoder().encode(ids)
+        return HTTPResponse(body: data)
+    }
+    public func getReflectionHistory(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let id = request.path.split(separator: "/").last else {
+            return HTTPResponse(status: 404)
+        }
+        let count = await TypesenseClient.shared.reflectionCount(for: String(id))
+        let data = try JSONEncoder().encode(HistoryListResponse(reflections: "\(count)"))
+        return HTTPResponse(body: data)
+    }
+    public func plannerExecute(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let plan = try? JSONDecoder().decode(PlanExecutionRequest.self, from: request.body) else {
+            return HTTPResponse(status: 400)
+        }
+        let resultData = try await functions.invoke(functionId: plan.steps, payload: Data(plan.objective.utf8))
+        let result = String(data: resultData, encoding: .utf8) ?? ""
+        let data = try JSONEncoder().encode(ExecutionResult(results: result))
+        return HTTPResponse(body: data)
+    }
+    public func postReflection(_ request: HTTPRequest) async throws -> HTTPResponse {
+        guard let model = try? JSONDecoder().decode(ChatReflectionRequest.self, from: request.body) else {
+            return HTTPResponse(status: 400)
+        }
+        let item = Reflection(content: model.message, corpusId: model.corpus_id, question: model.message, reflectionId: UUID().uuidString)
+        await TypesenseClient.shared.addReflection(item)
+        let resp = ReflectionItem(content: model.message, timestamp: ISO8601DateFormatter().string(from: Date()))
+        let data = try JSONEncoder().encode(resp)
+        return HTTPResponse(body: data)
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/planner/LLMGatewayClient.swift
+++ b/Sources/FountainOps/Generated/Server/planner/LLMGatewayClient.swift
@@ -1,0 +1,47 @@
+import Foundation
+#if canImport(FoundationNetworking)
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+#endif
+
+/// Client for the LLM Gateway. When `LLM_GATEWAY_URL` is unset it returns
+/// a stubbed response for offline tests. See `docs/environment_variables.md`.
+struct LLMGatewayClient {
+    private let baseURL: URL?
+
+    init() {
+        if let urlString = ProcessInfo.processInfo.environment["LLM_GATEWAY_URL"],
+           let url = URL(string: urlString) {
+            self.baseURL = url
+        } else {
+            self.baseURL = nil
+        }
+    }
+
+    func chat(objective: String) async throws -> String {
+        guard let baseURL else {
+            // Offline fallback used by integration tests
+            return "Plan for: \(objective)"
+        }
+
+        var req = URLRequest(url: baseURL.appendingPathComponent("chat"))
+        req.httpMethod = "POST"
+        let body: [String: Any] = [
+            "model": "gpt-3.5-turbo",
+            "messages": [["role": "user", "content": objective]]
+        ]
+        req.httpBody = try JSONSerialization.data(withJSONObject: body)
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let (data, _) = try await URLSession.shared.data(for: req)
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let choices = json["choices"] as? [[String: Any]],
+           let message = choices.first?["message"] as? [String: Any],
+           let content = message["content"] as? String {
+            return content
+        }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/planner/LocalFunctionCallerClient.swift
+++ b/Sources/FountainOps/Generated/Server/planner/LocalFunctionCallerClient.swift
@@ -1,0 +1,51 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import ServiceShared
+
+/// Client for delegating executions to the Function Caller service. When
+/// `FUNCTION_CALLER_URL` is unset it falls back to the local dispatcher used
+/// during tests. See `docs/environment_variables.md`.
+struct LocalFunctionCallerClient {
+    enum DispatchError: Error { case notFound }
+
+    private let baseURL: URL?
+
+    init() {
+        if let urlString = ProcessInfo.processInfo.environment["FUNCTION_CALLER_URL"],
+           let url = URL(string: urlString) {
+            self.baseURL = url
+        } else {
+            self.baseURL = nil
+        }
+    }
+
+    func invoke(functionId: String, payload: Data) async throws -> Data {
+        if let baseURL {
+            var req = URLRequest(url: baseURL.appendingPathComponent("functions/\(functionId)/invoke"))
+            req.httpMethod = "POST"
+            req.httpBody = payload
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            if let token = ProcessInfo.processInfo.environment["FUNCTION_CALLER_AUTH_TOKEN"] {
+                req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            }
+            let (data, _) = try await URLSession.shared.data(for: req)
+            return data
+        }
+
+        // Fallback to direct invocation via TypesenseClient
+        guard let fn = await TypesenseClient.shared.functionDetails(id: functionId),
+              let url = URL(string: fn.httpPath) else {
+            throw DispatchError.notFound
+        }
+        var req = URLRequest(url: url)
+        req.httpMethod = fn.httpMethod
+        req.httpBody = payload
+        let (data, _) = try await URLSession.shared.data(for: req)
+        return data
+    }
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/planner/Models.swift
+++ b/Sources/FountainOps/Generated/Server/planner/Models.swift
@@ -1,0 +1,57 @@
+// Models for FountainAI Planner Service
+
+public struct ChatReflectionRequest: Codable {
+    public let corpus_id: String
+    public let message: String
+}
+
+public struct ExecutionResult: Codable {
+    public let results: String
+}
+
+public struct FunctionCall: Codable {
+    public let arguments: String
+    public let name: String
+}
+
+public struct FunctionCallResult: Codable {
+    public let arguments: String
+    public let output: String
+    public let step: String
+}
+
+public struct HTTPValidationError: Codable {
+    public let detail: String
+}
+
+public struct HistoryListResponse: Codable {
+    public let reflections: String
+}
+
+public struct PlanExecutionRequest: Codable {
+    public let objective: String
+    public let steps: String
+}
+
+public struct PlanResponse: Codable {
+    public let objective: String
+    public let steps: String
+}
+
+public struct ReflectionItem: Codable {
+    public let content: String
+    public let timestamp: String
+}
+
+public struct UserObjectiveRequest: Codable {
+    public let objective: String
+}
+
+public struct ValidationError: Codable {
+    public let loc: String
+    public let msg: String
+    public let type: String
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/planner/Router.swift
+++ b/Sources/FountainOps/Generated/Server/planner/Router.swift
@@ -1,0 +1,34 @@
+import Foundation
+import ServiceShared
+
+public struct Router {
+    public var handlers: Handlers
+
+    public init(handlers: Handlers = Handlers()) {
+        self.handlers = handlers
+    }
+
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
+        switch (request.method, request.path) {
+        case ("POST", "/planner/reason"):
+            return try await handlers.plannerReason(request)
+        case ("GET", "/planner/reflections/{corpus_id}/semantic-arc"):
+            return try await handlers.getSemanticArc(request)
+        case ("GET", "/planner/corpora"):
+            return try await handlers.plannerListCorpora(request)
+        case ("GET", "/planner/reflections/{corpus_id}"):
+            return try await handlers.getReflectionHistory(request)
+        case ("POST", "/planner/execute"):
+            return try await handlers.plannerExecute(request)
+        case ("POST", "/planner/reflections/"):
+            return try await handlers.postReflection(request)
+        case ("GET", "/metrics"):
+            let text = await PrometheusAdapter.shared.exposition()
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data(text.utf8))
+        default:
+            return HTTPResponse(status: 404)
+        }
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/planner/main.swift
+++ b/Sources/FountainOps/Generated/Server/planner/main.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Dispatch
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+import PlannerService
+
+final class SimpleHTTPRuntime: @unchecked Sendable {
+    enum RuntimeError: Error { case socket, bind, listen }
+    let kernel: HTTPKernel
+    let port: Int32
+    private var serverFD: Int32 = -1
+
+    init(kernel: HTTPKernel, port: Int32 = 8080) {
+        self.kernel = kernel
+        self.port = port
+    }
+
+    func start() throws {
+        #if os(Linux)
+        let socketType: Int32 = Int32(SOCK_STREAM.rawValue)
+        #else
+        let socketType: Int32 = SOCK_STREAM
+        #endif
+
+        serverFD = socket(AF_INET, socketType, 0)
+        guard serverFD >= 0 else { throw RuntimeError.socket }
+        var opt: Int32 = 1
+        setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = in_port_t(UInt16(port).bigEndian)
+        addr.sin_addr = in_addr(s_addr: in_addr_t(0))
+        let bindResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { ptr in
+                bind(serverFD, ptr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult >= 0 else { throw RuntimeError.bind }
+        guard listen(serverFD, 16) >= 0 else { throw RuntimeError.listen }
+        DispatchQueue.global().async { [weak self] in self?.acceptLoop() }
+    }
+
+    private func acceptLoop() {
+        while true {
+            var addr = sockaddr()
+            var len: socklen_t = socklen_t(MemoryLayout<sockaddr>.size)
+            let fd = accept(serverFD, &addr, &len)
+            if fd >= 0 {
+                DispatchQueue.global().async {
+                    self.handle(fd: fd)
+                }
+            }
+        }
+    }
+
+    private func handle(fd: Int32) {
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        let n = read(fd, &buffer, buffer.count)
+        guard n > 0 else { close(fd); return }
+        let data = Data(buffer[0..<n])
+        guard let request = parseRequest(data) else { close(fd); return }
+        Task {
+            let resp = try await kernel.handle(request)
+            let respData = serialize(resp)
+            respData.withUnsafeBytes { _ = write(fd, $0.baseAddress!, respData.count) }
+            close(fd)
+        }
+    }
+
+    private func parseRequest(_ data: Data) -> HTTPRequest? {
+        guard let string = String(data: data, encoding: .utf8) else { return nil }
+        let parts = string.components(separatedBy: "\r\n\r\n")
+        let headerLines = parts[0].split(separator: "\r\n")
+        guard let requestLine = headerLines.first else { return nil }
+        let tokens = requestLine.split(separator: " ")
+        guard tokens.count >= 2 else { return nil }
+        let method = String(tokens[0])
+        let path = String(tokens[1])
+        return HTTPRequest(method: method, path: path)
+    }
+
+    private func serialize(_ resp: HTTPResponse) -> Data {
+        var text = "HTTP/1.1 \(resp.status) OK\r\n"
+        text += "Content-Length: \(resp.body.count)\r\n"
+        text += "\r\n"
+        var data = Data(text.utf8)
+        data.append(resp.body)
+        return data
+    }
+}
+
+let kernel = HTTPKernel()
+do {
+    let runtime = SimpleHTTPRuntime(kernel: kernel, port: 8080)
+    try runtime.start()
+    print("planner server listening on port 8080")
+    dispatchMain()
+} catch {
+    print("Failed to start server: \(error)")
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/tools-factory/Dockerfile
+++ b/Sources/FountainOps/Generated/Server/tools-factory/Dockerfile
@@ -1,0 +1,11 @@
+# tools-factory server container
+FROM swift:6.1-jammy AS build
+WORKDIR /src
+COPY . .
+RUN swift build -c release --product tools-factory-server
+
+FROM ubuntu:22.04
+COPY --from=build /src/.build/release/tools-factory-server /server
+CMD ["/server"]
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/tools-factory/HTTPKernel.swift
+++ b/Sources/FountainOps/Generated/Server/tools-factory/HTTPKernel.swift
@@ -1,0 +1,22 @@
+import Foundation
+import ServiceShared
+
+public struct HTTPKernel {
+    let router: Router
+
+    public init(handlers: Handlers = Handlers()) {
+        self.router = Router(handlers: handlers)
+    }
+
+    public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
+        if let token = ProcessInfo.processInfo.environment["TOOLS_FACTORY_AUTH_TOKEN"] {
+            let expected = "Bearer \(token)"
+            if request.headers["Authorization"] != expected { return HTTPResponse(status: 401) }
+        }
+        let resp = try await router.route(request)
+        await PrometheusAdapter.shared.record(service: "tools-factory", path: request.path)
+        return resp
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/tools-factory/HTTPRequest.swift
+++ b/Sources/FountainOps/Generated/Server/tools-factory/HTTPRequest.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct HTTPRequest {
+    public let method: String
+    public let path: String
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/tools-factory/HTTPResponse.swift
+++ b/Sources/FountainOps/Generated/Server/tools-factory/HTTPResponse.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public struct HTTPResponse {
+    public var status: Int
+    public var headers: [String: String]
+    public var body: Data
+
+    public init(status: Int = 200, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/tools-factory/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/tools-factory/Handlers.swift
@@ -1,0 +1,120 @@
+import Foundation
+import ServiceShared
+import Parser
+import Yams
+
+/// Implements the Tools Factory persistence logic backed by ``TypesenseClient``.
+public struct Handlers {
+    let typesense: TypesenseClient
+
+    public init(typesense: TypesenseClient = .shared) {
+        self.typesense = typesense
+        Task {
+            if await typesense.listFunctions().isEmpty {
+                let f1 = Function(description: "test1", functionId: "test1", httpMethod: "GET", httpPath: "http://example.com/test1", name: "test1")
+                let f2 = Function(description: "test2", functionId: "test2", httpMethod: "GET", httpPath: "http://example.com/test2", name: "test2")
+                await typesense.addFunction(f1)
+                await typesense.addFunction(f2)
+            }
+        }
+    }
+
+    /// Registers one or more functions defined by an OpenAPI document.
+    /// The request body may contain JSON or YAML. Each operationId is mapped to
+    /// a ``Function`` persisted via ``TypesenseClient``.
+    public func registerOpenapi(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let data = request.body
+
+        if let list = try? JSONDecoder().decode([Function].self, from: data) {
+            for fn in list { await typesense.addFunction(fn) }
+            let enc = JSONEncoder()
+            enc.keyEncodingStrategy = .convertToSnakeCase
+            let respData = try enc.encode(list)
+            return HTTPResponse(body: respData)
+        }
+
+        let spec: OpenAPISpec
+        do {
+            if let decoded = try? JSONDecoder().decode(OpenAPISpec.self, from: data) {
+                spec = decoded
+            } else if let string = String(data: data, encoding: .utf8),
+                      let yaml = try? Yams.load(yaml: string),
+                      let json = try? JSONSerialization.data(withJSONObject: yaml),
+                      let decoded = try? JSONDecoder().decode(OpenAPISpec.self, from: json) {
+                spec = decoded
+            } else {
+                throw SpecValidator.ValidationError("invalid document")
+            }
+            try SpecValidator.validate(spec)
+        } catch let error as SpecValidator.ValidationError {
+            let payload = try JSONEncoder().encode(ErrorResponse(error_code: "validation_error", message: error.message))
+            return HTTPResponse(status: 422, body: payload)
+        } catch {
+            let payload = try JSONEncoder().encode(ErrorResponse(error_code: "parse_error", message: "Unable to parse document"))
+            return HTTPResponse(status: 422, body: payload)
+        }
+
+        var functions: [Function] = []
+        if let paths = spec.paths {
+            for (path, item) in paths {
+                if let op = item.get {
+                    let schemaData = op.requestBody?.content["application/json"]?.schema
+                    let schemaString = schemaData.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
+                    functions.append(Function(description: op.operationId,
+                                                functionId: op.operationId,
+                                                httpMethod: "GET",
+                                                httpPath: path,
+                                                name: op.operationId,
+                                                parametersSchema: schemaString))
+                }
+                if let op = item.post {
+                    let schemaData = op.requestBody?.content["application/json"]?.schema
+                    let schemaString = schemaData.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
+                    functions.append(Function(description: op.operationId,
+                                                functionId: op.operationId,
+                                                httpMethod: "POST",
+                                                httpPath: path,
+                                                name: op.operationId,
+                                                parametersSchema: schemaString))
+                }
+                if let op = item.put {
+                    let schemaData = op.requestBody?.content["application/json"]?.schema
+                    let schemaString = schemaData.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
+                    functions.append(Function(description: op.operationId,
+                                                functionId: op.operationId,
+                                                httpMethod: "PUT",
+                                                httpPath: path,
+                                                name: op.operationId,
+                                                parametersSchema: schemaString))
+                }
+                if let op = item.delete {
+                    let schemaData = op.requestBody?.content["application/json"]?.schema
+                    let schemaString = schemaData.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) }
+                    functions.append(Function(description: op.operationId,
+                                                functionId: op.operationId,
+                                                httpMethod: "DELETE",
+                                                httpPath: path,
+                                                name: op.operationId,
+                                                parametersSchema: schemaString))
+                }
+            }
+        }
+
+        for fn in functions { await typesense.addFunction(fn) }
+        let enc = JSONEncoder()
+        enc.keyEncodingStrategy = .convertToSnakeCase
+        let respData = try enc.encode(functions)
+        return HTTPResponse(body: respData)
+    }
+
+    /// Returns all stored function definitions.
+    public func listTools(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let items = await typesense.listFunctions()
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        let data = try encoder.encode(items)
+        return HTTPResponse(body: data)
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/tools-factory/Models.swift
+++ b/Sources/FountainOps/Generated/Server/tools-factory/Models.swift
@@ -1,0 +1,26 @@
+// Models for FountainAI Tools Factory Service
+
+public struct ErrorResponse: Codable {
+    public let error_code: String
+    public let message: String
+}
+
+public struct FunctionInfo: Codable {
+    public let description: String
+    public let function_id: String
+    public let http_method: String
+    public let http_path: String
+    public let name: String
+    public let openapi: String
+    public let parameters_schema: String
+}
+
+public struct FunctionListResponse: Codable {
+    public let functions: String
+    public let page: Int
+    public let page_size: Int
+    public let total: Int
+}
+
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/tools-factory/Router.swift
+++ b/Sources/FountainOps/Generated/Server/tools-factory/Router.swift
@@ -1,0 +1,26 @@
+import Foundation
+import ServiceShared
+
+public struct Router {
+    public var handlers: Handlers
+
+    public init(handlers: Handlers = Handlers()) {
+        self.handlers = handlers
+    }
+
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
+        switch (request.method, request.path) {
+        case ("POST", "/tools/register"):
+            return try await handlers.registerOpenapi(request)
+        case ("GET", "/tools"):
+            return try await handlers.listTools(request)
+        case ("GET", "/metrics"):
+            let text = await PrometheusAdapter.shared.exposition()
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data(text.utf8))
+        default:
+            return HTTPResponse(status: 404)
+        }
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/tools-factory/main.swift
+++ b/Sources/FountainOps/Generated/Server/tools-factory/main.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Dispatch
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+import ToolsFactoryService
+
+final class SimpleHTTPRuntime: @unchecked Sendable {
+    enum RuntimeError: Error { case socket, bind, listen }
+    let kernel: HTTPKernel
+    let port: Int32
+    private var serverFD: Int32 = -1
+
+    init(kernel: HTTPKernel, port: Int32 = 8080) {
+        self.kernel = kernel
+        self.port = port
+    }
+
+    func start() throws {
+        #if os(Linux)
+        serverFD = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
+        #else
+        serverFD = socket(AF_INET, SOCK_STREAM, 0)
+        #endif
+        guard serverFD >= 0 else { throw RuntimeError.socket }
+        var opt: Int32 = 1
+        setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = in_port_t(UInt16(port).bigEndian)
+        addr.sin_addr = in_addr(s_addr: in_addr_t(0))
+        let bindResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { ptr in
+                bind(serverFD, ptr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult >= 0 else { throw RuntimeError.bind }
+        guard listen(serverFD, 16) >= 0 else { throw RuntimeError.listen }
+        DispatchQueue.global().async { [weak self] in self?.acceptLoop() }
+    }
+
+    private func acceptLoop() {
+        while true {
+            var addr = sockaddr()
+            var len: socklen_t = socklen_t(MemoryLayout<sockaddr>.size)
+            let fd = accept(serverFD, &addr, &len)
+            if fd >= 0 {
+                DispatchQueue.global().async {
+                    self.handle(fd: fd)
+                }
+            }
+        }
+    }
+
+    private func handle(fd: Int32) {
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        let n = read(fd, &buffer, buffer.count)
+        guard n > 0 else { close(fd); return }
+        let data = Data(buffer[0..<n])
+        guard let request = parseRequest(data) else { close(fd); return }
+        Task {
+            let resp = try await kernel.handle(request)
+            let respData = serialize(resp)
+            respData.withUnsafeBytes { _ = write(fd, $0.baseAddress!, respData.count) }
+            close(fd)
+        }
+    }
+
+    private func parseRequest(_ data: Data) -> HTTPRequest? {
+        guard let string = String(data: data, encoding: .utf8) else { return nil }
+        let parts = string.components(separatedBy: "\r\n\r\n")
+        let headerLines = parts[0].split(separator: "\r\n")
+        guard let requestLine = headerLines.first else { return nil }
+        let tokens = requestLine.split(separator: " ")
+        guard tokens.count >= 2 else { return nil }
+        let method = String(tokens[0])
+        let path = String(tokens[1])
+        return HTTPRequest(method: method, path: path)
+    }
+
+    private func serialize(_ resp: HTTPResponse) -> Data {
+        var text = "HTTP/1.1 \(resp.status) OK\r\n"
+        text += "Content-Length: \(resp.body.count)\r\n"
+        text += "\r\n"
+        var data = Data(text.utf8)
+        data.append(resp.body)
+        return data
+    }
+}
+
+let kernel = HTTPKernel()
+do {
+    let runtime = SimpleHTTPRuntime(kernel: kernel, port: 8080)
+    try runtime.start()
+    print("tools-factory server listening on port 8080")
+    dispatchMain()
+} catch {
+    print("Failed to start server: \(error)")
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- restore FountainAI OpenAPI specifications under `Sources/FountainOps/FountainAi/openAPI`
- restore generated client and server code under `Sources/FountainOps/Generated`
- add project copyright footer to all restored files

## Testing
- `swift test -v` *(fails: library product 'FountainOps' should not contain executable targets)*

------
https://chatgpt.com/codex/tasks/task_e_6888ca688c5c8325b92c860dd9f46c45