### PR TITLE
Implement conversation models listing endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -53,7 +53,9 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func retrieveallconversationmodels(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let models = try await service.retrieveAllConversationModels()
+        let data = try JSONEncoder().encode(models)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func createconversationmodel(_ request: HTTPRequest, body: ConversationModelCreateSchema?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -145,6 +145,10 @@ public final actor TypesenseService {
     public func deleteDocument(collection: String, id: String) async throws -> Data {
         try await client.send(deleteDocument(parameters: .init(collectionname: collection, documentid: id)))
     }
+
+    public func retrieveAllConversationModels() async throws -> retrieveAllConversationModelsResponse {
+        try await client.send(retrieveAllConversationModels())
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -57,8 +57,9 @@ The server currently supports the following endpoints (commit):
 - `POST /collections/{collectionName}/documents/import` – `11a3a92`
 - `GET /collections/{collectionName}/documents/{documentId}` – `637dca5`
 - `DELETE /collections/{collectionName}/documents/{documentId}` – `9a12fff`
+- `GET /conversations/models` – `fefbea0`
 
-Last updated at `9a12fff`.
+Last updated at `fefbea0`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- implement `retrieveAllConversationModels` in `TypesenseService`
- wire handler to return conversation model list
- document the new `GET /conversations/models` endpoint

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6889ef3a68f08325b37479f791a37305