### PR TITLE
Implement analytics rule retrieval

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -70,13 +70,29 @@ public struct Handlers {
         return HTTPResponse(status: 201, headers: ["Content-Type": "application/json"], body: data)
     }
     public func retrieveanalyticsrule(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 3 else { return HTTPResponse(status: 404) }
+        let name = String(parts[2])
+        let rule = try await service.retrieveAnalyticsRule(name: name)
+        let data = try JSONEncoder().encode(rule)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func upsertanalyticsrule(_ request: HTTPRequest, body: AnalyticsRuleUpsertSchema?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        guard let schema = body else { return HTTPResponse(status: 400) }
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 3 else { return HTTPResponse(status: 404) }
+        let name = String(parts[2])
+        let rule = try await service.upsertAnalyticsRule(name: name, schema: schema)
+        let data = try JSONEncoder().encode(rule)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func deleteanalyticsrule(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 3 else { return HTTPResponse(status: 404) }
+        let name = String(parts[2])
+        let result = try await service.deleteAnalyticsRule(name: name)
+        let data = try JSONEncoder().encode(result)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func liststemmingdictionaries(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -222,6 +222,18 @@ public final actor TypesenseService {
         try await client.send(retrieveAnalyticsRules())
     }
 
+    public func retrieveAnalyticsRule(name: String) async throws -> AnalyticsRuleSchema {
+        try await client.send(retrieveAnalyticsRule(parameters: .init(rulename: name)))
+    }
+
+    public func upsertAnalyticsRule(name: String, schema: AnalyticsRuleUpsertSchema) async throws -> AnalyticsRuleSchema {
+        try await client.send(upsertAnalyticsRule(parameters: .init(rulename: name), body: schema))
+    }
+
+    public func deleteAnalyticsRule(name: String) async throws -> AnalyticsRuleDeleteResponse {
+        try await client.send(deleteAnalyticsRule(parameters: .init(rulename: name)))
+    }
+
     public func multiSearch(parameters: String, body: MultiSearchSearchesParameter) async throws -> MultiSearchResult {
         struct Request: APIRequest {
             typealias Body = MultiSearchSearchesParameter

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -75,8 +75,9 @@ The server currently supports the following endpoints (commit):
 - `POST /analytics/events` – `73c01a2`
 - `POST /analytics/rules` – `3110987`
 - `GET /analytics/rules` – `7916239`
+- `GET /analytics/rules/{ruleName}` – `1191af5`
 
-Last updated at `7916239`.
+Last updated at `1191af5`.
 
 
 ---


### PR DESCRIPTION
## Summary
- implement server handlers for analytics rule endpoints
- wire up service methods to proxy to Typesense
- document `GET /analytics/rules/{ruleName}` implementation

## Testing
- `swift build`
- `swift test -v` *(fails: environment stalled)*

------
https://chatgpt.com/codex/tasks/task_e_688a433b5a1c83258ed7b4bfaa053004