### PR TITLE
Implement getKey endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -217,7 +217,11 @@ public struct Handlers {
         return HTTPResponse(status: 501)
     }
     public func getkey(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 2, let id = Int(parts[1]) else { return HTTPResponse(status: 404) }
+        let key = try await service.getKey(id: id)
+        let data = try JSONEncoder().encode(key)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func deletekey(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -58,6 +58,10 @@ public final actor TypesenseService {
         try await client.send(createKey(body: schema))
     }
 
+    public func getKey(id: Int) async throws -> ApiKey {
+        try await client.send(getKey(parameters: .init(keyid: id)))
+    }
+
     public func getAliases() async throws -> CollectionAliasesResponse {
         try await client.send(getAliases())
     }

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -44,12 +44,13 @@ The server currently supports the following endpoints (commit):
 - `GET /collections/{collectionName}/documents/search` – `55922a5`
 - `GET /keys` – `792ff5b`
 - `POST /keys` – `792ff5b`
+- `GET /keys/{keyId}` – `e6801c5`
 - `GET /aliases` – `384dc86`
 - `PUT /aliases/{aliasName}` – `1bce1dc`
 - `GET /aliases/{aliasName}` – `ca44a96`
 - `DELETE /aliases/{aliasName}` – `ebe309a`
 
-Last updated at `ebe309a`.
+Last updated at `e6801c5`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- handle GET /keys/{keyId} in Typesense service and handlers
- record the new endpoint in the Typesense API plan

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6889ba1325bc8325a6a4589448e7b160