### PR TITLE
Implement metrics endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -247,7 +247,9 @@ public struct Handlers {
         return HTTPResponse(status: 501)
     }
     public func retrievemetrics(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let metrics = try await service.retrieveMetrics()
+        let data = try JSONEncoder().encode(metrics)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func importstemmingdictionary(_ request: HTTPRequest, body: importStemmingDictionaryRequest?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -234,6 +234,10 @@ public final actor TypesenseService {
         try await client.send(deleteAnalyticsRule(parameters: .init(rulename: name)))
     }
 
+    public func retrieveMetrics() async throws -> retrieveMetricsResponse {
+        try await client.send(retrieveMetrics())
+    }
+
     public func multiSearch(parameters: String, body: MultiSearchSearchesParameter) async throws -> MultiSearchResult {
         struct Request: APIRequest {
             typealias Body = MultiSearchSearchesParameter

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -76,8 +76,9 @@ The server currently supports the following endpoints (commit):
 - `POST /analytics/rules` – `3110987`
 - `GET /analytics/rules` – `7916239`
 - `GET /analytics/rules/{ruleName}` – `1191af5`
+- `GET /metrics.json` – `ba0d4b3`
 
-Last updated at `1191af5`.
+Last updated at `ba0d4b3`.
 
 
 ---


### PR DESCRIPTION
## Summary
- implement Typesense metrics endpoint
- update Typesense API plan

## Testing
- `swift test -q`


------
https://chatgpt.com/codex/tasks/task_e_688a45a4dfd88325928af0c7098b9c04