### PR TITLE
Implement Typesense health endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -216,7 +216,9 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func health(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let status = try await service.health()
+        let data = try JSONEncoder().encode(status)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func getkey(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         let parts = request.path.split(separator: "/")

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -94,6 +94,10 @@ public final actor TypesenseService {
     public func debug() async throws -> debugResponse {
         try await client.send(debug())
     }
+
+    public func health() async throws -> HealthStatus {
+        try await client.send(health())
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -50,8 +50,9 @@ The server currently supports the following endpoints (commit):
 - `GET /aliases/{aliasName}` – `ca44a96`
 - `DELETE /aliases/{aliasName}` – `ebe309a`
 - `GET /debug` – `4de0ad4`
+- `GET /health` – `ce544f8`
 
-Last updated at `4de0ad4`.
+Last updated at `ce544f8`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- implement `health` call in `TypesenseService`
- wire `/health` route to a real handler
- document the newly supported endpoint in the API plan

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6889c3b88cb48325a3890932b0ed4775