### PR TITLE
Complete missing Typesense endpoints

### DIFF
--- a/Sources/FountainOps/Generated/Client/typesense/Models.swift
+++ b/Sources/FountainOps/Generated/Client/typesense/Models.swift
@@ -499,6 +499,10 @@ public typealias indexDocumentRequest = [String: String]
 
 public typealias updateDocumentsRequest = [String: String]
 
+public typealias updateDocumentRequest = [String: String]
+
+public typealias updateDocumentResponse = [String: String]
+
 public struct updateDocumentsResponse: Codable {
     public let num_updated: Int
 }

--- a/Sources/FountainOps/Generated/Client/typesense/Requests/updateCollection.swift
+++ b/Sources/FountainOps/Generated/Client/typesense/Requests/updateCollection.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct updateCollectionParameters: Codable {
+    public let collectionname: String
+}
+
+public struct updateCollection: APIRequest {
+    public typealias Body = CollectionUpdateSchema
+    public typealias Response = CollectionUpdateSchema
+    public var method: String { "PATCH" }
+    public var parameters: updateCollectionParameters
+    public var path: String {
+        var path = "/collections/{collectionName}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: updateCollectionParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Client/typesense/Requests/updateDocument.swift
+++ b/Sources/FountainOps/Generated/Client/typesense/Requests/updateDocument.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public struct updateDocumentParameters: Codable {
+    public let collectionname: String
+    public let documentid: String
+    public var dirtyValues: DirtyValues?
+}
+
+public struct updateDocument: APIRequest {
+    public typealias Body = updateDocumentRequest
+    public typealias Response = updateDocumentResponse
+    public var method: String { "PATCH" }
+    public var parameters: updateDocumentParameters
+    public var path: String {
+        var path = "/collections/{collectionName}/documents/{documentId}"
+        var query: [String] = []
+        path = path.replacingOccurrences(of: "{collectionName}", with: String(parameters.collectionname))
+        path = path.replacingOccurrences(of: "{documentId}", with: String(parameters.documentid))
+        if let value = parameters.dirtyValues { query.append("dirty_values=\(value)") }
+        if !query.isEmpty { path += "?" + query.joined(separator: "&") }
+        return path
+    }
+    public var body: Body?
+
+    public init(parameters: updateDocumentParameters, body: Body? = nil) {
+        self.parameters = parameters
+        self.body = body
+    }
+}
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Handlers.swift
@@ -128,6 +128,15 @@ public struct Handlers {
         let data = try JSONEncoder().encode(collection)
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
+    public func updatecollection(_ request: HTTPRequest, body: CollectionUpdateSchema?) async throws -> HTTPResponse {
+        guard let schema = body else { return HTTPResponse(status: 400) }
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 2 else { return HTTPResponse(status: 404) }
+        let name = String(parts[1])
+        let updated = try await service.updateCollection(name: name, schema: schema)
+        let data = try JSONEncoder().encode(updated)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+    }
     public func deletecollection(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         let parts = request.path.split(separator: "/")
         guard parts.count >= 2 else { return HTTPResponse(status: 404) }
@@ -258,6 +267,17 @@ public struct Handlers {
         let collection = String(parts[1])
         let id = String(parts[3])
         let data = try await service.getDocument(collection: collection, id: id)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+    }
+    public func updatedocument(_ request: HTTPRequest, body: updateDocumentRequest?) async throws -> HTTPResponse {
+        guard let fields = body else { return HTTPResponse(status: 400) }
+        let parts = request.path.split(separator: "/")
+        guard parts.count >= 4 else { return HTTPResponse(status: 404) }
+        let collection = String(parts[1])
+        let id = String(parts[3])
+        let comps = URLComponents(string: request.path)
+        let dirty = comps?.queryItems?.first(where: { $0.name == "dirty_values" })?.value.flatMap { DirtyValues(rawValue: $0) }
+        let data = try await service.updateDocument(collection: collection, id: id, document: fields, dirtyValues: dirty)
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
     public func deletedocument(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {

--- a/Sources/FountainOps/Generated/Server/typesense/Models.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Models.swift
@@ -576,6 +576,10 @@ public typealias indexDocumentRequest = [String: String]
 
 public typealias updateDocumentsRequest = [String: String]
 
+public typealias updateDocumentRequest = [String: String]
+
+public typealias updateDocumentResponse = [String: String]
+
 public struct updateDocumentsResponse: Codable {
     public let num_updated: Int
 }

--- a/Sources/FountainOps/Generated/Server/typesense/Router.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/Router.swift
@@ -61,6 +61,9 @@ public struct Router {
         case ("GET", "/collections/{collectionName}"):
             let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
             return try await handlers.getcollection(request, body: body)
+        case ("PATCH", "/collections/{collectionName}"):
+            let body = try? JSONDecoder().decode(CollectionUpdateSchema.self, from: request.body)
+            return try await handlers.updatecollection(request, body: body)
         case ("DELETE", "/collections/{collectionName}"):
             let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
             return try await handlers.deletecollection(request, body: body)
@@ -115,6 +118,9 @@ public struct Router {
         case ("GET", "/collections/{collectionName}/documents/{documentId}"):
             let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
             return try await handlers.getdocument(request, body: body)
+        case ("PATCH", "/collections/{collectionName}/documents/{documentId}"):
+            let body = try? JSONDecoder().decode(updateDocumentRequest.self, from: request.body)
+            return try await handlers.updatedocument(request, body: body)
         case ("DELETE", "/collections/{collectionName}/documents/{documentId}"):
             let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
             return try await handlers.deletedocument(request, body: body)

--- a/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
+++ b/Sources/FountainOps/Generated/Server/typesense/TypesenseService.swift
@@ -46,6 +46,10 @@ public final actor TypesenseService {
         try await client.send(getCollection(parameters: .init(collectionname: name)))
     }
 
+    public func updateCollection(name: String, schema: CollectionUpdateSchema) async throws -> CollectionUpdateSchema {
+        try await client.send(updateCollection(parameters: .init(collectionname: name), body: schema))
+    }
+
     public func deleteCollection(name: String) async throws -> CollectionResponse {
         try await client.send(deleteCollection(parameters: .init(collectionname: name)))
     }
@@ -184,6 +188,10 @@ public final actor TypesenseService {
 
     public func getDocument(collection: String, id: String) async throws -> Data {
         try await client.send(getDocument(parameters: .init(collectionname: collection, documentid: id)))
+    }
+
+    public func updateDocument(collection: String, id: String, document: updateDocumentRequest, dirtyValues: DirtyValues? = nil) async throws -> Data {
+        try await client.send(updateDocument(parameters: .init(collectionname: collection, documentid: id, dirtyValues: dirtyValues), body: document))
     }
 
     public func deleteDocument(collection: String, id: String) async throws -> Data {

--- a/docs/proposals/typesense_server_full_api_plan.md
+++ b/docs/proposals/typesense_server_full_api_plan.md
@@ -40,6 +40,7 @@ The server currently supports the following endpoints (commit):
 - `GET /collections` – `55922a5`
 - `POST /collections` – `55922a5`
 - `GET /collections/{collectionName}` – `9d2ad4f`
+- `PATCH /collections/{collectionName}` – `0eafb92`
 - `DELETE /collections/{collectionName}` – `792ff5b`
 - `GET /collections/{collectionName}/documents/search` – `55922a5`
 - `GET /keys` – `792ff5b`
@@ -57,6 +58,7 @@ The server currently supports the following endpoints (commit):
 - `GET /collections/{collectionName}/documents/export` – `2905227`
 - `POST /collections/{collectionName}/documents/import` – `11a3a92`
 - `GET /collections/{collectionName}/documents/{documentId}` – `637dca5`
+- `PATCH /collections/{collectionName}/documents/{documentId}` – `0eafb92`
 - `DELETE /collections/{collectionName}/documents/{documentId}` – `9a12fff`
 - `GET /conversations/models` – `fefbea0`
 - `POST /conversations/models` – `f66f5f3`
@@ -94,7 +96,7 @@ The server currently supports the following endpoints (commit):
 - `PUT /stopwords/{setId}` – `636fde0`
 - `DELETE /stopwords/{setId}` – `636fde0`
 
-Last updated at `636fde0`.
+Last updated at `0eafb92`.
 
 
 ---


### PR DESCRIPTION
## Summary
- implement `updateCollection` and `updateDocument` client requests
- wire up new Typesense service methods, handlers and routes
- record implemented endpoints in API plan

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688a67e34e7c83258f3af61e2c24d82c