### PR TITLE
Implement next Typesense endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -158,7 +158,14 @@ public struct Handlers {
         return HTTPResponse(status: 501)
     }
     public func importdocuments(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 4 else { return HTTPResponse(status: 404) }
+        let collection = String(parts[1])
+        let comps = URLComponents(string: request.path)
+        var params: [String: String] = [:]
+        for item in comps?.queryItems ?? [] { if let value = item.value { params[item.name] = value } }
+        let data = try await service.importDocuments(collection: collection, data: request.body, parameters: params.isEmpty ? nil : params)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/octet-stream"], body: data)
     }
     public func retrieveallpresets(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -54,8 +54,9 @@ The server currently supports the following endpoints (commit):
 - `GET /operations/schema_changes` – `76d8956`
 - `GET /collections/{collectionName}/synonyms/{synonymId}` – `5c2fb5d`
 - `GET /collections/{collectionName}/documents/export` – `2905227`
+- `POST /collections/{collectionName}/documents/import` – `11a3a92`
 
-Last updated at `2905227`.
+Last updated at `11a3a92`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- implement `importDocuments` API call in `TypesenseService`
- wire `POST /collections/{collectionName}/documents/import` handler
- update progress in `typesense_server_full_api_plan.md`

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6889db16e12c832598fe371584f4188a