### PR TITLE
Implement PublishingFrontend scaffolding

### DIFF
--- a/Configuration/publishing.yml
+++ b/Configuration/publishing.yml
@@ -1,0 +1,4 @@
+port: 8085
+rootPath: ./Public
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAiLauncher/Sources/FountainAiLauncher/main.swift
+++ b/FountainAiLauncher/Sources/FountainAiLauncher/main.swift
@@ -8,6 +8,7 @@ let services: [Service] = [
     Service(name: "Persistence Service", binaryPath: "/usr/local/bin/persistence-service", port: 8005, healthPath: "/metrics"),
     Service(name: "LLM Gateway", binaryPath: "/usr/local/bin/llm-gateway", port: 8006, healthPath: "/metrics"),
     Service(name: "Gateway", binaryPath: "/usr/local/bin/fountain-gateway", port: 8010, healthPath: "/metrics"),
+    Service(name: "Publishing Frontend", binaryPath: "/usr/local/bin/publishing-frontend", port: 8085, healthPath: "/metrics"),
     Service(name: "Typesense Proxy", binaryPath: "/usr/local/bin/typesense-proxy", port: 8100, healthPath: "/metrics")
 ]
 

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,8 @@ let package = Package(
         .library(name: "FountainCore", targets: ["FountainCore"]),
         .library(name: "FountainCodex", targets: ["FountainCodex"]),
         .executable(name: "clientgen-service", targets: ["clientgen-service"]),
-        .executable(name: "gateway-server", targets: ["gateway-server"])
+        .executable(name: "gateway-server", targets: ["gateway-server"]),
+        .executable(name: "publishing-frontend", targets: ["publishing-frontend"])
     ],
     dependencies: [
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.0"),
@@ -38,11 +39,23 @@ let package = Package(
         ),
         .executableTarget(
             name: "gateway-server",
-            dependencies: ["FountainCodex"],
+            dependencies: ["FountainCodex", "PublishingFrontend"],
             path: "Sources/GatewayApp"
         ),
+        .target(
+            name: "PublishingFrontend",
+            dependencies: ["FountainCodex", "Yams"],
+            path: "Sources/PublishingFrontend"
+        ),
+        .executableTarget(
+            name: "publishing-frontend",
+            dependencies: ["PublishingFrontend"],
+            path: "Sources/publishing-frontend"
+        ),
         .testTarget(name: "FountainCoreTests", dependencies: ["FountainCore"], path: "Tests/FountainCoreTests"),
-        .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainCodex"], path: "Tests/ClientGeneratorTests")
+        .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainCodex"], path: "Tests/ClientGeneratorTests"),
+        .testTarget(name: "PublishingFrontendTests", dependencies: ["PublishingFrontend"], path: "Tests/PublishingFrontendTests"),
+        .testTarget(name: "DNSTests", dependencies: ["PublishingFrontend"], path: "Tests/DNSTests")
     ]
 )
 

