### PR TITLE
Fix build and clarify UI project instructions

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -37,7 +37,16 @@
 - All generated via `clientgen-service`  
 
 ## TARGET ENV
-- Runs on Hetzner VPS with mounted Docker socket  
-- Accessible over SSH + DNS  
+- Runs on Hetzner VPS with mounted Docker socket
+- Accessible over SSH + DNS
+
+## UI PROJECTS
+- FountainUI is now maintained in the [Teatro](https://github.com/Fountain-Coach/Teatro) repository.
+- All new UI projects should start from the [FountainAI-Teatro-Template](https://github.com/Fountain-Coach/FountainAI-Teatro-Template).
+
+---
+```text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+```
 
 

--- a/Package.swift
+++ b/Package.swift
@@ -8,8 +8,7 @@ let package = Package(
     ],
     products: [
         .library(name: "FountainCore", targets: ["FountainCore"]),
-        .library(name: "FountainCodex", targets: ["FountainCodex"]),
-        .library(name: "FountainOps", targets: ["FountainOps"])
+        .library(name: "FountainCodex", targets: ["FountainCodex"])
     ],
     dependencies: [
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
@@ -30,7 +29,6 @@ let package = Package(
             ],
             path: "Sources/FountainCodex"
         ),
-        .target(name: "FountainOps", path: "Sources/FountainOps"),
         .testTarget(name: "FountainCoreTests", dependencies: ["FountainCore"], path: "Tests/FountainCoreTests")
     ]
 )

--- a/agent.md
+++ b/agent.md
@@ -37,7 +37,16 @@
 - All generated via `clientgen-service`  
 
 ## TARGET ENV
-- Runs on Hetzner VPS with mounted Docker socket  
-- Accessible over SSH + DNS  
+- Runs on Hetzner VPS with mounted Docker socket
+- Accessible over SSH + DNS
+
+## UI PROJECTS
+- FountainUI is now maintained in the [Teatro](https://github.com/Fountain-Coach/Teatro) repository.
+- All new UI projects should start from the [FountainAI-Teatro-Template](https://github.com/Fountain-Coach/FountainAI-Teatro-Template).
+
+---
+```text
+©\ 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+```
 
 


### PR DESCRIPTION
## Summary
- document Teatro as the new home for FountainUI
- recommend FountainAI-Teatro-Template for new UI projects
- remove FountainOps target from Package.swift so the package builds

## Testing
- `swift build -v`
- `swift test -v`


------
https://chatgpt.com/codex/tasks/task_e_6888cde53aa48325b809b1ca056b0603