### PR TITLE
Implement debug endpoint in typesense server

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -211,7 +211,9 @@ public struct Handlers {
         return HTTPResponse(status: 501)
     }
     public func debug(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let info = try await service.debug()
+        let data = try JSONEncoder().encode(info)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func health(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -90,6 +90,10 @@ public final actor TypesenseService {
         }
         return try await client.send(Request(collection: collection, parameters: parameters))
     }
+
+    public func debug() async throws -> debugResponse {
+        try await client.send(debug())
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -49,8 +49,9 @@ The server currently supports the following endpoints (commit):
 - `PUT /aliases/{aliasName}` – `1bce1dc`
 - `GET /aliases/{aliasName}` – `ca44a96`
 - `DELETE /aliases/{aliasName}` – `ebe309a`
+- `GET /debug` – `4de0ad4`
 
-Last updated at `e6801c5`.
+Last updated at `4de0ad4`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add `debug()` helper in `TypesenseService`
- handle `/debug` route in `Handlers`
- note `GET /debug` support in API progress doc

## Testing
- `git log -2 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6889bdc0d3fc8325bf5689ba6504ab8a