### PR TITLE
Implement GET /analytics/rules endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -132,7 +132,9 @@ public struct Handlers {
         return HTTPResponse(status: 501)
     }
     public func retrieveanalyticsrules(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let rules = try await service.retrieveAnalyticsRules()
+        let data = try JSONEncoder().encode(rules)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func createanalyticsrule(_ request: HTTPRequest, body: AnalyticsRuleSchema?) async throws -> HTTPResponse {
         guard let schema = body else { return HTTPResponse(status: 400) }

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -218,6 +218,10 @@ public final actor TypesenseService {
         try await client.send(createAnalyticsRule(body: schema))
     }
 
+    public func retrieveAnalyticsRules() async throws -> AnalyticsRulesRetrieveSchema {
+        try await client.send(retrieveAnalyticsRules())
+    }
+
     public func multiSearch(parameters: String, body: MultiSearchSearchesParameter) async throws -> MultiSearchResult {
         struct Request: APIRequest {
             typealias Body = MultiSearchSearchesParameter

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -74,8 +74,9 @@ The server currently supports the following endpoints (commit):
 - `POST /multi_search` – `3e66160`
 - `POST /analytics/events` – `73c01a2`
 - `POST /analytics/rules` – `3110987`
+- `GET /analytics/rules` – `7916239`
 
-Last updated at `3110987`.
+Last updated at `7916239`.
 
 
 ---


### PR DESCRIPTION
## Summary
- implement retrieval of analytics rules in `TypesenseService`
- return rules from HTTP handler
- document new endpoint in API plan

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688a3b755c7c8325a528789b17a026b3