### PR TITLE
Implement GET synonyms endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -248,7 +248,12 @@ public struct Handlers {
         return HTTPResponse(status: 501)
     }
     public func getsearchsynonyms(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 3 else { return HTTPResponse(status: 404) }
+        let collection = String(parts[1])
+        let synonyms = try await service.getSearchSynonyms(collection: collection)
+        let data = try JSONEncoder().encode(synonyms)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func getschemachanges(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         let changes = try await service.getSchemaChanges()

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -111,6 +111,10 @@ public final actor TypesenseService {
         try await client.send(getSearchOverrides(parameters: .init(collectionname: collection)))
     }
 
+    public func getSearchSynonyms(collection: String) async throws -> SearchSynonymsResponse {
+        try await client.send(getSearchSynonyms(parameters: .init(collectionname: collection)))
+    }
+
     public func getSearchSynonym(collection: String, id: String) async throws -> SearchSynonym {
         try await client.send(getSearchSynonym(parameters: .init(collectionname: collection, synonymid: id)))
     }

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -64,8 +64,9 @@ The server currently supports the following endpoints (commit):
 - `PUT /conversations/models/{modelId}` – `a1a5fea`
 - `DELETE /conversations/models/{modelId}` – `285ca93`
 - `GET /collections/{collectionName}/overrides` – `c2ae25a`
+- `GET /collections/{collectionName}/synonyms` – `26244cd`
 
-Last updated at `c2ae25a`.
+Last updated at `26244cd`.
 
 
 ---


### PR DESCRIPTION
## Summary
- support listing search synonyms in Typesense server
- document the new endpoint

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_688a0d74b24c83258f059f6e3a9444da