### PR TITLE
Implement retrieveConversationModel endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -124,7 +124,12 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func retrieveconversationmodel(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 3 else { return HTTPResponse(status: 404) }
+        let id = String(parts[2])
+        let model = try await service.retrieveConversationModel(id: id)
+        let data = try JSONEncoder().encode(model)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func updateconversationmodel(_ request: HTTPRequest, body: ConversationModelUpdateSchema?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -153,6 +153,10 @@ public final actor TypesenseService {
     public func createConversationModel(schema: ConversationModelCreateSchema) async throws -> ConversationModelSchema {
         try await client.send(createConversationModel(body: schema))
     }
+
+    public func retrieveConversationModel(id: String) async throws -> ConversationModelSchema {
+        try await client.send(retrieveConversationModel(parameters: .init(modelid: id)))
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -59,8 +59,9 @@ The server currently supports the following endpoints (commit):
 - `DELETE /collections/{collectionName}/documents/{documentId}` – `9a12fff`
 - `GET /conversations/models` – `fefbea0`
 - `POST /conversations/models` – `f66f5f3`
+- `GET /conversations/models/{modelId}` – `361d89c`
 
-Last updated at `f66f5f3`.
+Last updated at `361d89c`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- implement `retrieveConversationModel` in `TypesenseService`
- wire up `retrieveconversationmodel` handler
- document the new endpoint in the Typesense server plan

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_6889fa762d808325930a99041eaf8d72