### PR TITLE
Implement delete document endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -151,7 +151,12 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func deletedocument(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 4 else { return HTTPResponse(status: 404) }
+        let collection = String(parts[1])
+        let id = String(parts[3])
+        let data = try await service.deleteDocument(collection: collection, id: id)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func getstemmingdictionary(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -141,6 +141,10 @@ public final actor TypesenseService {
     public func getDocument(collection: String, id: String) async throws -> Data {
         try await client.send(getDocument(parameters: .init(collectionname: collection, documentid: id)))
     }
+
+    public func deleteDocument(collection: String, id: String) async throws -> Data {
+        try await client.send(deleteDocument(parameters: .init(collectionname: collection, documentid: id)))
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -56,8 +56,9 @@ The server currently supports the following endpoints (commit):
 - `GET /collections/{collectionName}/documents/export` – `2905227`
 - `POST /collections/{collectionName}/documents/import` – `11a3a92`
 - `GET /collections/{collectionName}/documents/{documentId}` – `637dca5`
+- `DELETE /collections/{collectionName}/documents/{documentId}` – `9a12fff`
 
-Last updated at `637dca5`.
+Last updated at `9a12fff`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- support DELETE /collections/{collectionName}/documents/{documentId}
- document new endpoint in Typesense plan

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6889e860a5948325828b39c667ca702c