### PR TITLE
Implement search synonym retrieval

### DIFF
--- a/Sources/FountainOps/Generated/Client/typesense/Models.swift
+++ b/Sources/FountainOps/Generated/Client/typesense/Models.swift
@@ -451,6 +451,14 @@ public struct SearchSynonymSchema: Codable {
     public let synonyms: [String]
 }
 
+public struct SearchSynonym: Codable {
+    public let locale: String
+    public let root: String
+    public let symbols_to_index: [String]
+    public let synonyms: [String]
+    public let id: String
+}
+
 public struct SearchSynonymsResponse: Codable {
     public let synonyms: [SearchSynonym]
 }

--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -204,7 +204,13 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func getsearchsynonym(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 4 else { return HTTPResponse(status: 404) }
+        let collection = String(parts[1])
+        let id = String(parts[3])
+        let synonym = try await service.getSearchSynonym(collection: collection, id: id)
+        let data = try JSONEncoder().encode(synonym)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func upsertsearchsynonym(_ request: HTTPRequest, body: SearchSynonymSchema?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/Models.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Models.swift
@@ -451,6 +451,14 @@ public struct SearchSynonymSchema: Codable {
     public let synonyms: [String]
 }
 
+public struct SearchSynonym: Codable {
+    public let locale: String
+    public let root: String
+    public let symbols_to_index: [String]
+    public let synonyms: [String]
+    public let id: String
+}
+
 public struct SearchSynonymsResponse: Codable {
     public let synonyms: [SearchSynonym]
 }

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -102,6 +102,10 @@ public final actor TypesenseService {
     public func getSchemaChanges() async throws -> getSchemaChangesResponse {
         try await client.send(getSchemaChanges())
     }
+
+    public func getSearchSynonym(collection: String, id: String) async throws -> SearchSynonym {
+        try await client.send(getSearchSynonym(parameters: .init(collectionname: collection, synonymid: id)))
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -52,8 +52,9 @@ The server currently supports the following endpoints (commit):
 - `GET /debug` – `4de0ad4`
 - `GET /health` – `ce544f8`
 - `GET /operations/schema_changes` – `76d8956`
+- `GET /collections/{collectionName}/synonyms/{synonymId}` – `5c2fb5d`
 
-Last updated at `76d8956`.
+Last updated at `5c2fb5d`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- support `GET /collections/{collectionName}/synonyms/{synonymId}`
- provide `SearchSynonym` model in generated client and server code
- implement `getSearchSynonym` in `TypesenseService`
- handle the route in `Handlers`
- update API progress documentation

## Testing
- `swift build -c release`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_6889ca4aa2e483258067ecd48e6e7593