### PR TITLE
Implement plugin hooks and Typesense integration docs

### DIFF
--- a/Sources/GatewayApp/GatewayPlugin.swift
+++ b/Sources/GatewayApp/GatewayPlugin.swift
@@ -1,0 +1,14 @@
+import Foundation
+import FountainCodex
+
+public protocol GatewayPlugin: Sendable {
+    func prepare(_ request: HTTPRequest) async throws -> HTTPRequest
+    func respond(_ response: HTTPResponse, for request: HTTPRequest) async throws -> HTTPResponse
+}
+
+public extension GatewayPlugin {
+    func prepare(_ request: HTTPRequest) async throws -> HTTPRequest { request }
+    func respond(_ response: HTTPResponse, for request: HTTPRequest) async throws -> HTTPResponse { response }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/GatewayApp/LoggingPlugin.swift
+++ b/Sources/GatewayApp/LoggingPlugin.swift
@@ -1,0 +1,17 @@
+import Foundation
+import FountainCodex
+
+public struct LoggingPlugin: GatewayPlugin {
+    public init() {}
+    public func prepare(_ request: HTTPRequest) async throws -> HTTPRequest {
+        print("-> \(request.method) \(request.path)")
+        return request
+    }
+
+    public func respond(_ response: HTTPResponse, for request: HTTPRequest) async throws -> HTTPResponse {
+        print("<- \(response.status) for \(request.path)")
+        return response
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/GatewayApp/main.swift
+++ b/Sources/GatewayApp/main.swift
@@ -2,7 +2,7 @@ import Foundation
 
 import Dispatch
 
-let server = GatewayServer()
+let server = GatewayServer(plugins: [LoggingPlugin()])
 Task { @MainActor in
     try await server.start(port: 8080)
 }

--- a/docs/proposals/swift_api_gateway_implementation.md
+++ b/docs/proposals/swift_api_gateway_implementation.md
@@ -18,8 +18,8 @@ The gateway must present valid HTTPS certificates at all times. We rely on Let's
 ## 3. Next Steps Toward a Kong-Like Gateway
 - Add middleware for authentication, rate limiting and request logging based on the configuration files.
 - Expose health and metrics endpoints defined in the OpenAPI spec.
-- Implement plugin-style hooks so future features (like request transformations) mirror Kong's extensibility model.
-- Document how to integrate other services using the generated Typesense client.
+ - Plugin-style hooks allow custom middleware (for example request transformations) to mirror Kong's extensibility model.
+ - [Integrating other services](../typesense_client_integration.md) explains how to use the generated Typesense client.
 - Generate server stubs from `gateway.yml` and integrate `CertificateManager` with the HTTP server.
 - Extend the OpenAPI spec with `/certificates` and `/certificates/renew` endpoints.
 

--- a/docs/typesense_client_integration.md
+++ b/docs/typesense_client_integration.md
@@ -1,0 +1,27 @@
+# Integrating Services with the Typesense Client
+
+The Typesense client is generated from the Typesense OpenAPI definition and lives at
+`Sources/FountainOps/Generated/Server/Shared/TypesenseClient.swift`. All FountainAI
+microservices import this file through the `FountainOps` package.
+
+1. Add `FountainOps` as a dependency in your `Package.swift`:
+   ```swift
+   .package(path: "../codex-deployer")
+   ```
+2. Import the client in your service code:
+   ```swift
+   import FountainOps
+   ```
+3. Use `TypesenseClient.shared` to store or query data. The client automatically
+   picks up `TYPESENSE_URL` and `TYPESENSE_API_KEY` from the environment.
+
+Example:
+```swift
+let functions = await TypesenseClient.shared.listFunctions()
+```
+
+This approach keeps persistence logic consistent across services and allows the
+gateway to apply plugins or request transforms before hitting Typesense.
+
+---
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add `GatewayPlugin` protocol and example `LoggingPlugin`
- extend `GatewayServer` to execute plugin hooks
- enable plugins in `main.swift`
- document Typesense client integration
- update gateway proposal with link to new doc

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6889090f32408325b608ed343f28ac8e