### PR TITLE
Implement getDocument endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -143,7 +143,12 @@ public struct Handlers {
         return HTTPResponse(status: 501)
     }
     public func getdocument(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 4 else { return HTTPResponse(status: 404) }
+        let collection = String(parts[1])
+        let id = String(parts[3])
+        let data = try await service.getDocument(collection: collection, id: id)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func deletedocument(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -137,6 +137,10 @@ public final actor TypesenseService {
         let (respData, _) = try await client.session.data(for: request)
         return respData
     }
+
+    public func getDocument(collection: String, id: String) async throws -> Data {
+        try await client.send(getDocument(parameters: .init(collectionname: collection, documentid: id)))
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -55,8 +55,9 @@ The server currently supports the following endpoints (commit):
 - `GET /collections/{collectionName}/synonyms/{synonymId}` – `5c2fb5d`
 - `GET /collections/{collectionName}/documents/export` – `2905227`
 - `POST /collections/{collectionName}/documents/import` – `11a3a92`
+- `GET /collections/{collectionName}/documents/{documentId}` – `637dca5`
 
-Last updated at `11a3a92`.
+Last updated at `637dca5`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- enable `GET /collections/{collectionName}/documents/{documentId}` on the Typesense server
- document the new endpoint in the API plan

## Testing
- `swift --version`
- `swift build` *(failed: compilation exceeded time limits)*
- `swift test -l` *(failed: build interrupted due to time)*

------
https://chatgpt.com/codex/tasks/task_e_6889e45683488325861dc8e9786e519d