### PR TITLE
Implement basic certificate management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ __pycache__/
 *.egg-info/
 build/
 dist/
+.build/
+Package.resolved
 
 # Virtual environments
 .venv/

--- a/Configuration/gateway.yml
+++ b/Configuration/gateway.yml
@@ -1,0 +1,6 @@
+domain: gateway.fountain.coach
+certificatePath: /var/lib/gateway/certs/live/gateway.fountain.coach/fullchain.pem
+privateKeyPath: /var/lib/gateway/certs/live/gateway.fountain.coach/privkey.pem
+renewIntervalHours: 12
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,8 @@ let package = Package(
     products: [
         .library(name: "FountainCore", targets: ["FountainCore"]),
         .library(name: "FountainCodex", targets: ["FountainCodex"]),
-        .executable(name: "clientgen-service", targets: ["clientgen-service"])
+        .executable(name: "clientgen-service", targets: ["clientgen-service"]),
+        .executable(name: "gateway-server", targets: ["gateway-server"])
     ],
     dependencies: [
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
@@ -34,6 +35,11 @@ let package = Package(
             name: "clientgen-service",
             dependencies: ["FountainCodex"],
             path: "Sources/clientgen-service"
+        ),
+        .executableTarget(
+            name: "gateway-server",
+            dependencies: [],
+            path: "Sources/GatewayApp"
         ),
         .testTarget(name: "FountainCoreTests", dependencies: ["FountainCore"], path: "Tests/FountainCoreTests"),
         .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainCodex"], path: "Tests/ClientGeneratorTests")

--- a/Scripts/renew-certs.sh
+++ b/Scripts/renew-certs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CERTBOT=${CERTBOT:-certbot}
+DOMAIN=${GATEWAY_DOMAIN:-gateway.fountain.coach}
+EMAIL=${LE_EMAIL:-admin@fountain.coach}
+DATA_DIR=${CERT_DIR:-/var/lib/gateway/certs}
+
+mkdir -p "$DATA_DIR"
+
+exec $CERTBOT certonly \
+  --non-interactive --standalone \
+  --agree-tos --email "$EMAIL" \
+  --config-dir "$DATA_DIR" \
+  --logs-dir "$DATA_DIR" \
+  --work-dir "$DATA_DIR" \
+  -d "$DOMAIN"
+
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/FountainAi/openAPI/v1/gateway.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/gateway.yml
@@ -59,6 +59,30 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+  /certificates:
+    get:
+      summary: Certificate Info
+      description: Returns metadata about the active TLS certificate.
+      operationId: certificateInfo
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CertificateInfo'
+  /certificates/renew:
+    post:
+      summary: Trigger certificate renewal
+      description: Manually invoke the renewal process for the TLS certificate.
+      operationId: renewCertificate
+      responses:
+        '202':
+          description: Renewal triggered
+          content:
+            application/json:
+              schema:
+                type: object
   /routes:
     get:
       summary: List Configured Routes
@@ -198,5 +222,18 @@ components:
         error:
           type: string
           description: Description of the error
+    CertificateInfo:
+      type: object
+      required:
+        - notAfter
+        - issuer
+      properties:
+        notAfter:
+          type: string
+          format: date-time
+          description: Expiration date of the certificate
+        issuer:
+          type: string
+          description: Certificate issuer
 
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/GatewayApp/CertificateManager.swift
+++ b/Sources/GatewayApp/CertificateManager.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+public final class CertificateManager {
+    private var timer: DispatchSourceTimer?
+    private let scriptPath: String
+    private let interval: TimeInterval
+
+    public init(scriptPath: String = "./Scripts/renew-certs.sh", interval: TimeInterval = 86_400) {
+        self.scriptPath = scriptPath
+        self.interval = interval
+    }
+
+    public func start() {
+        let timer = DispatchSource.makeTimerSource()
+        timer.schedule(deadline: .now(), repeating: interval)
+        timer.setEventHandler { [scriptPath] in
+            let task = Process()
+            task.executableURL = URL(fileURLWithPath: scriptPath)
+            do {
+                try task.run()
+            } catch {
+                print("Certificate renewal failed: \(error)")
+            }
+        }
+        self.timer = timer
+        timer.resume()
+    }
+
+    public func stop() {
+        timer?.cancel()
+        timer = nil
+    }
+
+    public func triggerNow() {
+        let task = Process()
+        task.executableURL = URL(fileURLWithPath: scriptPath)
+        do {
+            try task.run()
+        } catch {
+            print("Certificate renewal failed: \(error)")
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/GatewayApp/main.swift
+++ b/Sources/GatewayApp/main.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+let manager = CertificateManager()
+manager.start()
+
+RunLoop.main.run()
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/proposals/swift_api_gateway_implementation.md
+++ b/docs/proposals/swift_api_gateway_implementation.md
@@ -9,10 +9,10 @@ This document outlines the initial code structure for the Swift-based API gatewa
 - `Sources/GatewayApp/`: entry point bootstrapping NIO, loading configuration and starting the server with HTTPS enabled.
 
 ## 2. Certificate Management
-The gateway must present valid HTTPS certificates at all times. We rely on Let's Encrypt for issuance and renewal.
+The gateway must present valid HTTPS certificates at all times. We rely on Let's Encrypt for issuance and renewal and ship a helper script.
 1. On first launch, `renew-certs.sh` requests a certificate for the gateway's domain using the ACME HTTP challenge.
 2. The script stores the resulting files in a shared directory mounted into the Docker container.
-3. A Swift task monitors certificate expiry and invokes the script periodically (e.g. via `DispatchSourceTimer`).
+3. `CertificateManager` wraps a `DispatchSourceTimer` and periodically runs the script to renew certificates.
 4. If renewal succeeds, the gateway reloads its TLS configuration without downtime.
 
 ## 3. Next Steps Toward a Kong-Like Gateway
@@ -20,6 +20,8 @@ The gateway must present valid HTTPS certificates at all times. We rely on Let's
 - Expose health and metrics endpoints defined in the OpenAPI spec.
 - Implement plugin-style hooks so future features (like request transformations) mirror Kong's extensibility model.
 - Document how to integrate other services using the generated Typesense client.
+- Generate server stubs from `gateway.yml` and integrate `CertificateManager` with the HTTP server.
+- Extend the OpenAPI spec with `/certificates` and `/certificates/renew` endpoints.
 
 These steps follow the common patterns of gateways modelled after Kong while keeping the implementation fully Swift.
 


### PR DESCRIPTION
## Summary
- add helper script `renew-certs.sh` for Let's Encrypt
- create `GatewayApp` target with `CertificateManager`
- add sample configuration for the gateway
- extend gateway OpenAPI spec with certificate endpoints
- document certificate management details and next steps
- update `.gitignore`

## Testing
- `swift build -c release`
- `swift test -c release`

------
https://chatgpt.com/codex/tasks/task_e_6888fbb3fd388325bb830bbb81c7a5a7