### PR TITLE
Implement document index/delete endpoints

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -50,6 +50,14 @@ public final actor TypesenseService {
         try await client.send(deleteCollection(parameters: .init(collectionname: name)))
     }
 
+    public func indexDocument(collection: String, document: indexDocumentRequest, action: IndexAction? = nil, dirtyValues: DirtyValues? = nil) async throws -> Data {
+        try await client.send(indexDocument(parameters: .init(collectionname: collection, action: action, dirtyValues: dirtyValues), body: document))
+    }
+
+    public func deleteDocuments(collection: String, parameters: [String: String]? = nil) async throws -> deleteDocumentsResponse {
+        try await client.send(deleteDocuments(parameters: .init(collectionname: collection, deletedocumentsparameters: parameters)))
+    }
+
     public func getKeys() async throws -> ApiKeysResponse {
         try await client.send(getKeys())
     }

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -67,8 +67,10 @@ The server currently supports the following endpoints (commit):
 - `GET /collections/{collectionName}/overrides/{overrideId}` – `f875609`
 - `GET /collections/{collectionName}/synonyms` – `26244cd`
 - `PUT /collections/{collectionName}/synonyms/{synonymId}` – `d8b7a3e`
+- `POST /collections/{collectionName}/documents` – `28fb9e3`
+- `DELETE /collections/{collectionName}/documents` – `28fb9e3`
 
-Last updated at `f875609`.
+Last updated at `28fb9e3`.
 
 
 ---


### PR DESCRIPTION
## Summary
- support POST and DELETE collection documents in Typesense server
- document new endpoint implementations

## Testing
- `./Sources/FountainOps/run-tests.sh` *(fails: `swift test` unexpected argument)*
- `swift build -c release`

------
https://chatgpt.com/codex/tasks/task_e_688a1cefca2883258cddd71ccb25e066