### PR TITLE
Implement createConversationModel endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -58,7 +58,10 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func createconversationmodel(_ request: HTTPRequest, body: ConversationModelCreateSchema?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        guard let schema = body else { return HTTPResponse(status: 400) }
+        let model = try await service.createConversationModel(schema: schema)
+        let data = try JSONEncoder().encode(model)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func getcollection(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         let parts = request.path.split(separator: "/")

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -149,6 +149,10 @@ public final actor TypesenseService {
     public func retrieveAllConversationModels() async throws -> retrieveAllConversationModelsResponse {
         try await client.send(retrieveAllConversationModels())
     }
+
+    public func createConversationModel(schema: ConversationModelCreateSchema) async throws -> ConversationModelSchema {
+        try await client.send(createConversationModel(body: schema))
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -58,8 +58,9 @@ The server currently supports the following endpoints (commit):
 - `GET /collections/{collectionName}/documents/{documentId}` – `637dca5`
 - `DELETE /collections/{collectionName}/documents/{documentId}` – `9a12fff`
 - `GET /conversations/models` – `fefbea0`
+- `POST /conversations/models` – `f66f5f3`
 
-Last updated at `fefbea0`.
+Last updated at `f66f5f3`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- implement Typesense conversation model creation
- add handler method to invoke service
- record progress of new endpoint in docs

## Testing
- `swift build -c debug`
- `swift test -c debug`

------
https://chatgpt.com/codex/tasks/task_e_6889f3b9c9348325965527be0b9d72db