### PR TITLE
Implement export documents endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -10,7 +10,16 @@ public struct Handlers {
         return HTTPResponse(status: 501)
     }
     public func exportdocuments(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 4 else { return HTTPResponse(status: 404) }
+        let collection = String(parts[1])
+        let comps = URLComponents(string: request.path)
+        var params: [String: String] = [:]
+        for item in comps?.queryItems ?? [] {
+            if let value = item.value { params[item.name] = value }
+        }
+        let data = try await service.exportDocuments(collection: collection, parameters: params.isEmpty ? nil : params)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/octet-stream"], body: data)
     }
     public func indexdocument(_ request: HTTPRequest, body: indexDocumentRequest?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -106,6 +106,10 @@ public final actor TypesenseService {
     public func getSearchSynonym(collection: String, id: String) async throws -> SearchSynonym {
         try await client.send(getSearchSynonym(parameters: .init(collectionname: collection, synonymid: id)))
     }
+
+    public func exportDocuments(collection: String, parameters: [String: String]? = nil) async throws -> Data {
+        try await client.send(exportDocuments(parameters: .init(collectionname: collection, exportdocumentsparameters: parameters)))
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -53,8 +53,9 @@ The server currently supports the following endpoints (commit):
 - `GET /health` – `ce544f8`
 - `GET /operations/schema_changes` – `76d8956`
 - `GET /collections/{collectionName}/synonyms/{synonymId}` – `5c2fb5d`
+- `GET /collections/{collectionName}/documents/export` – `2905227`
 
-Last updated at `5c2fb5d`.
+Last updated at `2905227`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- support exporting documents in Typesense server
- document the new endpoint in the API plan

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6889cdc7c2088325a30fff85c1e95f62