### PR TITLE
Implement Typesense alias delete endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -102,7 +102,12 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func deletealias(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 2 else { return HTTPResponse(status: 404) }
+        let name = String(parts[1])
+        let alias = try await service.deleteAlias(name: name)
+        let data = try JSONEncoder().encode(alias)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func retrieveconversationmodel(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -70,6 +70,10 @@ public final actor TypesenseService {
         try await client.send(getAlias(parameters: .init(aliasname: name)))
     }
 
+    public func deleteAlias(name: String) async throws -> CollectionAlias {
+        try await client.send(deleteAlias(parameters: .init(aliasname: name)))
+    }
+
     public func search(collection: String, parameters: String) async throws -> SearchResult {
         struct Request: APIRequest {
             typealias Body = NoBody

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -47,8 +47,9 @@ The server currently supports the following endpoints (commit):
 - `GET /aliases` – `384dc86`
 - `PUT /aliases/{aliasName}` – `1bce1dc`
 - `GET /aliases/{aliasName}` – `ca44a96`
+- `DELETE /aliases/{aliasName}` – `ebe309a`
 
-Last updated at `ca44a96`.
+Last updated at `ebe309a`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- support deleting aliases in `TypesenseService`
- wire up `deletealias` handler
- track DELETE `/aliases/{aliasName}` in progress docs

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6889b7555d508325bd6968a6efd74013