### PR TITLE
Add basic Typesense server scaffolding

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Dockerfile
+++ b/Sources/FountainOps/Generated/Server/typesense/Dockerfile
@@ -1,0 +1,11 @@
+# typesense server container
+FROM swift:6.1-jammy AS build
+WORKDIR /src
+COPY . .
+RUN swift build -c release --product typesense-server
+
+FROM ubuntu:22.04
+COPY --from=build /src/.build/release/typesense-server /server
+CMD ["/server"]
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -1,193 +1,208 @@
 import Foundation
 
 public struct Handlers {
-    public init() {}
+    let service: TypesenseService
+
+    public init(service: TypesenseService = try! TypesenseService()) {
+        self.service = service
+    }
     public func getsearchoverrides(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func exportdocuments(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func indexdocument(_ request: HTTPRequest, body: indexDocumentRequest?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func deletedocuments(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func createanalyticsevent(_ request: HTTPRequest, body: AnalyticsEventCreateSchema?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func retrieveanalyticsrule(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func upsertanalyticsrule(_ request: HTTPRequest, body: AnalyticsRuleUpsertSchema?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func deleteanalyticsrule(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func liststemmingdictionaries(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func getcollections(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        let collections = try await service.listCollections()
+        let data = try JSONEncoder().encode(collections)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func createcollection(_ request: HTTPRequest, body: CollectionSchema?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        guard let schema = body else { return HTTPResponse(status: 400) }
+        let data = try await service.createCollection(schema: schema)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func retrieveallconversationmodels(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func createconversationmodel(_ request: HTTPRequest, body: ConversationModelCreateSchema?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func getcollection(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func deletecollection(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func getkeys(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func createkey(_ request: HTTPRequest, body: ApiKeySchema?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func vote(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func retrieveanalyticsrules(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func createanalyticsrule(_ request: HTTPRequest, body: AnalyticsRuleSchema?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func getalias(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func upsertalias(_ request: HTTPRequest, body: CollectionAliasSchema?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func deletealias(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func retrieveconversationmodel(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func updateconversationmodel(_ request: HTTPRequest, body: ConversationModelUpdateSchema?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func deleteconversationmodel(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func takesnapshot(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func multisearch(_ request: HTTPRequest, body: MultiSearchSearchesParameter?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func retrievenlsearchmodel(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func updatenlsearchmodel(_ request: HTTPRequest, body: NLSearchModelUpdateSchema?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func deletenlsearchmodel(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func getdocument(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func deletedocument(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func getstemmingdictionary(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func retrievemetrics(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func importstemmingdictionary(_ request: HTTPRequest, body: importStemmingDictionaryRequest?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func importdocuments(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func retrieveallpresets(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func retrieveapistats(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func retrieveallnlsearchmodels(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func createnlsearchmodel(_ request: HTTPRequest, body: NLSearchModelCreateSchema?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func getsearchoverride(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func upsertsearchoverride(_ request: HTTPRequest, body: SearchOverrideSchema?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func deletesearchoverride(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func getaliases(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func retrievestopwordsset(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func upsertstopwordsset(_ request: HTTPRequest, body: StopwordsSetUpsertSchema?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func deletestopwordsset(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func retrievepreset(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func upsertpreset(_ request: HTTPRequest, body: PresetUpsertSchema?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func deletepreset(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func getsearchsynonyms(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func getschemachanges(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func getsearchsynonym(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func upsertsearchsynonym(_ request: HTTPRequest, body: SearchSynonymSchema?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func deletesearchsynonym(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func debug(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func health(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func getkey(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func deletekey(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
     public func searchcollection(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 4 else { return HTTPResponse(status: 404) }
+        let collection = String(parts[1])
+        let comps = URLComponents(string: request.path)
+        let params = comps?.queryItems?.first(where: { $0.name == "searchParameters" })?.value ?? "{}"
+        let result = try await service.search(collection: collection, parameters: params)
+        let data = try JSONEncoder().encode(result)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func retrievestopwordssets(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse()
+        return HTTPResponse(status: 501)
     }
 }
 
-© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -1,0 +1,59 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public enum TypesenseServiceError: LocalizedError {
+    case missingURL
+    case missingAPIKey
+    case invalidURL(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingURL: return "TYPESENSE_URL environment variable is not set"
+        case .missingAPIKey: return "TYPESENSE_API_KEY environment variable is not set"
+        case .invalidURL(let value): return "TYPESENSE_URL is invalid: \(value)"
+        }
+    }
+}
+
+public final actor TypesenseService {
+    private let client: APIClient
+
+    public init(environment: [String: String] = ProcessInfo.processInfo.environment,
+                session: HTTPSession = URLSession.shared) throws {
+        guard let urlString = environment["TYPESENSE_URL"], !urlString.isEmpty else {
+            throw TypesenseServiceError.missingURL
+        }
+        guard let apiKey = environment["TYPESENSE_API_KEY"], !apiKey.isEmpty else {
+            throw TypesenseServiceError.missingAPIKey
+        }
+        guard let url = URL(string: urlString) else {
+            throw TypesenseServiceError.invalidURL(urlString)
+        }
+        self.client = APIClient(baseURL: url, session: session, defaultHeaders: ["X-TYPESENSE-API-KEY": apiKey])
+    }
+
+    public func listCollections() async throws -> getCollectionsResponse {
+        try await client.send(getCollections())
+    }
+
+    public func createCollection(schema: CollectionSchema) async throws -> Data {
+        try await client.send(createCollection(body: schema))
+    }
+
+    public func search(collection: String, parameters: String) async throws -> SearchResult {
+        struct Request: APIRequest {
+            typealias Body = NoBody
+            typealias Response = SearchResult
+            let collection: String
+            let parameters: String
+            var method: String { "GET" }
+            var path: String { "/collections/\(collection)/documents/search?searchParameters=\(parameters)" }
+            var body: Body? { nil }
+        }
+        return try await client.send(Request(collection: collection, parameters: parameters))
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/typesense/main.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/main.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Dispatch
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+import TypesenseService
+
+final class SimpleHTTPRuntime: @unchecked Sendable {
+    enum RuntimeError: Error { case socket, bind, listen }
+    let kernel: HTTPKernel
+    let port: Int32
+    private var serverFD: Int32 = -1
+
+    init(kernel: HTTPKernel, port: Int32 = 8080) {
+        self.kernel = kernel
+        self.port = port
+    }
+
+    func start() throws {
+        #if os(Linux)
+        let socketType: Int32 = Int32(SOCK_STREAM.rawValue)
+        #else
+        let socketType: Int32 = SOCK_STREAM
+        #endif
+
+        serverFD = socket(AF_INET, socketType, 0)
+        guard serverFD >= 0 else { throw RuntimeError.socket }
+        var opt: Int32 = 1
+        setsockopt(serverFD, SOL_SOCKET, SO_REUSEADDR, &opt, socklen_t(MemoryLayout.size(ofValue: opt)))
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = in_port_t(UInt16(port).bigEndian)
+        addr.sin_addr = in_addr(s_addr: in_addr_t(0))
+        let bindResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { ptr in
+                bind(serverFD, ptr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult >= 0 else { throw RuntimeError.bind }
+        guard listen(serverFD, 16) >= 0 else { throw RuntimeError.listen }
+        DispatchQueue.global().async { [weak self] in self?.acceptLoop() }
+    }
+
+    private func acceptLoop() {
+        while true {
+            var addr = sockaddr()
+            var len: socklen_t = socklen_t(MemoryLayout<sockaddr>.size)
+            let fd = accept(serverFD, &addr, &len)
+            if fd >= 0 {
+                DispatchQueue.global().async {
+                    self.handle(fd: fd)
+                }
+            }
+        }
+    }
+
+    private func handle(fd: Int32) {
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        let n = read(fd, &buffer, buffer.count)
+        guard n > 0 else { close(fd); return }
+        let data = Data(buffer[0..<n])
+        guard let request = parseRequest(data) else { close(fd); return }
+        Task {
+            let resp = try await kernel.handle(request)
+            let respData = serialize(resp)
+            respData.withUnsafeBytes { _ = write(fd, $0.baseAddress!, respData.count) }
+            close(fd)
+        }
+    }
+
+    private func parseRequest(_ data: Data) -> HTTPRequest? {
+        guard let string = String(data: data, encoding: .utf8) else { return nil }
+        let parts = string.components(separatedBy: "\r\n\r\n")
+        let headerLines = parts[0].split(separator: "\r\n")
+        guard let requestLine = headerLines.first else { return nil }
+        let tokens = requestLine.split(separator: " ")
+        guard tokens.count >= 2 else { return nil }
+        let method = String(tokens[0])
+        let path = String(tokens[1])
+        return HTTPRequest(method: method, path: path)
+    }
+
+    private func serialize(_ resp: HTTPResponse) -> Data {
+        var text = "HTTP/1.1 \(resp.status) OK\r\n"
+        text += "Content-Length: \(resp.body.count)\r\n"
+        text += "\r\n"
+        var data = Data(text.utf8)
+        data.append(resp.body)
+        return data
+    }
+}
+
+let kernel = HTTPKernel()
+let port = Int32(ProcessInfo.processInfo.environment["PORT"] ?? "8080") ?? 8080
+
+do {
+    let runtime = SimpleHTTPRuntime(kernel: kernel, port: port)
+    try runtime.start()
+    print("typesense server listening on port \(port)")
+    dispatchMain()
+} catch {
+    print("Failed to start server: \(error)")
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- introduce `TypesenseService` for simple Typesense API access
- wire service into generated handlers
- provide minimal runtime entry point and Dockerfile

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_688991403b88832585e0a0254c489b54