--- a/Sources/GatewayApp/PublishingFrontendPlugin.swift
+++ b/Sources/GatewayApp/PublishingFrontendPlugin.swift
@@ -1,0 +1,21 @@
+import Foundation
+import FountainCodex
+
+public struct PublishingFrontendPlugin: GatewayPlugin {
+    let rootPath: String
+
+    public init(rootPath: String = "./Public") {
+        self.rootPath = rootPath
+    }
+
+    public func respond(_ response: HTTPResponse, for request: HTTPRequest) async throws -> HTTPResponse {
+        guard request.method == "GET" else { return response }
+        let path = rootPath + (request.path == "/" ? "/index.html" : request.path)
+        if let data = FileManager.default.contents(atPath: path) {
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/html"], body: data)
+        }
+        return response
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/GatewayApp/main.swift
+++ b/Sources/GatewayApp/main.swift
@@ -1,8 +1,9 @@
 import Foundation
-
 import Dispatch
+import PublishingFrontend
 
-let server = GatewayServer(plugins: [LoggingPlugin()])
+let publishingConfig = try? loadPublishingConfig()
+let server = GatewayServer(plugins: [LoggingPlugin(), PublishingFrontendPlugin(rootPath: publishingConfig?.rootPath ?? "./Public")])
 Task { @MainActor in
     try await server.start(port: 8080)
 }

--- a/Sources/PublishingFrontend/DNSProvider.swift
+++ b/Sources/PublishingFrontend/DNSProvider.swift
@@ -1,0 +1,36 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public protocol DNSProvider {
+    func listZones() async throws -> [String]
+    func createRecord(zone: String, name: String, type: String, value: String) async throws
+    func updateRecord(id: String, value: String) async throws
+    func deleteRecord(id: String) async throws
+}
+
+public struct HetznerDNSClient: DNSProvider {
+    let token: String
+    let session: URLSession
+
+    public init(token: String, session: URLSession = .shared) {
+        self.token = token
+        self.session = session
+    }
+
+    public func listZones() async throws -> [String] { [] }
+    public func createRecord(zone: String, name: String, type: String, value: String) async throws {}
+    public func updateRecord(id: String, value: String) async throws {}
+    public func deleteRecord(id: String) async throws {}
+}
+
+public struct Route53Client: DNSProvider {
+    public init() {}
+    public func listZones() async throws -> [String] { throw NSError(domain: "Route53", code: 501) }
+    public func createRecord(zone: String, name: String, type: String, value: String) async throws { throw NSError(domain: "Route53", code: 501) }
+    public func updateRecord(id: String, value: String) async throws { throw NSError(domain: "Route53", code: 501) }
+    public func deleteRecord(id: String) async throws { throw NSError(domain: "Route53", code: 501) }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/PublishingFrontend.swift
+++ b/Sources/PublishingFrontend/PublishingFrontend.swift
@@ -1,0 +1,55 @@
+import Foundation
+import NIO
+import NIOHTTP1
+import FountainCodex
+import Yams
+
+public struct PublishingConfig: Codable {
+    public var port: Int
+    public var rootPath: String
+
+    public init(port: Int = 8085, rootPath: String = "./Public") {
+        self.port = port
+        self.rootPath = rootPath
+    }
+}
+
+public final class PublishingFrontend {
+    private let server: NIOHTTPServer
+    private let group: EventLoopGroup
+    private let config: PublishingConfig
+
+    public init(config: PublishingConfig) {
+        self.config = config
+        self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let kernel = HTTPKernel { [config] req in
+            guard req.method == "GET" else { return HTTPResponse(status: 405) }
+            let path = config.rootPath + (req.path == "/" ? "/index.html" : req.path)
+            if let data = FileManager.default.contents(atPath: path) {
+                return HTTPResponse(status: 200, headers: ["Content-Type": "text/html"], body: data)
+            }
+            return HTTPResponse(status: 404)
+        }
+        self.server = NIOHTTPServer(kernel: kernel, group: group)
+    }
+
+    @MainActor
+    public func start() async throws {
+        _ = try await server.start(port: config.port)
+    }
+
+    @MainActor
+    public func stop() async throws {
+        try await server.stop()
+    }
+}
+
+public func loadPublishingConfig() throws -> PublishingConfig {
+    let url = URL(fileURLWithPath: "Configuration/publishing.yml")
+    let string = try String(contentsOf: url)
+    let yaml = try Yams.load(yaml: string) as? [String: Any] ?? [:]
+    let data = try JSONSerialization.data(withJSONObject: yaml)
+    return try JSONDecoder().decode(PublishingConfig.self, from: data)
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/publishing-frontend/main.swift
+++ b/Sources/publishing-frontend/main.swift
@@ -1,0 +1,13 @@
+import Foundation
+import Dispatch
+import PublishingFrontend
+
+let config = try loadPublishingConfig()
+let app = PublishingFrontend(config: config)
+Task { @MainActor in
+    try await app.start()
+}
+
+dispatchMain()
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/DNSTests/DNSClientTests.swift
+++ b/Tests/DNSTests/DNSClientTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import PublishingFrontend
+
+final class DNSClientTests: XCTestCase {
+    func testRoute53Stub() async throws {
+        let client = Route53Client()
+        do {
+            _ = try await client.listZones()
+            XCTFail("expected failure")
+        } catch {
+            // expected not implemented
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/PublishingFrontendTests/PublishingFrontendTests.swift
+++ b/Tests/PublishingFrontendTests/PublishingFrontendTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import PublishingFrontend
+
+final class PublishingFrontendTests: XCTestCase {
+    @MainActor
+    func testServerServesIndex() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("public")
+        try? FileManager.default.removeItem(at: dir)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let indexURL = dir.appendingPathComponent("index.html")
+        try "hello".write(to: indexURL, atomically: true, encoding: .utf8)
+        var cfg = PublishingConfig()
+        cfg.rootPath = dir.path
+        cfg.port = 9099
+        let frontend = PublishingFrontend(config: cfg)
+        try await frontend.start()
+        let url = URL(string: "http://127.0.0.1:\(cfg.port)/")!
+        let data = try Data(contentsOf: url)
+        XCTAssertEqual(String(data: data, encoding: .utf8), "hello")
+        try await frontend.stop()
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -1,0 +1,13 @@
+# Environment Variables
+
+The publishing service and DNS clients rely on the following variables:
+
+| Variable | Default | Purpose |
+|---------|---------|---------|
+| `DNS_PROVIDER` | `hetzner` | Selects the DNS implementation to use. |
+| `HETZNER_API_TOKEN` | _(none)_ | API token for Hetzner DNS requests. |
+| `ROUTE53_ACCESS_KEY` | _(none)_ | AWS key for Route 53 (not yet used). |
+| `ROUTE53_SECRET_KEY` | _(none)_ | AWS secret key for Route 53. |
+
+---
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- scaffold `PublishingFrontend` target for static hosting
- create plugin for gateway integration
- expose publishing config and environment variables
- stub DNS provider implementations
- integrate new service in `FountainAiLauncher`
- add basic tests

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688c559d2d808325a7870d947678f128