### PR TITLE
Add inline docs and integration tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31063   28253     9.05%   13773   12229    11.21%   97925   88227     9.90%
+TOTAL                                          31054   28461     8.35%   13766   12408     9.86%   97890   88577     9.51%
 ```
 
-The repository contains **97,925** executable lines, with **9,698** lines covered (approx. **9.90%** line coverage).
+The repository contains **97,890** executable lines, with **8,857** lines covered (approx. **9.51%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                            676     481    28.85%     234     142    39.32%    1543     964    37.52%
+TOTAL                                            543     421    22.47%     155     110    29.03%    1224     815    33.42%
 ```
 
-Within repository sources there are **1,543** lines, with **579** covered, giving **37.52%** line coverage.
+Within repository sources there are **1,224** lines, with **815** covered, giving **33.42%** line coverage.
 
 ## Action Plan
 

--- a/FountainAiLauncher/Sources/FountainAiLauncher/Service.swift
+++ b/FountainAiLauncher/Sources/FountainAiLauncher/Service.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Describes an executable service managed by ``Supervisor``.
 public struct Service {
     public let name: String
     public let binaryPath: String
@@ -7,6 +8,13 @@ public struct Service {
     public let port: Int?
     public let healthPath: String?
 
+    /// Creates a new service descriptor.
+    /// - Parameters:
+    ///   - name: Human readable identifier.
+    ///   - binaryPath: Absolute path to the executable.
+    ///   - arguments: Arguments passed on launch.
+    ///   - port: Optional port for health checks.
+    ///   - healthPath: Health check endpoint path.
     public init(name: String, binaryPath: String, arguments: [String] = [], port: Int? = nil, healthPath: String? = nil) {
         self.name = name
         self.binaryPath = binaryPath

--- a/FountainAiLauncher/Sources/FountainAiLauncher/Supervisor.swift
+++ b/FountainAiLauncher/Sources/FountainAiLauncher/Supervisor.swift
@@ -1,11 +1,15 @@
 import Foundation
 
+/// Manages child service processes and keeps them alive.
 public final class Supervisor {
     private var processes: [String: Process] = [:]
 
     public init() {}
 
     @discardableResult
+    /// Launches a single service process.
+    /// - Parameter service: Descriptor for the binary to execute.
+    /// - Returns: The running `Process` instance.
     public func start(service: Service) throws -> Process {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: service.binaryPath)
@@ -18,12 +22,14 @@ public final class Supervisor {
         return process
     }
 
+    /// Starts a collection of services sequentially.
     public func start(services: [Service]) throws {
         for service in services {
             try start(service: service)
         }
     }
 
+    /// Terminates all running services.
     public func terminateAll() {
         for (_, process) in processes {
             if process.isRunning {

--- a/Sources/FountainCodex/IntegrationRuntime/HTTPKernel.swift
+++ b/Sources/FountainCodex/IntegrationRuntime/HTTPKernel.swift
@@ -1,12 +1,18 @@
 import Foundation
 
+/// Minimal async HTTP router used by lightweight servers.
 public struct HTTPKernel: @unchecked Sendable {
+    /// Closure that transforms a ``HTTPRequest`` into an ``HTTPResponse``.
     let router: (HTTPRequest) async throws -> HTTPResponse
 
+    /// Creates a new kernel with the given routing closure.
+    /// - Parameter route: Handler responsible for processing requests.
     public init(route: @escaping (HTTPRequest) async throws -> HTTPResponse) {
         self.router = route
     }
 
+    /// Passes a request through the router and returns the response.
+    /// - Parameter request: Incoming request object.
     public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
         try await router(request)
     }

--- a/Sources/GatewayApp/GatewayServer.swift
+++ b/Sources/GatewayApp/GatewayServer.swift
@@ -3,6 +3,7 @@ import NIO
 import NIOHTTP1
 import FountainCodex
 
+/// HTTP gateway server that composes plugins for request handling.
 @MainActor
 public final class GatewayServer {
     private let server: NIOHTTPServer
@@ -10,6 +11,10 @@ public final class GatewayServer {
     private let group: EventLoopGroup
     private let plugins: [GatewayPlugin]
 
+    /// Creates a new gateway server instance.
+    /// - Parameters:
+    ///   - manager: Certificate renewal manager.
+    ///   - plugins: Plugins applied before and after routing.
     public init(manager: CertificateManager = CertificateManager(),
                 plugins: [GatewayPlugin] = []) {
         self.manager = manager
@@ -40,11 +45,14 @@ public final class GatewayServer {
         self.server = NIOHTTPServer(kernel: kernel, group: group)
     }
 
+    /// Starts the gateway on the given port.
+    /// - Parameter port: TCP port to bind.
     public func start(port: Int = 8080) async throws {
         manager.start()
         _ = try await server.start(port: port)
     }
 
+    /// Stops the server and terminates certificate renewal.
     public func stop() async throws {
         manager.stop()
         try await server.stop()

--- a/Sources/PublishingFrontend/PublishingFrontend.swift
+++ b/Sources/PublishingFrontend/PublishingFrontend.swift
@@ -4,21 +4,29 @@ import NIOHTTP1
 import FountainCodex
 import Yams
 
+/// Configuration for the ``PublishingFrontend`` server.
 public struct PublishingConfig: Codable {
     public var port: Int
     public var rootPath: String
 
+    /// Creates a new configuration with optional port and root path.
+    /// - Parameters:
+    ///   - port: Port to bind the HTTP server to.
+    ///   - rootPath: Directory containing static files to serve.
     public init(port: Int = 8085, rootPath: String = "./Public") {
         self.port = port
         self.rootPath = rootPath
     }
 }
 
+/// Lightweight HTTP server for serving generated documentation.
 public final class PublishingFrontend {
     private let server: NIOHTTPServer
     private let group: EventLoopGroup
     private let config: PublishingConfig
 
+    /// Creates a new server instance with the given configuration.
+    /// - Parameter config: Runtime configuration options.
     public init(config: PublishingConfig) {
         self.config = config
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -34,16 +42,19 @@ public final class PublishingFrontend {
     }
 
     @MainActor
+    /// Starts the HTTP server on the configured port.
     public func start() async throws {
         _ = try await server.start(port: config.port)
     }
 
     @MainActor
+    /// Stops the HTTP server and releases all resources.
     public func stop() async throws {
         try await server.stop()
     }
 }
 
+/// Loads the publishing configuration from `Configuration/publishing.yml`.
 public func loadPublishingConfig() throws -> PublishingConfig {
     let url = URL(fileURLWithPath: "Configuration/publishing.yml")
     let string = try String(contentsOf: url)

--- a/Tests/IntegrationRuntimeTests/HTTPKernelTests.swift
+++ b/Tests/IntegrationRuntimeTests/HTTPKernelTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import FountainCodex
+
+final class HTTPKernelTests: XCTestCase {
+    func testKernelRoutesRequest() async throws {
+        let kernel = HTTPKernel { req in
+            if req.path == "/hello" {
+                return HTTPResponse(status: 200, body: Data("world".utf8))
+            }
+            return HTTPResponse(status: 404)
+        }
+        let request = HTTPRequest(method: "GET", path: "/hello")
+        let response = try await kernel.handle(request)
+        XCTAssertEqual(response.status, 200)
+        XCTAssertEqual(String(data: response.body, encoding: .utf8), "world")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/IntegrationRuntimeTests/LoggingPluginTests.swift
+++ b/Tests/IntegrationRuntimeTests/LoggingPluginTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import GatewayApp
+
+final class LoggingPluginTests: XCTestCase {
+    func testLoggingPluginPassThrough() async throws {
+        let plugin = LoggingPlugin()
+        let req = HTTPRequest(method: "GET", path: "/")
+        let prepared = try await plugin.prepare(req)
+        XCTAssertEqual(prepared.path, req.path)
+        let response = HTTPResponse(status: 200)
+        let resp = try await plugin.respond(response, for: req)
+        XCTAssertEqual(resp.status, response.status)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,13 @@
-# placeholder...
+# Developer Documentation
 
-for index of documentation based on inline code comments enforced by root agent.md
+This directory collects generated documentation derived from inline `///` comments.
+As modules gain documentation, brief summaries are added here.
+
+## Current Highlights
+- **PublishingFrontend** – lightweight static HTTP server for serving the `/Public` directory.
+- **HTTPKernel** – simple asynchronous router used by the gateway and publishing frontend.
+
+Documentation coverage will expand alongside test coverage.
+
+---
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- document PublishingFrontend, HTTPKernel, GatewayServer and Supervisor
- add integration tests for HTTPKernel and LoggingPlugin
- track documentation progress in `docs/README.md`
- update coverage stats in `COVERAGE.md`

## Testing
- `swift test -c release --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688cd4353ebc8325ae59ea08b6137009