### PR TITLE
Implement importStemmingDictionary endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -259,7 +259,13 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func importstemmingdictionary(_ request: HTTPRequest, body: importStemmingDictionaryRequest?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        guard let content = body else { return HTTPResponse(status: 400) }
+        let comps = URLComponents(string: request.path)
+        guard let id = comps?.queryItems?.first(where: { $0.name == "id" })?.value else {
+            return HTTPResponse(status: 400)
+        }
+        let data = try await service.importStemmingDictionary(id: id, body: content)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/octet-stream"], body: data)
     }
     public func importdocuments(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         let parts = request.path.split(separator: "/")

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -246,6 +246,10 @@ public final actor TypesenseService {
         try await client.send(retrieveMetrics())
     }
 
+    public func importStemmingDictionary(id: String, body: importStemmingDictionaryRequest) async throws -> Data {
+        try await client.send(importStemmingDictionary(parameters: .init(id: id), body: body))
+    }
+
     public func multiSearch(parameters: String, body: MultiSearchSearchesParameter) async throws -> MultiSearchResult {
         struct Request: APIRequest {
             typealias Body = MultiSearchSearchesParameter

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -79,8 +79,9 @@ The server currently supports the following endpoints (commit):
 - `GET /metrics.json` – `ba0d4b3`
 - `GET /stemming/dictionaries` – `e2315ef`
 - `GET /stemming/dictionaries/{dictionaryId}` – `43a5db8`
+- `POST /stemming/dictionaries/import` – `caa51bd`
 
-Last updated at `43a5db8`.
+Last updated at `caa51bd`.
 
 
 ---


### PR DESCRIPTION
## Summary
- implement `importStemmingDictionary` service method
- wire up handler for `POST /stemming/dictionaries/import`
- update API implementation plan progress

## Testing
- `swift build`
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_e_688a4f4ef5a08325a93f8420b15da5f7