### PR TITLE
Implement Typesense override upsert

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -257,10 +257,23 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func upsertsearchoverride(_ request: HTTPRequest, body: SearchOverrideSchema?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        guard let schema = body else { return HTTPResponse(status: 400) }
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 4 else { return HTTPResponse(status: 404) }
+        let collection = String(parts[1])
+        let id = String(parts[3])
+        let override = try await service.upsertSearchOverride(collection: collection, id: id, schema: schema)
+        let data = try JSONEncoder().encode(override)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func deletesearchoverride(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 4 else { return HTTPResponse(status: 404) }
+        let collection = String(parts[1])
+        let id = String(parts[3])
+        let result = try await service.deleteSearchOverride(collection: collection, id: id)
+        let data = try JSONEncoder().encode(result)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func getaliases(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         let aliases = try await service.getAliases()

--- a/Sources/FountainOps/Generated/Server/typesense/Models.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Models.swift
@@ -333,6 +333,22 @@ public struct SearchOverrideSchema: Codable {
     public let stop_processing: Bool
 }
 
+public struct SearchOverride: Codable {
+    public let effective_from_ts: Int
+    public let effective_to_ts: Int
+    public let excludes: [SearchOverrideExclude]
+    public let filter_by: String
+    public let filter_curated_hits: Bool
+    public let includes: [SearchOverrideInclude]
+    public let metadata: [String: String]
+    public let remove_matched_tokens: Bool
+    public let replace_query: String
+    public let rule: SearchOverrideRule
+    public let sort_by: String
+    public let stop_processing: Bool
+    public let id: String
+}
+
 public struct SearchOverridesResponse: Codable {
     public let overrides: [SearchOverride]
 }

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -127,6 +127,14 @@ public final actor TypesenseService {
         try await client.send(getSearchOverride(parameters: .init(collectionname: collection, overrideid: id)))
     }
 
+    public func upsertSearchOverride(collection: String, id: String, schema: SearchOverrideSchema) async throws -> SearchOverride {
+        try await client.send(upsertSearchOverride(parameters: .init(collectionname: collection, overrideid: id), body: schema))
+    }
+
+    public func deleteSearchOverride(collection: String, id: String) async throws -> SearchOverrideDeleteResponse {
+        try await client.send(deleteSearchOverride(parameters: .init(collectionname: collection, overrideid: id)))
+    }
+
     public func getSearchSynonyms(collection: String) async throws -> SearchSynonymsResponse {
         try await client.send(getSearchSynonyms(parameters: .init(collectionname: collection)))
     }

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -65,13 +65,14 @@ The server currently supports the following endpoints (commit):
 - `DELETE /conversations/models/{modelId}` – `285ca93`
 - `GET /collections/{collectionName}/overrides` – `c2ae25a`
 - `GET /collections/{collectionName}/overrides/{overrideId}` – `f875609`
+- `PUT /collections/{collectionName}/overrides/{overrideId}` – `6f97f80`
 - `GET /collections/{collectionName}/synonyms` – `26244cd`
 - `PUT /collections/{collectionName}/synonyms/{synonymId}` – `d8b7a3e`
 - `POST /collections/{collectionName}/documents` – `28fb9e3`
 - `DELETE /collections/{collectionName}/documents` – `28fb9e3`
 - `PATCH /collections/{collectionName}/documents` – `181cab6`
 
-Last updated at `181cab6`.
+Last updated at `6f97f80`.
 
 
 ---


### PR DESCRIPTION
## Summary
- implement PUT/DELETE overrides endpoints in `TypesenseService` and handlers
- generate `SearchOverride` model
- document new API endpoint in progress log

## Testing
- `swift test -c release`

------
https://chatgpt.com/codex/tasks/task_e_688a23d88c0083258e518dbc7866a9ef