### PR TITLE
Document code and extend DNS tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31054   28461     8.35%   13766  12408     9.86%   97890   88577     9.51%
+TOTAL                                          31192   28328     9.18%   13839 12335    10.87%   98196   88284    10.09%
 ```
 
-The repository contains **97,890** executable lines, with **8,857** lines covered (approx. **9.51%** line coverage).
+The repository contains **98,196** executable lines, with **9,912** lines covered (approx. **10.09%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                            543     421    22.47%     155   110    29.03%    1224     815    33.42%
+TOTAL                                            416     794    34.38%     0   0    0.00%    1210     794    34.38%
 ```
 
-Within repository sources there are **1,224** lines, with **815** covered, giving **33.42%** line coverage.
+Within repository sources there are **1,210** lines, with **416** covered, giving **34.38%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules.
 

--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,8 @@ let package = Package(
         .testTarget(name: "FountainCoreTests", dependencies: ["FountainCore"], path: "Tests/FountainCoreTests"),
         .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainCodex"], path: "Tests/ClientGeneratorTests"),
         .testTarget(name: "PublishingFrontendTests", dependencies: ["PublishingFrontend"], path: "Tests/PublishingFrontendTests"),
-        .testTarget(name: "DNSTests", dependencies: ["PublishingFrontend"], path: "Tests/DNSTests")
+        .testTarget(name: "DNSTests", dependencies: ["PublishingFrontend"], path: "Tests/DNSTests"),
+        .testTarget(name: "IntegrationRuntimeTests", dependencies: ["gateway-server", "FountainCodex"], path: "Tests/IntegrationRuntimeTests")
     ]
 )
 

--- a/Sources/FountainCore/Models.swift
+++ b/Sources/FountainCore/Models.swift
@@ -1,5 +1,6 @@
 // Models for Sample API
 
