### PR TITLE
Implement delete conversation model endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -141,7 +141,12 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func deleteconversationmodel(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 3 else { return HTTPResponse(status: 404) }
+        let id = String(parts[2])
+        let model = try await service.deleteConversationModel(id: id)
+        let data = try JSONEncoder().encode(model)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func takesnapshot(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -161,6 +161,10 @@ public final actor TypesenseService {
     public func updateConversationModel(id: String, schema: ConversationModelUpdateSchema) async throws -> ConversationModelSchema {
         try await client.send(updateConversationModel(parameters: .init(modelid: id), body: schema))
     }
+
+    public func deleteConversationModel(id: String) async throws -> ConversationModelSchema {
+        try await client.send(deleteConversationModel(parameters: .init(modelid: id)))
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -61,8 +61,9 @@ The server currently supports the following endpoints (commit):
 - `POST /conversations/models` – `f66f5f3`
 - `GET /conversations/models/{modelId}` – `361d89c`
 - `PUT /conversations/models/{modelId}` – `a1a5fea`
+- `DELETE /conversations/models/{modelId}` – `285ca93`
 
-Last updated at `a1a5fea`.
+Last updated at `285ca93`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- implement TypesenseService and handler for deleting conversation models
- document `/conversations/models/{modelId}` DELETE endpoint in the API plan

## Testing
- `swift test -v` *(fails: build timed out)*

------
https://chatgpt.com/codex/tasks/task_e_688a01b6cd708325978bccc763fb94e6