### PR TITLE
Implement stemming dictionaries listing

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -95,7 +95,9 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func liststemmingdictionaries(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let list = try await service.listStemmingDictionaries()
+        let data = try JSONEncoder().encode(list)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func getcollections(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         let collections = try await service.listCollections()

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -234,6 +234,10 @@ public final actor TypesenseService {
         try await client.send(deleteAnalyticsRule(parameters: .init(rulename: name)))
     }
 
+    public func listStemmingDictionaries() async throws -> listStemmingDictionariesResponse {
+        try await client.send(listStemmingDictionaries())
+    }
+
     public func retrieveMetrics() async throws -> retrieveMetricsResponse {
         try await client.send(retrieveMetrics())
     }

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -77,8 +77,9 @@ The server currently supports the following endpoints (commit):
 - `GET /analytics/rules` – `7916239`
 - `GET /analytics/rules/{ruleName}` – `1191af5`
 - `GET /metrics.json` – `ba0d4b3`
+- `GET /stemming/dictionaries` – `e2315ef`
 
-Last updated at `ba0d4b3`.
+Last updated at `e2315ef`.
 
 
 ---


### PR DESCRIPTION
## Summary
- add API implementation for GET /stemming/dictionaries
- record the new endpoint in the Typesense server implementation plan

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688a48bfc5d4832599b570aa4435d743