### PR TITLE
Extend Typesense server with getCollection support

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -50,7 +50,12 @@ public struct Handlers {
         return HTTPResponse(status: 501)
     }
     public func getcollection(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 2 else { return HTTPResponse(status: 404) }
+        let name = String(parts[1])
+        let collection = try await service.getCollection(name: name)
+        let data = try JSONEncoder().encode(collection)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func deletecollection(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/Router.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Router.swift
@@ -8,6 +8,13 @@ public struct Router {
     }
 
     public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
+        if request.method == "GET" && request.path.starts(with: "/collections/") {
+            let parts = request.path.split(separator: "/")
+            if parts.count == 2 {
+                let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
+                return try await handlers.getcollection(request, body: body)
+            }
+        }
         switch (request.method, request.path) {
         case ("GET", "/collections/{collectionName}/overrides"):
             let body = try? JSONDecoder().decode(NoBody.self, from: request.body)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -42,6 +42,10 @@ public final actor TypesenseService {
         try await client.send(createCollection(body: schema))
     }
 
+    public func getCollection(name: String) async throws -> CollectionResponse {
+        try await client.send(getCollection(parameters: .init(collectionname: name)))
+    }
+
     public func search(collection: String, parameters: String) async throws -> SearchResult {
         struct Request: APIRequest {
             typealias Body = NoBody


### PR DESCRIPTION
## Summary
- implement `getCollection` in `TypesenseService`
- handle `/collections/<name>` in router
- return collection info via new handler

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6889a0e3268483258abbe0ea5c1b4a95