### PR TITLE
Implement PATCH documents endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Client/typesense/Models.swift
+++ b/Sources/FountainOps/Generated/Client/typesense/Models.swift
@@ -497,6 +497,12 @@ public struct VoiceQueryModelCollectionConfig: Codable {
 
 public typealias indexDocumentRequest = [String: String]
 
+public typealias updateDocumentsRequest = [String: String]
+
+public struct updateDocumentsResponse: Codable {
+    public let num_updated: Int
+}
+
 public struct deleteDocumentsResponse: Codable {
     public let num_deleted: Int
 }

--- a/Sources/FountainOps/Generated/Client/typesense/Requests/updateDocuments.swift
+++ b/Sources/FountainOps/Generated/Client/typesense/Requests/updateDocuments.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public struct updateDocumentsParameters: Codable {
+    public let collectionname: String
+    public var updatedocumentsparameters: [String: String]?
+}
+
+public struct updateDocuments: APIRequest {
+    public typealias Body = updateDocumentsRequest
+    public typealias Response = updateDocumentsResponse
+    public var method: String { "PATCH" }
+    public var parameters: updateDocumentsParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/documents"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        if let value = parameters.updatedocumentsparameters { query.append("updateDocumentsParameters=\(value)") }
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: updateDocumentsParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -41,6 +41,18 @@ public struct Handlers {
         let data = try await service.indexDocument(collection: collection, document: doc, action: action, dirtyValues: dirty)
         return HTTPResponse(status: 201, headers: ["Content-Type": "application/json"], body: data)
     }
+    public func updatedocuments(_ request: HTTPRequest, body: updateDocumentsRequest?) async throws -> HTTPResponse {
+        guard let fields = body else { return HTTPResponse(status: 400) }
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 3 else { return HTTPResponse(status: 404) }
+        let collection = String(parts[1])
+        let comps = URLComponents(string: request.path)
+        var params: [String: String] = [:]
+        for item in comps?.queryItems ?? [] { if let value = item.value { params[item.name] = value } }
+        let result = try await service.updateDocuments(collection: collection, document: fields, parameters: params.isEmpty ? nil : params)
+        let data = try JSONEncoder().encode(result)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+    }
     public func deletedocuments(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         let parts = request.path.split(separator: "/")
         guard parts.count >= 3 else { return HTTPResponse(status: 404) }

--- a/Sources/FountainOps/Generated/Server/typesense/Models.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Models.swift
@@ -497,6 +497,12 @@ public struct VoiceQueryModelCollectionConfig: Codable {
 
 public typealias indexDocumentRequest = [String: String]
 
+public typealias updateDocumentsRequest = [String: String]
+
+public struct updateDocumentsResponse: Codable {
+    public let num_updated: Int
+}
+
 public struct deleteDocumentsResponse: Codable {
     public let num_deleted: Int
 }

--- a/Sources/FountainOps/Generated/Server/typesense/Router.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Router.swift
@@ -25,6 +25,9 @@ public struct Router {
         case ("POST", "/collections/{collectionName}/documents"):
             let body = try? JSONDecoder().decode(indexDocumentRequest.self, from: request.body)
             return try await handlers.indexdocument(request, body: body)
+        case ("PATCH", "/collections/{collectionName}/documents"):
+            let body = try? JSONDecoder().decode(updateDocumentsRequest.self, from: request.body)
+            return try await handlers.updatedocuments(request, body: body)
         case ("DELETE", "/collections/{collectionName}/documents"):
             let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
             return try await handlers.deletedocuments(request, body: body)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -54,6 +54,10 @@ public final actor TypesenseService {
         try await client.send(indexDocument(parameters: .init(collectionname: collection, action: action, dirtyValues: dirtyValues), body: document))
     }
 
+    public func updateDocuments(collection: String, document: updateDocumentsRequest, parameters: [String: String]? = nil) async throws -> updateDocumentsResponse {
+        try await client.send(updateDocuments(parameters: .init(collectionname: collection, updatedocumentsparameters: parameters), body: document))
+    }
+
     public func deleteDocuments(collection: String, parameters: [String: String]? = nil) async throws -> deleteDocumentsResponse {
         try await client.send(deleteDocuments(parameters: .init(collectionname: collection, deletedocumentsparameters: parameters)))
     }

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -69,8 +69,9 @@ The server currently supports the following endpoints (commit):
 - `PUT /collections/{collectionName}/synonyms/{synonymId}` – `d8b7a3e`
 - `POST /collections/{collectionName}/documents` – `28fb9e3`
 - `DELETE /collections/{collectionName}/documents` – `28fb9e3`
+- `PATCH /collections/{collectionName}/documents` – `181cab6`
 
-Last updated at `28fb9e3`.
+Last updated at `181cab6`.
 
 
 ---


### PR DESCRIPTION
## Summary
- extend generated Typesense service with `updateDocuments`
- route PATCH `/collections/{collectionName}/documents`
- handle document updates in server handlers
- expose updateDocuments request in client
- document new endpoint in API progress list

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688a208970b883259abcc9172d228564