### PR TITLE
Implement Typesense vote endpoint

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -147,7 +147,9 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func vote(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let status = try await service.vote()
+        let data = try JSONEncoder().encode(status)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func retrieveanalyticsrules(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         let rules = try await service.retrieveAnalyticsRules()

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -270,6 +270,10 @@ public final actor TypesenseService {
         try await client.send(deleteNLSearchModel(parameters: .init(modelid: id)))
     }
 
+    public func vote() async throws -> SuccessStatus {
+        try await client.send(vote())
+    }
+
     public func multiSearch(parameters: String, body: MultiSearchSearchesParameter) async throws -> MultiSearchResult {
         struct Request: APIRequest {
             typealias Body = MultiSearchSearchesParameter

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -82,8 +82,9 @@ The server currently supports the following endpoints (commit):
 - `POST /stemming/dictionaries/import` – `caa51bd`
 - `GET /nl_search_models` – `d7e7891`
 - `POST /nl_search_models` – `f39a3bb`
+- `POST /operations/vote` – `2521109`
 
-Last updated at `f39a3bb`.
+Last updated at `2521109`.
 
 
 ---


### PR DESCRIPTION
## Summary
- add TypesenseService.vote
- implement handler logic for POST `/operations/vote`
- record new endpoint in API plan docs

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688a5dfe9c188325b22a2feaae406427