### PR TITLE
Implement schema changes endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -199,7 +199,9 @@ public struct Handlers {
         return HTTPResponse(status: 501)
     }
     public func getschemachanges(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let changes = try await service.getSchemaChanges()
+        let data = try JSONEncoder().encode(changes)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func getsearchsynonym(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -98,6 +98,10 @@ public final actor TypesenseService {
     public func health() async throws -> HealthStatus {
         try await client.send(health())
     }
+
+    public func getSchemaChanges() async throws -> getSchemaChangesResponse {
+        try await client.send(getSchemaChanges())
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -51,8 +51,9 @@ The server currently supports the following endpoints (commit):
 - `DELETE /aliases/{aliasName}` – `ebe309a`
 - `GET /debug` – `4de0ad4`
 - `GET /health` – `ce544f8`
+- `GET /operations/schema_changes` – `76d8956`
 
-Last updated at `ce544f8`.
+Last updated at `76d8956`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- support `GET /operations/schema_changes` via `TypesenseService.getSchemaChanges`
- implement `getschemachanges` handler
- document new endpoint in the implementation plan

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6889c7aeb84083258361263a3f9e5baf