### PR TITLE
Add skeleton gateway server

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         ),
         .executableTarget(
             name: "gateway-server",
-            dependencies: [],
+            dependencies: ["FountainCodex"],
             path: "Sources/GatewayApp"
         ),
         .testTarget(name: "FountainCoreTests", dependencies: ["FountainCore"], path: "Tests/FountainCoreTests"),

--- a/Sources/FountainOps/regenerate.sh
+++ b/Sources/FountainOps/regenerate.sh
@@ -9,7 +9,7 @@ for spec in FountainAi/openAPI/*/*.yml; do
     service=$(basename "$spec" .yml)
     outDir="Generated/$service"
     rm -rf "$outDir"
-    swift run generator --input "$spec" --output "$outDir"
+    swift run clientgen-service --input "$spec" --output "$outDir"
 
     mkdir -p "Generated/Client/$service" "Generated/Server/$service"
     cp -r "$outDir/Client/." "Generated/Client/$service/"

--- a/Sources/GatewayApp/GatewayServer.swift
+++ b/Sources/GatewayApp/GatewayServer.swift
@@ -1,0 +1,42 @@
+import Foundation
+import NIO
+import NIOHTTP1
+import FountainCodex
+
+@MainActor
+public final class GatewayServer {
+    private let server: NIOHTTPServer
+    private let manager: CertificateManager
+    private let group: EventLoopGroup
+
+    public init(manager: CertificateManager = CertificateManager()) {
+        self.manager = manager
+        self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let kernel = HTTPKernel { req in
+            switch (req.method, req.path) {
+            case ("GET", "/health"):
+                let json = try JSONEncoder().encode(["status": "ok"])
+                return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: json)
+            case ("GET", "/metrics"):
+                let metrics: [String: [String]] = ["metrics": []]
+                let json = try JSONEncoder().encode(metrics)
+                return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: json)
+            default:
+                return HTTPResponse(status: 404)
+            }
+        }
+        self.server = NIOHTTPServer(kernel: kernel, group: group)
+    }
+
+    public func start(port: Int = 8080) async throws {
+        manager.start()
+        _ = try await server.start(port: port)
+    }
+
+    public func stop() async throws {
+        manager.stop()
+        try await server.stop()
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/GatewayApp/main.swift
+++ b/Sources/GatewayApp/main.swift
@@ -1,8 +1,12 @@
 import Foundation
 
-let manager = CertificateManager()
-manager.start()
+import Dispatch
 
-RunLoop.main.run()
+let server = GatewayServer()
+Task { @MainActor in
+    try await server.start(port: 8080)
+}
+
+dispatchMain()
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- fix regeneration script to use `clientgen-service`
- depend gateway-server target on `FountainCodex`
- introduce `GatewayServer` implementing basic health and metrics endpoints
- update main executable to launch `GatewayServer`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688901aa9f6c8325a4ed61a6c0ec274a