### PR TITLE
Update generator utilities

### DIFF
--- a/Sources/FountainOps/regenerate.sh
+++ b/Sources/FountainOps/regenerate.sh
@@ -9,7 +9,7 @@ for spec in FountainAi/openAPI/*/*.yml; do
     service=$(basename "$spec" .yml)
     outDir="Generated/$service"
     rm -rf "$outDir"
-    swift run generator --input "$spec" --output "$outDir"
+    swift run clientgen-service --input "$spec" --output "$outDir"
 
     mkdir -p "Generated/Client/$service" "Generated/Server/$service"
     cp -r "$outDir/Client/." "Generated/Client/$service/"


### PR DESCRIPTION
## Summary
- strip copyright lines when loading OpenAPI specs
- use `clientgen-service` in `regenerate.sh`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688901aa9f6c8325a4ed61a6c0ec274a