### PR TITLE
Fix tests for HetznerDNSClient

### DIFF
--- a/Sources/PublishingFrontend/HetznerDNSClient/APIClient.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/APIClient.swift
@@ -50,4 +50,5 @@ public extension APIClient {
         self.init(baseURL: baseURL, session: session, defaultHeaders: ["Authorization": "Bearer \(bearerToken)"])
     }
 }
-\n// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/HetznerDNSClient/Requests/DeleteRecord.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Requests/DeleteRecord.swift
@@ -23,4 +23,5 @@ public struct DeleteRecord: APIRequest {
         self.body = body
     }
 }
-\n// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/DNSTests/HetznerDNSClientTests.swift
+++ b/Tests/DNSTests/HetznerDNSClientTests.swift
@@ -24,7 +24,7 @@ final class HetznerDNSClientTests: XCTestCase {
         let client = HetznerDNSClient(token: "t", session: session)
         try await client.createRecord(zone: "z", name: "www", type: "A", value: "1.2.3.4")
         XCTAssertEqual(session.lastRequest?.httpMethod, "POST")
-        XCTAssertEqual(session.lastRequest?.url?.path, "/records")
+        XCTAssertEqual(session.lastRequest?.url?.path, "/api/v1/records")
         XCTAssertEqual(session.lastRequest?.value(forHTTPHeaderField: "Auth-API-Token"), "t")
     }
 
@@ -33,7 +33,7 @@ final class HetznerDNSClientTests: XCTestCase {
         let client = HetznerDNSClient(token: "x", session: session)
         try await client.deleteRecord(id: "123")
         XCTAssertEqual(session.lastRequest?.httpMethod, "DELETE")
-        XCTAssertEqual(session.lastRequest?.url?.path, "/records/123")
+        XCTAssertEqual(session.lastRequest?.url?.path, "/api/v1/records/123")
     }
 
     func testUpdateRecordRequest() async throws {
@@ -42,7 +42,7 @@ final class HetznerDNSClientTests: XCTestCase {
         let session = MockSession(data: data)
         let client = HetznerDNSClient(token: "t", session: session)
         try await client.updateRecord(id: "1", zone: "z", name: "www", type: "A", value: "2.2.2.2")
-        XCTAssertEqual(session.lastRequest?.url?.path, "/records/1")
+        XCTAssertEqual(session.lastRequest?.url?.path, "/api/v1/records/1")
         XCTAssertEqual(session.lastRequest?.httpMethod, "PUT")
     }
 }


### PR DESCRIPTION
## Summary
- fix newline comment markers in `APIClient` and `DeleteRecord` models
- update `HetznerDNSClientTests` to match `/api/v1` base path
- ensure `swift test` succeeds

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_688caf7688d4832597eeaa605adbae12