### PR TITLE
Implement Typesense alias upsert

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -88,7 +88,13 @@ public struct Handlers {
         return HTTPResponse(status: 501)
     }
     public func upsertalias(_ request: HTTPRequest, body: CollectionAliasSchema?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        guard let schema = body else { return HTTPResponse(status: 400) }
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 2 else { return HTTPResponse(status: 404) }
+        let name = String(parts[1])
+        let alias = try await service.upsertAlias(name: name, schema: schema)
+        let data = try JSONEncoder().encode(alias)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func deletealias(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -62,6 +62,10 @@ public final actor TypesenseService {
         try await client.send(getAliases())
     }
 
+    public func upsertAlias(name: String, schema: CollectionAliasSchema) async throws -> CollectionAlias {
+        try await client.send(upsertAlias(parameters: .init(aliasname: name), body: schema))
+    }
+
     public func search(collection: String, parameters: String) async throws -> SearchResult {
         struct Request: APIRequest {
             typealias Body = NoBody

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -45,8 +45,9 @@ The server currently supports the following endpoints (commit):
 - `GET /keys` – `792ff5b`
 - `POST /keys` – `792ff5b`
 - `GET /aliases` – `384dc86`
+- `PUT /aliases/{aliasName}` – `1bce1dc`
 
-Last updated at `384dc86`.
+Last updated at `1bce1dc`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- implement `upsertAlias` in Typesense service and handler
- document new endpoint implementation in API plan

## Testing
- `swift build`
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_6889b07628fc832593ac09e68e71d82c