### PR TITLE
Implement update conversation model endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -132,7 +132,13 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func updateconversationmodel(_ request: HTTPRequest, body: ConversationModelUpdateSchema?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        guard let schema = body else { return HTTPResponse(status: 400) }
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 3 else { return HTTPResponse(status: 404) }
+        let id = String(parts[2])
+        let model = try await service.updateConversationModel(id: id, schema: schema)
+        let data = try JSONEncoder().encode(model)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func deleteconversationmodel(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -157,6 +157,10 @@ public final actor TypesenseService {
     public func retrieveConversationModel(id: String) async throws -> ConversationModelSchema {
         try await client.send(retrieveConversationModel(parameters: .init(modelid: id)))
     }
+
+    public func updateConversationModel(id: String, schema: ConversationModelUpdateSchema) async throws -> ConversationModelSchema {
+        try await client.send(updateConversationModel(parameters: .init(modelid: id), body: schema))
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -60,8 +60,9 @@ The server currently supports the following endpoints (commit):
 - `GET /conversations/models` – `fefbea0`
 - `POST /conversations/models` – `f66f5f3`
 - `GET /conversations/models/{modelId}` – `361d89c`
+- `PUT /conversations/models/{modelId}` – `a1a5fea`
 
-Last updated at `361d89c`.
+Last updated at `a1a5fea`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- implement `updateConversationModel` in `TypesenseService`
- wire up `updateconversationmodel` handler
- track endpoint progress in docs

## Testing
- `swift build` *(fails: log truncated)*
- `swift test -v` *(fails: log truncated)*

------
https://chatgpt.com/codex/tasks/task_e_6889fda6c02c8325a97fe2e655c6a33c