+/// Simple task model used in unit tests.
 public struct Todo: Codable {
     public let id: Int
     public let name: String

--- a/Sources/GatewayApp/PublishingFrontendPlugin.swift
+++ b/Sources/GatewayApp/PublishingFrontendPlugin.swift
@@ -1,13 +1,16 @@
 import Foundation
 import FountainCodex
 
+/// Serves static files from disk when requests are not handled elsewhere.
 public struct PublishingFrontendPlugin: GatewayPlugin {
     let rootPath: String
 
+    /// Creates a new plugin pointing at the given directory.
     public init(rootPath: String = "./Public") {
         self.rootPath = rootPath
     }
 
+    /// Attempts to serve a file for GET requests that resulted in `404`.
     public func respond(_ response: HTTPResponse, for request: HTTPRequest) async throws -> HTTPResponse {
         guard request.method == "GET" else { return response }
         let path = rootPath + (request.path == "/" ? "/index.html" : request.path)

--- a/Sources/PublishingFrontend/DNSProvider.swift
+++ b/Sources/PublishingFrontend/DNSProvider.swift
@@ -3,16 +3,23 @@ import Foundation
 import FoundationNetworking
 #endif
 
+/// Abstraction over DNS providers used for certificate challenges and routing.
 public protocol DNSProvider {
+    /// Lists all zone identifiers available to the account.
     func listZones() async throws -> [String]
+    /// Creates a new DNS record within the given zone.
     func createRecord(zone: String, name: String, type: String, value: String) async throws
+    /// Updates an existing record with a new value.
     func updateRecord(id: String, zone: String, name: String, type: String, value: String) async throws
+    /// Deletes a DNS record by identifier.
     func deleteRecord(id: String) async throws
 }
 
+/// Concrete ``DNSProvider`` that talks to the Hetzner DNS API.
 public struct HetznerDNSClient: DNSProvider {
     let api: APIClient
 
+    /// Creates a new client with the given API token and session.
     public init(token: String, session: HTTPSession = URLSession.shared) {
         self.api = APIClient(
             baseURL: URL(string: "https://dns.hetzner.com/api/v1")!,
@@ -21,33 +28,43 @@ public struct HetznerDNSClient: DNSProvider {
         )
     }
 
+    /// Returns all zone identifiers the token has access to.
     public func listZones() async throws -> [String] {
         let response = try await api.send(ListZones(parameters: ListZonesParameters()))
         return response.zones.map { $0.id }
     }
 
+    /// Adds an ``A`` or ``TXT`` record to the zone.
     public func createRecord(zone: String, name: String, type: String, value: String) async throws {
         let body = RecordCreate(name: name, ttl: 60, type: type, value: value, zone_id: zone)
         _ = try await api.send(CreateRecord(body: body))
     }
 
+    /// Updates a DNS record's value.
     public func updateRecord(id: String, zone: String, name: String, type: String, value: String) async throws {
         let params = UpdateRecordParameters(recordid: id)
         let body = RecordCreate(name: name, ttl: 60, type: type, value: value, zone_id: zone)
         _ = try await api.send(UpdateRecord(parameters: params, body: body))
     }
 
+    /// Removes a DNS record from the zone.
     public func deleteRecord(id: String) async throws {
         let params = DeleteRecordParameters(recordid: id)
         _ = try await api.send(DeleteRecord(parameters: params))
     }
 }
 
+/// Stub implementation used during development.
 public struct Route53Client: DNSProvider {
+    /// Creates a new client instance.
     public init() {}
+    /// :nodoc: Currently unimplemented.
     public func listZones() async throws -> [String] { throw NSError(domain: "Route53", code: 501) }
+    /// :nodoc: Currently unimplemented.
     public func createRecord(zone: String, name: String, type: String, value: String) async throws { throw NSError(domain: "Route53", code: 501) }
+    /// :nodoc: Currently unimplemented.
     public func updateRecord(id: String, zone: String, name: String, type: String, value: String) async throws { throw NSError(domain: "Route53", code: 501) }
+    /// :nodoc: Currently unimplemented.
     public func deleteRecord(id: String) async throws { throw NSError(domain: "Route53", code: 501) }
 }
 

--- a/Tests/DNSTests/DNSClientTests.swift
+++ b/Tests/DNSTests/DNSClientTests.swift
@@ -11,6 +11,36 @@ final class DNSClientTests: XCTestCase {
             // expected not implemented
         }
     }
+
+    func testRoute53CreateRecordStub() async throws {
+        let client = Route53Client()
+        do {
+            try await client.createRecord(zone: "z", name: "n", type: "A", value: "v")
+            XCTFail("expected failure")
+        } catch {
+            // expected
+        }
+    }
+
+    func testRoute53UpdateRecordStub() async throws {
+        let client = Route53Client()
+        do {
+            try await client.updateRecord(id: "1", zone: "z", name: "n", type: "A", value: "v")
+            XCTFail("expected failure")
+        } catch {
+            // expected
+        }
+    }
+
+    func testRoute53DeleteRecordStub() async throws {
+        let client = Route53Client()
+        do {
+            try await client.deleteRecord(id: "1")
+            XCTFail("expected failure")
+        } catch {
+            // expected
+        }
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/IntegrationRuntimeTests/GatewayPluginTests.swift
+++ b/Tests/IntegrationRuntimeTests/GatewayPluginTests.swift
@@ -1,5 +1,6 @@
 import XCTest
-@testable import GatewayApp
+@testable import gateway_server
+@testable import FountainCodex
 
 final class GatewayPluginDefaultTests: XCTestCase {
     func testDefaultImplementationsPassThrough() async throws {

--- a/Tests/IntegrationRuntimeTests/LoggingPluginTests.swift
+++ b/Tests/IntegrationRuntimeTests/LoggingPluginTests.swift
@@ -1,5 +1,6 @@
 import XCTest
-@testable import GatewayApp
+@testable import gateway_server
+@testable import FountainCodex
 
 final class LoggingPluginTests: XCTestCase {
     func testLoggingPluginPassThrough() async throws {

--- a/Tests/IntegrationRuntimeTests/PublishingFrontendPluginTests.swift
+++ b/Tests/IntegrationRuntimeTests/PublishingFrontendPluginTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import gateway_server
+@testable import FountainCodex
+
+final class PublishingFrontendPluginTests: XCTestCase {
+    func testPluginServesFile() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("static")
+        try? FileManager.default.removeItem(at: dir)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let fileURL = dir.appendingPathComponent("index.html")
+        try "hi".write(to: fileURL, atomically: true, encoding: .utf8)
+        let plugin = PublishingFrontendPlugin(rootPath: dir.path)
+        let req = HTTPRequest(method: "GET", path: "/")
+        let resp = try await plugin.respond(HTTPResponse(status: 404), for: req)
+        XCTAssertEqual(resp.status, 200)
+        XCTAssertEqual(String(data: resp.body, encoding: .utf8), "hi")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ As modules gain documentation, brief summaries are added here.
 - **PublishingFrontend** – lightweight static HTTP server for serving the `/Public` directory.
 - **HTTPKernel** – simple asynchronous router used by the gateway and publishing frontend.
 - **HetznerDNSClient** – Swift wrapper for the Hetzner DNS API with typed requests.
+- **DNSProvider** – abstraction over DNS APIs with stubs for Route53.
 - **AsyncHTTPClientDriver** and **URLSessionHTTPClient** – documented HTTP clients powering network requests.
 - **NIOHTTPServer** – documented server adapter built on SwiftNIO.
 - **LoggingPlugin** – prints requests and responses for debugging.


### PR DESCRIPTION
## Summary
- document DNSProvider and PublishingFrontendPlugin
- add missing docstring for Todo model
- improve Route53 client test coverage
- enable IntegrationRuntimeTests with new plugin test
- update docs and coverage reports

## Testing
- `swift test -c release --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688ce6a8a4c48325928d30a122666c1b