### PR TITLE
Add multiSearch endpoint implementation

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -189,7 +189,12 @@ public struct Handlers {
         return HTTPResponse(status: 501)
     }
     public func multisearch(_ request: HTTPRequest, body: MultiSearchSearchesParameter?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        guard let searches = body else { return HTTPResponse(status: 400) }
+        let comps = URLComponents(string: request.path)
+        let params = comps?.queryItems?.first(where: { $0.name == "multiSearchParameters" })?.value ?? "{}"
+        let result = try await service.multiSearch(parameters: params, body: searches)
+        let data = try JSONEncoder().encode(result)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func retrievenlsearchmodel(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -209,6 +209,19 @@ public final actor TypesenseService {
     public func deleteConversationModel(id: String) async throws -> ConversationModelSchema {
         try await client.send(deleteConversationModel(parameters: .init(modelid: id)))
     }
+
+    public func multiSearch(parameters: String, body: MultiSearchSearchesParameter) async throws -> MultiSearchResult {
+        struct Request: APIRequest {
+            typealias Body = MultiSearchSearchesParameter
+            typealias Response = MultiSearchResult
+            let parameters: String
+            var body: Body? { bodyParam }
+            let bodyParam: Body
+            var method: String { "POST" }
+            var path: String { "/multi_search?multiSearchParameters=\(parameters)" }
+        }
+        return try await client.send(Request(parameters: parameters, bodyParam: body))
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -71,8 +71,9 @@ The server currently supports the following endpoints (commit):
 - `POST /collections/{collectionName}/documents` – `28fb9e3`
 - `DELETE /collections/{collectionName}/documents` – `28fb9e3`
 - `PATCH /collections/{collectionName}/documents` – `181cab6`
+- `POST /multi_search` – `3e66160`
 
-Last updated at `6f97f80`.
+Last updated at `3e66160`.
 
 
 ---


### PR DESCRIPTION
## Summary
- implement `multiSearch` in `TypesenseService`
- wire up handler logic for `POST /multi_search`
- document endpoint progress in Typesense server plan

## Testing
- `swift build && swift test`

------
https://chatgpt.com/codex/tasks/task_e_688a29bbbe408325a1998de83bb8aa45