### PR TITLE
Improve docs and tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -20,7 +20,7 @@ TOTAL                                            543     421    22.47%     155  
 
 Within repository sources there are **1,224** lines, with **815** covered, giving **33.42%** line coverage.
 
-Additional tests for `HetznerDNSClient` raise coverage slightly by exercising request headers and query generation.
+Additional tests for `HetznerDNSClient` and `PublishingFrontend` raise coverage slightly by exercising request headers, query generation, and configuration parsing.
 
 ## Action Plan
 

--- a/Sources/FountainCodex/IntegrationRuntime/AsyncHTTPClientDriver.swift
+++ b/Sources/FountainCodex/IntegrationRuntime/AsyncHTTPClientDriver.swift
@@ -3,12 +3,21 @@ import NIOCore
 import NIOHTTP1
 
 public final class AsyncHTTPClientDriver: HTTPClientProtocol, @unchecked Sendable {
+    /// Underlying async HTTP client used for requests.
     let client: HTTPClient
 
+    /// Creates a new driver wrapping ``HTTPClient``.
+    /// - Parameter eventLoopGroupProvider: Event loop provider for the client.
     public init(eventLoopGroupProvider: HTTPClient.EventLoopGroupProvider = .singleton) {
         self.client = HTTPClient(eventLoopGroupProvider: eventLoopGroupProvider)
     }
 
+    /// Executes an HTTP request and returns the response payload and headers.
+    /// - Parameters:
+    ///   - method: HTTP verb to use when contacting the server.
+    ///   - url: Absolute URL string of the resource.
+    ///   - headers: Request headers to send.
+    ///   - body: Optional request body buffer.
     public func execute(method: HTTPMethod, url: String, headers: HTTPHeaders = HTTPHeaders(), body: ByteBuffer?) async throws -> (ByteBuffer, HTTPHeaders) {
         var request = HTTPClientRequest(url: url)
         request.method = method
@@ -21,6 +30,7 @@ public final class AsyncHTTPClientDriver: HTTPClientProtocol, @unchecked Sendabl
         return (bytes, response.headers)
     }
 
+    /// Gracefully shuts down the underlying client.
     public func shutdown() async throws {
         try await client.shutdown()
     }

--- a/Sources/FountainCodex/IntegrationRuntime/NIOHTTPServer.swift
+++ b/Sources/FountainCodex/IntegrationRuntime/NIOHTTPServer.swift
@@ -12,6 +12,9 @@ public final class NIOHTTPServer: @unchecked Sendable {
         self.group = group
     }
 
+    /// Starts the HTTP server.
+    /// - Parameter port: Port to bind the server on.
+    /// - Returns: The actual bound port.
     @discardableResult
     public func start(port: Int) async throws -> Int {
         let bootstrap = ServerBootstrap(group: group)
@@ -26,6 +29,7 @@ public final class NIOHTTPServer: @unchecked Sendable {
         return self.channel?.localAddress?.port ?? port
     }
 
+    /// Stops the server and releases allocated resources.
     public func stop() async throws {
         try await channel?.close().get()
         try await group.shutdownGracefully()

--- a/Sources/FountainCodex/IntegrationRuntime/URLSessionHTTPClient.swift
+++ b/Sources/FountainCodex/IntegrationRuntime/URLSessionHTTPClient.swift
@@ -5,13 +5,24 @@ import FoundationNetworking
 import NIOCore
 import NIOHTTP1
 
+/// Simple HTTP client backed by ``URLSession``.
 public struct URLSessionHTTPClient: HTTPClientProtocol {
+    /// ``URLSession`` instance used to perform requests.
     let session: URLSession
 
+    /// Creates a new client with the provided session.
+    /// - Parameter session: The session to send requests with.
     public init(session: URLSession = .shared) {
         self.session = session
     }
 
+    /// Performs an HTTP request using `URLSession`.
+    /// - Parameters:
+    ///   - method: HTTP method to execute.
+    ///   - url: Target URL string.
+    ///   - headers: Headers for the request.
+    ///   - body: Optional request payload.
+    /// - Returns: A tuple of response body and headers.
     public func execute(method: HTTPMethod, url: String, headers: HTTPHeaders = HTTPHeaders(), body: ByteBuffer?) async throws -> (ByteBuffer, HTTPHeaders) {
         var request = URLRequest(url: URL(string: url)!)
         request.httpMethod = method.rawValue

--- a/Sources/PublishingFrontend/PublishingFrontend.swift
+++ b/Sources/PublishingFrontend/PublishingFrontend.swift
@@ -55,6 +55,7 @@ public final class PublishingFrontend {
 }
 
 /// Loads the publishing configuration from `Configuration/publishing.yml`.
+/// - Returns: Parsed ``PublishingConfig`` instance.
 public func loadPublishingConfig() throws -> PublishingConfig {
     let url = URL(fileURLWithPath: "Configuration/publishing.yml")
     let string = try String(contentsOf: url)

--- a/Tests/PublishingFrontendTests/PublishingFrontendTests.swift
+++ b/Tests/PublishingFrontendTests/PublishingFrontendTests.swift
@@ -19,6 +19,25 @@ final class PublishingFrontendTests: XCTestCase {
         XCTAssertEqual(String(data: data, encoding: .utf8), "hello")
         try await frontend.stop()
     }
+
+    func testLoadPublishingConfigParsesYaml() throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("cfg", isDirectory: true)
+        let configDir = dir.appendingPathComponent("Configuration", isDirectory: true)
+        try? FileManager.default.removeItem(at: dir)
+        try FileManager.default.createDirectory(at: configDir, withIntermediateDirectories: true)
+        let fileURL = configDir.appendingPathComponent("publishing.yml")
+        let yaml = """
+        port: 1234
+        rootPath: /tmp/Public
+        """
+        try yaml.write(to: fileURL, atomically: true, encoding: .utf8)
+        let cwd = FileManager.default.currentDirectoryPath
+        defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+        FileManager.default.changeCurrentDirectoryPath(dir.path)
+        let config = try loadPublishingConfig()
+        XCTAssertEqual(config.port, 1234)
+        XCTAssertEqual(config.rootPath, "/tmp/Public")
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@ As modules gain documentation, brief summaries are added here.
 - **PublishingFrontend** – lightweight static HTTP server for serving the `/Public` directory.
 - **HTTPKernel** – simple asynchronous router used by the gateway and publishing frontend.
 - **HetznerDNSClient** – Swift wrapper for the Hetzner DNS API with typed requests.
+- **AsyncHTTPClientDriver** and **URLSessionHTTPClient** – documented HTTP clients powering network requests.
+- **NIOHTTPServer** – documented server adapter built on SwiftNIO.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- document HTTP client and server utilities
- expand publishing frontend tests for config loading
- note coverage progress

## Testing
- `swift test -c release --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688cdcb676d4832593bf84e64af14e1d