### PR TITLE
Implement delete key endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -283,7 +283,11 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func deletekey(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 2, let id = Int(parts[1]) else { return HTTPResponse(status: 404) }
+        let result = try await service.deleteKey(id: id)
+        let data = try JSONEncoder().encode(result)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func searchcollection(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         let parts = request.path.split(separator: "/")

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -62,6 +62,10 @@ public final actor TypesenseService {
         try await client.send(getKey(parameters: .init(keyid: id)))
     }
 
+    public func deleteKey(id: Int) async throws -> ApiKeyDeleteResponse {
+        try await client.send(deleteKey(parameters: .init(keyid: id)))
+    }
+
     public func getAliases() async throws -> CollectionAliasesResponse {
         try await client.send(getAliases())
     }

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -45,6 +45,7 @@ The server currently supports the following endpoints (commit):
 - `GET /keys` – `792ff5b`
 - `POST /keys` – `792ff5b`
 - `GET /keys/{keyId}` – `e6801c5`
+- `DELETE /keys/{keyId}` – `9f4ad19`
 - `GET /aliases` – `384dc86`
 - `PUT /aliases/{aliasName}` – `1bce1dc`
 - `GET /aliases/{aliasName}` – `ca44a96`
@@ -63,7 +64,7 @@ The server currently supports the following endpoints (commit):
 - `PUT /conversations/models/{modelId}` – `a1a5fea`
 - `DELETE /conversations/models/{modelId}` – `285ca93`
 
-Last updated at `285ca93`.
+Last updated at `9f4ad19`.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- implement `DELETE /keys/{keyId}` in Typesense server
- document progress in full API plan

## Testing
- `swift test -v` *(fails: building dependencies took too long)*

------
https://chatgpt.com/codex/tasks/task_e_688a04b131a883259a4b5954bb594fb4