### PR TITLE
Implement analytics rule creation endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -135,7 +135,9 @@ public struct Handlers {
         return HTTPResponse(status: 501)
     }
     public func createanalyticsrule(_ request: HTTPRequest, body: AnalyticsRuleSchema?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        guard let schema = body else { return HTTPResponse(status: 400) }
+        let data = try await service.createAnalyticsRule(schema: schema)
+        return HTTPResponse(status: 201, headers: ["Content-Type": "application/json"], body: data)
     }
     public func getalias(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         let parts = request.path.split(separator: "/")

--- a/Sources/FountainOps/Generated/Server/typesense/Models.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Models.swift
@@ -52,6 +52,12 @@ public struct AnalyticsRuleUpsertSchema: Codable {
     public let type: String
 }
 
+public struct AnalyticsRuleSchema: Codable {
+    public let params: AnalyticsRuleParameters
+    public let type: String
+    public let name: String
+}
+
 public struct AnalyticsRulesRetrieveSchema: Codable {
     public let rules: [AnalyticsRuleSchema]
 }

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -214,6 +214,10 @@ public final actor TypesenseService {
         try await client.send(createAnalyticsEvent(body: schema))
     }
 
+    public func createAnalyticsRule(schema: AnalyticsRuleSchema) async throws -> Data {
+        try await client.send(createAnalyticsRule(body: schema))
+    }
+
     public func multiSearch(parameters: String, body: MultiSearchSearchesParameter) async throws -> MultiSearchResult {
         struct Request: APIRequest {
             typealias Body = MultiSearchSearchesParameter

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -73,8 +73,9 @@ The server currently supports the following endpoints (commit):
 - `PATCH /collections/{collectionName}/documents` – `181cab6`
 - `POST /multi_search` – `3e66160`
 - `POST /analytics/events` – `73c01a2`
+- `POST /analytics/rules` – `3110987`
 
-Last updated at `73c01a2`.
+Last updated at `3110987`.
 
 
 ---


### PR DESCRIPTION
## Summary
- add `AnalyticsRuleSchema`
- implement `createAnalyticsRule` service
- wire up analytics rule creation handler
- document `POST /analytics/rules` in API plan

## Testing
- `swift build && swift test`

------
https://chatgpt.com/codex/tasks/task_e_688a3335922483259dd5b39d867a56b6