### PR TITLE
Implement Typesense get alias endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -85,7 +85,12 @@ public struct Handlers {
         return HTTPResponse(status: 501)
     }
     public func getalias(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 2 else { return HTTPResponse(status: 404) }
+        let name = String(parts[1])
+        let alias = try await service.getAlias(name: name)
+        let data = try JSONEncoder().encode(alias)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func upsertalias(_ request: HTTPRequest, body: CollectionAliasSchema?) async throws -> HTTPResponse {
         guard let schema = body else { return HTTPResponse(status: 400) }

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -66,6 +66,10 @@ public final actor TypesenseService {
         try await client.send(upsertAlias(parameters: .init(aliasname: name), body: schema))
     }
 
+    public func getAlias(name: String) async throws -> CollectionAlias {
+        try await client.send(getAlias(parameters: .init(aliasname: name)))
+    }
+
     public func search(collection: String, parameters: String) async throws -> SearchResult {
         struct Request: APIRequest {
             typealias Body = NoBody

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -46,8 +46,9 @@ The server currently supports the following endpoints (commit):
 - `POST /keys` – `792ff5b`
 - `GET /aliases` – `384dc86`
 - `PUT /aliases/{aliasName}` – `1bce1dc`
+- `GET /aliases/{aliasName}` – `ca44a96`
 
-Last updated at `1bce1dc`.
+Last updated at `ca44a96`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- implement `GET /aliases/{aliasName}` in Typesense server
- expose `getAlias` in `TypesenseService`
- document progress in the Typesense API plan

## Testing
- `swift build`
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_6889b33983ec83258bd7b7426003d2c0