### PR TITLE
Implement GET /nl_search_models endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -284,7 +284,9 @@ public struct Handlers {
         return HTTPResponse(status: 501)
     }
     public func retrieveallnlsearchmodels(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let models = try await service.retrieveAllNLSearchModels()
+        let data = try JSONEncoder().encode(models)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func createnlsearchmodel(_ request: HTTPRequest, body: NLSearchModelCreateSchema?) async throws -> HTTPResponse {
         return HTTPResponse(status: 501)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -250,6 +250,10 @@ public final actor TypesenseService {
         try await client.send(importStemmingDictionary(parameters: .init(id: id), body: body))
     }
 
+    public func retrieveAllNLSearchModels() async throws -> retrieveAllNLSearchModelsResponse {
+        try await client.send(retrieveAllNLSearchModels())
+    }
+
     public func multiSearch(parameters: String, body: MultiSearchSearchesParameter) async throws -> MultiSearchResult {
         struct Request: APIRequest {
             typealias Body = MultiSearchSearchesParameter

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -80,8 +80,9 @@ The server currently supports the following endpoints (commit):
 - `GET /stemming/dictionaries` – `e2315ef`
 - `GET /stemming/dictionaries/{dictionaryId}` – `43a5db8`
 - `POST /stemming/dictionaries/import` – `caa51bd`
+- `GET /nl_search_models` – `d7e7891`
 
-Last updated at `caa51bd`.
+Last updated at `d7e7891`.
 
 
 ---


### PR DESCRIPTION
## Summary
- implement `retrieveAllNLSearchModels` in `TypesenseService`
- return actual data in `retrieveallnlsearchmodels` handler
- document new endpoint in API implementation plan

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688a56d71edc8325852974230f1b512a