### PR TITLE
Implement next Typesense endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -246,7 +246,12 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func getstemmingdictionary(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 3 else { return HTTPResponse(status: 404) }
+        let id = String(parts[2])
+        let dictionary = try await service.getStemmingDictionary(id: id)
+        let data = try JSONEncoder().encode(dictionary)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func retrievemetrics(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         let metrics = try await service.retrieveMetrics()

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -238,6 +238,10 @@ public final actor TypesenseService {
         try await client.send(listStemmingDictionaries())
     }
 
+    public func getStemmingDictionary(id: String) async throws -> StemmingDictionary {
+        try await client.send(getStemmingDictionary(parameters: .init(dictionaryid: id)))
+    }
+
     public func retrieveMetrics() async throws -> retrieveMetricsResponse {
         try await client.send(retrieveMetrics())
     }

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -78,8 +78,9 @@ The server currently supports the following endpoints (commit):
 - `GET /analytics/rules/{ruleName}` – `1191af5`
 - `GET /metrics.json` – `ba0d4b3`
 - `GET /stemming/dictionaries` – `e2315ef`
+- `GET /stemming/dictionaries/{dictionaryId}` – `43a5db8`
 
-Last updated at `e2315ef`.
+Last updated at `43a5db8`.
 
 
 ---


### PR DESCRIPTION
## Summary
- support `GET /stemming/dictionaries/{dictionaryId}` in typesense server
- log new endpoint in API plan

## Testing
- `swift test -c debug`

------
https://chatgpt.com/codex/tasks/task_e_688a4bc1bfec8325aecb265e8b7783a3