### PR TITLE
Improve Hetzner client docs and tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -20,6 +20,8 @@ TOTAL                                            543     421    22.47%     155  
 
 Within repository sources there are **1,224** lines, with **815** covered, giving **33.42%** line coverage.
 
+Additional tests for `HetznerDNSClient` raise coverage slightly by exercising request headers and query generation.
+
 ## Action Plan
 
 1. **Increase unit tests** for modules with zero coverage such as the API request structs in `PublishingFrontend` and parsing utilities in `FountainCodex`.

--- a/Sources/PublishingFrontend/HetznerDNSClient/APIClient.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/APIClient.swift
@@ -24,6 +24,9 @@ public struct APIClient {
         self.defaultHeaders = defaultHeaders
     }
 
+    /// Executes an ``APIRequest`` and decodes the server response.
+    /// - Parameter request: The request to perform.
+    /// - Returns: The decoded response value for ``R.Response``.
     public func send<R: APIRequest>(_ request: R) async throws -> R.Response {
         var urlRequest = URLRequest(url: baseURL.appendingPathComponent(request.path))
         urlRequest.httpMethod = request.method

--- a/Sources/PublishingFrontend/HetznerDNSClient/Requests/DeleteRecord.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Requests/DeleteRecord.swift
@@ -1,9 +1,11 @@
 import Foundation
 
+/// Identifies the DNS record to remove.
 public struct DeleteRecordParameters: Codable {
     public let recordid: String
 }
 
+/// Request wrapper for deleting a specific DNS record.
 public struct DeleteRecord: APIRequest {
     public typealias Body = NoBody
     public typealias Response = NoBody

--- a/Sources/PublishingFrontend/HetznerDNSClient/Requests/ListZones.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Requests/ListZones.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+/// Parameters for filtering the list zones endpoint.
+/// When all fields are `nil`, the API returns every zone.
 public struct ListZonesParameters: Codable {
     public var name: String?
     public var searchName: String?
@@ -7,6 +9,8 @@ public struct ListZonesParameters: Codable {
     public var perPage: Int?
 }
 
+/// Request for fetching DNS zones from the Hetzner API.
+/// Builds a query string based on the provided parameters.
 public struct ListZones: APIRequest {
     public typealias Body = NoBody
     public typealias Response = ZonesResponse
@@ -29,3 +33,4 @@ public struct ListZones: APIRequest {
         self.body = body
     }
 }
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/DNSTests/HetznerDNSClientTests.swift
+++ b/Tests/DNSTests/HetznerDNSClientTests.swift
@@ -45,6 +45,21 @@ final class HetznerDNSClientTests: XCTestCase {
         XCTAssertEqual(session.lastRequest?.url?.path, "/api/v1/records/1")
         XCTAssertEqual(session.lastRequest?.httpMethod, "PUT")
     }
+
+    func testCreateRecordSetsContentTypeHeader() async throws {
+        let response = RecordResponse(record: Record(created: "", id: "1", modified: "", name: "www", ttl: 60, type: "A", value: "1.1.1.1", zone_id: "z"))
+        let data = try JSONEncoder().encode(response)
+        let session = MockSession(data: data)
+        let client = HetznerDNSClient(token: "t", session: session)
+        try await client.createRecord(zone: "z", name: "www", type: "A", value: "1.1.1.1")
+        XCTAssertEqual(session.lastRequest?.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+
+    func testListZonesPathBuilder() {
+        let params = ListZonesParameters(name: "foo", searchName: "bar", page: 1, perPage: 5)
+        let req = ListZones(parameters: params)
+        XCTAssertEqual(req.path, "/zones?name=foo&search_name=bar&page=1&per_page=5")
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ As modules gain documentation, brief summaries are added here.
 ## Current Highlights
 - **PublishingFrontend** – lightweight static HTTP server for serving the `/Public` directory.
 - **HTTPKernel** – simple asynchronous router used by the gateway and publishing frontend.
+- **HetznerDNSClient** – Swift wrapper for the Hetzner DNS API with typed requests.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- document Hetzner DNS request structs and API client
- extend HetznerDNSClientTests with header and path checks
- record coverage progress
- mention new documentation in developer docs

## Testing
- `swift test -c release --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688cd800fc488325a2b13d8a98e05b04