### PR TITLE
Add Gateway OpenAPI specification

### DIFF
--- a/Sources/FountainOps/FountainAi/openAPI/README.md
+++ b/Sources/FountainOps/FountainAi/openAPI/README.md
@@ -8,6 +8,7 @@ This directory contains the OpenAPI specifications for each FountainAI microserv
 | Bootstrap | http://bootstrap.fountain.coach/api/v1 | Initializes corpora, seeds GPT roles and adds baseline snapshots. Relies on the Awareness API to store initial artifacts. | [v1/bootstrap.yml](v1/bootstrap.yml) |
 | Function Caller | http://functions.fountain.coach/api/v1 | Maps OpenAI function-calling plans to HTTP operations. Retrieves definitions from the Tools Factory. | [v1/function-caller.yml](v1/function-caller.yml) |
 | LLM Gateway | http://llm-gateway.fountain.coach/api/v1 | Proxies requests to any LLM with function-calling support. Used by the Planner for LLM-driven tasks. | [v2/llm-gateway.yml](v2/llm-gateway.yml) |
+| Gateway | https://gateway.fountain.coach/api/v1 | Entry point for all FountainAI HTTP traffic. Handles HTTPS termination, routing, authentication and metrics. | [v1/gateway.yml](v1/gateway.yml) |
 | Persistence | http://persist.fountain.coach/api/v1 | Typesense-backed store for baselines, drifts, reflections and registered tools. | [v1/persist.yml](v1/persist.yml) |
 | Planner | http://planner.fountain.coach/api/v1 | Orchestrates planning workflows across the LLM Gateway and Function Caller. | [v1/planner.yml](v1/planner.yml) |
 | Tools Factory | http://tools-factory.fountain.coach/api/v1 | Registers new tool definitions in the shared Typesense collection consumed by the Function Caller. | [v1/tools-factory.yml](v1/tools-factory.yml) |

--- a/Sources/FountainOps/FountainAi/openAPI/v1/gateway.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/gateway.yml
@@ -1,0 +1,202 @@
+---
+openapi: 3.1.0
+info:
+  title: FountainAI Gateway
+  description: >
+    Swift-based API gateway providing HTTPS termination, routing,
+    authentication and metrics for FountainAI services.
+  version: 1.0.0
+servers:
+  - url: https://gateway.fountain.coach/api/v1
+paths:
+  /health:
+    get:
+      summary: Health
+      description: Returns 200 if the gateway is running.
+      operationId: gatewayHealth
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+  /metrics:
+    get:
+      summary: Metrics
+      description: Endpoint that serves Prometheus metrics.
+      operationId: gatewayMetrics
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: object
+  /auth/token:
+    post:
+      summary: Issue Authentication Token
+      description: >
+        Verify client credentials and issue a JWT used for accessing
+        protected routes.
+      operationId: issueAuthToken
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CredentialRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TokenResponse'
+        '401':
+          description: Invalid credentials
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /routes:
+    get:
+      summary: List Configured Routes
+      description: Returns all routing definitions active in the gateway.
+      operationId: listRoutes
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RouteInfo'
+    post:
+      summary: Add a new route
+      operationId: createRoute
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RouteInfo'
+      responses:
+        '201':
+          description: Route created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RouteInfo'
+        '409':
+          description: Route already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /routes/{routeId}:
+    parameters:
+      - name: routeId
+        in: path
+        required: true
+        schema:
+          type: string
+          description: Unique identifier for the route
+    put:
+      summary: Update an existing route
+      operationId: updateRoute
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RouteInfo'
+      responses:
+        '200':
+          description: Route updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RouteInfo'
+        '404':
+          description: Route not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      summary: Delete a route
+      operationId: deleteRoute
+      responses:
+        '204':
+          description: Route deleted
+        '404':
+          description: Route not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    CredentialRequest:
+      type: object
+      required:
+        - clientId
+        - clientSecret
+      properties:
+        clientId:
+          type: string
+          description: API client identifier
+        clientSecret:
+          type: string
+          description: API client secret
+    TokenResponse:
+      type: object
+      required:
+        - token
+        - expiresAt
+      properties:
+        token:
+          type: string
+          description: Bearer token for gateway access
+        expiresAt:
+          type: string
+          format: date-time
+          description: Expiration timestamp of the token
+    RouteInfo:
+      type: object
+      required:
+        - id
+        - path
+        - target
+        - methods
+      properties:
+        id:
+          type: string
+          description: Unique identifier of the route
+        path:
+          type: string
+          description: URL path pattern for matching requests
+        target:
+          type: string
+          description: Upstream service address
+        methods:
+          type: array
+          items:
+            type: string
+            enum: [GET, POST, PUT, PATCH, DELETE]
+          description: HTTP methods forwarded to the upstream
+        rateLimit:
+          type: integer
+          description: Optional maximum requests per minute
+    ErrorResponse:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          description: Description of the error
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add OpenAPI 3.1 spec for the Gateway
- reference Gateway spec in service catalog

## Testing
- `swift test -v` *(fails: command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6888f214dc648325a7d8d33efa648a09