### PR TITLE
Expand Typesense server

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -58,13 +58,22 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func deletecollection(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 2 else { return HTTPResponse(status: 404) }
+        let name = String(parts[1])
+        let collection = try await service.deleteCollection(name: name)
+        let data = try JSONEncoder().encode(collection)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func getkeys(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let keys = try await service.getKeys()
+        let data = try JSONEncoder().encode(keys)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func createkey(_ request: HTTPRequest, body: ApiKeySchema?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        guard let schema = body else { return HTTPResponse(status: 400) }
+        let data = try await service.createKey(schema: schema)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func vote(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -46,6 +46,18 @@ public final actor TypesenseService {
         try await client.send(getCollection(parameters: .init(collectionname: name)))
     }
 
+    public func deleteCollection(name: String) async throws -> CollectionResponse {
+        try await client.send(deleteCollection(parameters: .init(collectionname: name)))
+    }
+
+    public func getKeys() async throws -> ApiKeysResponse {
+        try await client.send(getKeys())
+    }
+
+    public func createKey(schema: ApiKeySchema) async throws -> Data {
+        try await client.send(createKey(body: schema))
+    }
+
     public func search(collection: String, parameters: String) async throws -> SearchResult {
         struct Request: APIRequest {
             typealias Body = NoBody

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -33,5 +33,17 @@ This plan details how to implement every endpoint defined in `repos/typesense-co
 
 Following this plan will turn the current stub into a full-fledged Typesense proxy in Swift.
 
+### Progress
+
+The server currently supports the following endpoints:
+
+- `GET /collections`
+- `POST /collections`
+- `GET /collections/{collectionName}`
+- `DELETE /collections/{collectionName}`
+- `GET /collections/{collectionName}/documents/search`
+- `GET /keys`
+- `POST /keys`
+
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- implement Typesense service methods for deleting collections and managing keys
- implement corresponding HTTP handlers
- note progress in Typesense server API plan

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6889a5f22eec83259b704565b9511cb1