### PR TITLE
Add remaining Typesense server endpoints

### DIFF
--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -212,7 +212,12 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func takesnapshot(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let comps = URLComponents(string: request.path)
+        guard let path = comps?.queryItems?.first(where: { $0.name == "snapshot_path" })?.value else {
+            return HTTPResponse(status: 400)
+        }
+        let data = try await service.takeSnapshot(path: path)
+        return HTTPResponse(status: 201, headers: ["Content-Type": "application/json"], body: data)
     }
     public func multisearch(_ request: HTTPRequest, body: MultiSearchSearchesParameter?) async throws -> HTTPResponse {
         guard let searches = body else { return HTTPResponse(status: 400) }
@@ -296,10 +301,14 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/octet-stream"], body: data)
     }
     public func retrieveallpresets(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let presets = try await service.retrieveAllPresets()
+        let data = try JSONEncoder().encode(presets)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func retrieveapistats(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let stats = try await service.retrieveAPIStats()
+        let data = try JSONEncoder().encode(stats)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func retrieveallnlsearchmodels(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         let models = try await service.retrieveAllNLSearchModels()
@@ -345,22 +354,54 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func retrievestopwordsset(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 2 else { return HTTPResponse(status: 404) }
+        let id = String(parts[1])
+        let result = try await service.retrieveStopwordsSet(id: id)
+        let data = try JSONEncoder().encode(result)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func upsertstopwordsset(_ request: HTTPRequest, body: StopwordsSetUpsertSchema?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        guard let schema = body else { return HTTPResponse(status: 400) }
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 2 else { return HTTPResponse(status: 404) }
+        let id = String(parts[1])
+        let result = try await service.upsertStopwordsSet(id: id, schema: schema)
+        let data = try JSONEncoder().encode(result)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func deletestopwordsset(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 2 else { return HTTPResponse(status: 404) }
+        let id = String(parts[1])
+        let result = try await service.deleteStopwordsSet(id: id)
+        let data = try JSONEncoder().encode(result)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func retrievepreset(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 2 else { return HTTPResponse(status: 404) }
+        let id = String(parts[1])
+        let preset = try await service.retrievePreset(id: id)
+        let data = try JSONEncoder().encode(preset)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func upsertpreset(_ request: HTTPRequest, body: PresetUpsertSchema?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        guard let schema = body else { return HTTPResponse(status: 400) }
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 2 else { return HTTPResponse(status: 404) }
+        let id = String(parts[1])
+        let preset = try await service.upsertPreset(id: id, schema: schema)
+        let data = try JSONEncoder().encode(preset)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func deletepreset(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 2 else { return HTTPResponse(status: 404) }
+        let id = String(parts[1])
+        let result = try await service.deletePreset(id: id)
+        let data = try JSONEncoder().encode(result)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func getsearchsynonyms(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         let parts = request.path.split(separator: "/")
@@ -438,7 +479,9 @@ public struct Handlers {
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func retrievestopwordssets(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        return HTTPResponse(status: 501)
+        let sets = try await service.retrieveStopwordsSets()
+        let data = try JSONEncoder().encode(sets)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
 }
 

--- a/Sources/FountainOps/Generated/Server/typesense/Models.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Models.swift
@@ -320,6 +320,15 @@ public struct NLSearchModelDeleteSchema: Codable {
     public let id: String
 }
 
+public struct PresetUpsertSchema: Codable {
+    public let value: [String: String]
+}
+
+public struct PresetSchema: Codable {
+    public let value: [String: String]
+    public let name: String
+}
+
 public struct PresetDeleteSchema: Codable {
     public let name: String
 }

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -286,6 +286,46 @@ public final actor TypesenseService {
         }
         return try await client.send(Request(parameters: parameters, bodyParam: body))
     }
+
+    public func takeSnapshot(path: String) async throws -> Data {
+        try await client.send(takeSnapshot(parameters: .init(snapshotPath: path)))
+    }
+
+    public func retrieveAllPresets() async throws -> PresetsRetrieveSchema {
+        try await client.send(retrieveAllPresets())
+    }
+
+    public func retrievePreset(id: String) async throws -> PresetSchema {
+        try await client.send(retrievePreset(parameters: .init(presetid: id)))
+    }
+
+    public func upsertPreset(id: String, schema: PresetUpsertSchema) async throws -> PresetSchema {
+        try await client.send(upsertPreset(parameters: .init(presetid: id), body: schema))
+    }
+
+    public func deletePreset(id: String) async throws -> PresetDeleteSchema {
+        try await client.send(deletePreset(parameters: .init(presetid: id)))
+    }
+
+    public func retrieveAPIStats() async throws -> APIStatsResponse {
+        try await client.send(retrieveAPIStats())
+    }
+
+    public func retrieveStopwordsSets() async throws -> StopwordsSetsRetrieveAllSchema {
+        try await client.send(retrieveStopwordsSets())
+    }
+
+    public func retrieveStopwordsSet(id: String) async throws -> StopwordsSetRetrieveSchema {
+        try await client.send(retrieveStopwordsSet(parameters: .init(setid: id)))
+    }
+
+    public func upsertStopwordsSet(id: String, schema: StopwordsSetUpsertSchema) async throws -> StopwordsSetSchema {
+        try await client.send(upsertStopwordsSet(parameters: .init(setid: id), body: schema))
+    }
+
+    public func deleteStopwordsSet(id: String) async throws -> deleteStopwordsSetResponse {
+        try await client.send(deleteStopwordsSet(parameters: .init(setid: id)))
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -83,8 +83,18 @@ The server currently supports the following endpoints (commit):
 - `GET /nl_search_models` – `d7e7891`
 - `POST /nl_search_models` – `f39a3bb`
 - `POST /operations/vote` – `2521109`
+- `POST /operations/snapshot` – `636fde0`
+- `GET /presets` – `636fde0`
+- `GET /presets/{presetId}` – `636fde0`
+- `PUT /presets/{presetId}` – `636fde0`
+- `DELETE /presets/{presetId}` – `636fde0`
+- `GET /stats.json` – `636fde0`
+- `GET /stopwords` – `636fde0`
+- `GET /stopwords/{setId}` – `636fde0`
+- `PUT /stopwords/{setId}` – `636fde0`
+- `DELETE /stopwords/{setId}` – `636fde0`
 
-Last updated at `2521109`.
+Last updated at `636fde0`.
 
 
 ---


### PR DESCRIPTION
## Summary
- implement snapshot, presets and stopwords endpoints in Typesense server
- expose new service methods for the endpoints
- define missing preset models
- document the additional routes in the API plan

## Testing
- `swift build` *(fails: timed out due to environment)*
- `swift test` *(fails: timed out due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_688a626b392883259b362d164bcfddfc