### PR TITLE
Implement GET /aliases for Typesense server

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -157,7 +157,9 @@ public struct Handlers {
         return HTTPResponse(status: 501)
     }
     public func getaliases(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let aliases = try await service.getAliases()
+        let data = try JSONEncoder().encode(aliases)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func retrievestopwordsset(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -58,6 +58,10 @@ public final actor TypesenseService {
         try await client.send(createKey(body: schema))
     }
 
+    public func getAliases() async throws -> CollectionAliasesResponse {
+        try await client.send(getAliases())
+    }
+
     public func search(collection: String, parameters: String) async throws -> SearchResult {
         struct Request: APIRequest {
             typealias Body = NoBody

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -44,8 +44,9 @@ The server currently supports the following endpoints (commit):
 - `GET /collections/{collectionName}/documents/search` – `55922a5`
 - `GET /keys` – `792ff5b`
 - `POST /keys` – `792ff5b`
+- `GET /aliases` – `384dc86`
 
-Last updated at `44ccb44`.
+Last updated at `384dc86`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- implement `getAliases` endpoint in `TypesenseService` and `Handlers`
- document new endpoint in the Typesense server progress list

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6889ac1b485c832599caeffd84070c61