### PR TITLE
Implement analytics event endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -65,7 +65,9 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func createanalyticsevent(_ request: HTTPRequest, body: AnalyticsEventCreateSchema?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        guard let schema = body else { return HTTPResponse(status: 400) }
+        let data = try await service.createAnalyticsEvent(schema: schema)
+        return HTTPResponse(status: 201, headers: ["Content-Type": "application/json"], body: data)
     }
     public func retrieveanalyticsrule(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -210,6 +210,10 @@ public final actor TypesenseService {
         try await client.send(deleteConversationModel(parameters: .init(modelid: id)))
     }
 
+    public func createAnalyticsEvent(schema: AnalyticsEventCreateSchema) async throws -> Data {
+        try await client.send(createAnalyticsEvent(body: schema))
+    }
+
     public func multiSearch(parameters: String, body: MultiSearchSearchesParameter) async throws -> MultiSearchResult {
         struct Request: APIRequest {
             typealias Body = MultiSearchSearchesParameter

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -72,8 +72,9 @@ The server currently supports the following endpoints (commit):
 - `DELETE /collections/{collectionName}/documents` – `28fb9e3`
 - `PATCH /collections/{collectionName}/documents` – `181cab6`
 - `POST /multi_search` – `3e66160`
+- `POST /analytics/events` – `73c01a2`
 
-Last updated at `3e66160`.
+Last updated at `73c01a2`.
 
 
 ---


### PR DESCRIPTION
## Summary
- implement `createAnalyticsEvent` API call and handler
- document new endpoint in Typesense server plan

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_688a2d074bd883259c5e6c108886ad0d