### PR TITLE
Implement FountainAiLauncher CLI

### DIFF
--- a/FountainAiLauncher/Package.swift
+++ b/FountainAiLauncher/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "FountainAiLauncher",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .executable(name: "FountainAiLauncher", targets: ["FountainAiLauncher"])
+    ],
+    targets: [
+        .executableTarget(
+            name: "FountainAiLauncher",
+            path: "Sources/FountainAiLauncher"
+        ),
+        .testTarget(
+            name: "FountainAiLauncherTests",
+            dependencies: ["FountainAiLauncher"],
+            path: "Tests/FountainAiLauncherTests"
+        )
+    ]
+)
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAiLauncher/Sources/FountainAiLauncher/Service.swift
+++ b/FountainAiLauncher/Sources/FountainAiLauncher/Service.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+public struct Service {
+    public let name: String
+    public let binaryPath: String
+    public let arguments: [String]
+    public let port: Int?
+    public let healthPath: String?
+
+    public init(name: String, binaryPath: String, arguments: [String] = [], port: Int? = nil, healthPath: String? = nil) {
+        self.name = name
+        self.binaryPath = binaryPath
+        self.arguments = arguments
+        self.port = port
+        self.healthPath = healthPath
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAiLauncher/Sources/FountainAiLauncher/Supervisor.swift
+++ b/FountainAiLauncher/Sources/FountainAiLauncher/Supervisor.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+public final class Supervisor {
+    private var processes: [String: Process] = [:]
+
+    public init() {}
+
+    @discardableResult
+    public func start(service: Service) throws -> Process {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: service.binaryPath)
+        process.arguments = service.arguments
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        processes[service.name] = process
+        print("Started \(service.name) (pid: \(process.processIdentifier))")
+        return process
+    }
+
+    public func start(services: [Service]) throws {
+        for service in services {
+            try start(service: service)
+        }
+    }
+
+    public func terminateAll() {
+        for (_, process) in processes {
+            if process.isRunning {
+                process.terminate()
+            }
+        }
+        processes.removeAll()
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAiLauncher/Sources/FountainAiLauncher/main.swift
+++ b/FountainAiLauncher/Sources/FountainAiLauncher/main.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+let services: [Service] = [
+    Service(name: "Awareness Service", binaryPath: "/usr/local/bin/awareness-service", port: 8001, healthPath: "/metrics"),
+    Service(name: "Bootstrap Service", binaryPath: "/usr/local/bin/bootstrap-service", port: 8002, healthPath: "/metrics"),
+    Service(name: "Planner Service", binaryPath: "/usr/local/bin/planner-service", port: 8003, healthPath: "/metrics"),
+    Service(name: "Function Caller", binaryPath: "/usr/local/bin/function-caller", port: 8004, healthPath: "/metrics"),
+    Service(name: "Persistence Service", binaryPath: "/usr/local/bin/persistence-service", port: 8005, healthPath: "/metrics"),
+    Service(name: "LLM Gateway", binaryPath: "/usr/local/bin/llm-gateway", port: 8006, healthPath: "/metrics"),
+    Service(name: "Gateway", binaryPath: "/usr/local/bin/fountain-gateway", port: 8010, healthPath: "/metrics"),
+    Service(name: "Typesense Proxy", binaryPath: "/usr/local/bin/typesense-proxy", port: 8100, healthPath: "/metrics")
+]
+
+let supervisor = Supervisor()
+
+do {
+    try supervisor.start(services: services)
+    dispatchMain()
+} catch {
+    let message = "Failed to launch services: \(error)\n"
+    if let data = message.data(using: .utf8) {
+        FileHandle.standardError.write(data)
+    }
+    exit(1)
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAiLauncher/Tests/FountainAiLauncherTests/FountainAiLauncherTests.swift
+++ b/FountainAiLauncher/Tests/FountainAiLauncherTests/FountainAiLauncherTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import FountainAiLauncher
+
+final class FountainAiLauncherTests: XCTestCase {
+    func testServiceLaunch() throws {
+        let supervisor = Supervisor()
+        let service = Service(name: "Echo", binaryPath: "/usr/bin/env", arguments: ["true"])
+        let process = try supervisor.start(service: service)
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add `FountainAiLauncher` package with executable and tests
- define `Service` model and `Supervisor` for launching services
- implement `main.swift` launching all FountainAI binaries
- basic test ensures processes launch correctly

## Testing
- `swift build`
- `swift test`
- `cd FountainAiLauncher && swift test`

------
https://chatgpt.com/codex/tasks/task_e_688b61caaacc8325a73c0c37b9a5e6d6