### PR TITLE
Improve docs and add SpecValidator tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -23,6 +23,7 @@ Within repository sources there are **1,634** lines, with **747** covered, givin
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
 The new ``CertificateManagerTests`` ensure renewal scripts run correctly.
+New ``SpecValidatorTests`` and ``ListRecordsRequestTests`` bring the total test count to **31**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainCodex/Parser/SpecValidator.swift
+++ b/Sources/FountainCodex/Parser/SpecValidator.swift
@@ -1,6 +1,8 @@
 import Foundation
 
+/// Utility validating parsed ``OpenAPISpec`` models for common mistakes.
 public enum SpecValidator {
+    /// Error describing why a specification failed validation.
     public struct ValidationError: Error, Equatable, CustomStringConvertible {
         public let message: String
         public var description: String { message }
@@ -10,6 +12,9 @@ public enum SpecValidator {
         }
     }
 
+    /// Performs a series of assertions to ensure the specification is usable.
+    /// - Parameter spec: The specification model to verify.
+    /// - Throws: ``ValidationError`` when the document contains inconsistencies.
     public static func validate(_ spec: OpenAPISpec) throws {
         if spec.title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             throw ValidationError("title cannot be empty")

--- a/Sources/GatewayApp/main.swift
+++ b/Sources/GatewayApp/main.swift
@@ -2,6 +2,9 @@ import Foundation
 import Dispatch
 import PublishingFrontend
 
+/// Launches ``GatewayServer`` with the publishing plugin enabled.
+/// The server stays running until the process is terminated.
+
 let publishingConfig = try? loadPublishingConfig()
 let server = GatewayServer(plugins: [LoggingPlugin(), PublishingFrontendPlugin(rootPath: publishingConfig?.rootPath ?? "./Public")])
 Task { @MainActor in

--- a/Sources/PublishingFrontend/HetznerDNSClient/Requests/listPrimaryServers.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Requests/listPrimaryServers.swift
@@ -1,9 +1,11 @@
 import Foundation
 
+/// Parameters controlling ``listPrimaryServers``.
 public struct listPrimaryServersParameters: Codable {
     public var zoneId: String?
 }
 
+/// Request listing primary DNS servers for a zone.
 public struct listPrimaryServers: APIRequest {
     public typealias Body = NoBody
     public typealias Response = PrimaryServersResponse
@@ -18,8 +20,14 @@ public struct listPrimaryServers: APIRequest {
     }
     public var body: Body?
 
+    /// Creates a new ``listPrimaryServers`` request.
+    /// - Parameters:
+    ///   - parameters: Zone identifier.
+    ///   - body: Always `nil`.
     public init(parameters: listPrimaryServersParameters, body: Body? = nil) {
         self.parameters = parameters
         self.body = body
     }
 }
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/HetznerDNSClient/Requests/listRecords.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Requests/listRecords.swift
@@ -1,11 +1,13 @@
 import Foundation
 
+/// Parameters for ``listRecords`` defining the zone and pagination.
 public struct listRecordsParameters: Codable {
     public var zoneId: String?
     public var page: Int?
     public var perPage: Int?
 }
 
+/// Request type listing DNS records for a zone.
 public struct listRecords: APIRequest {
     public typealias Body = NoBody
     public typealias Response = RecordsResponse
@@ -22,8 +24,14 @@ public struct listRecords: APIRequest {
     }
     public var body: Body?
 
+    /// Creates a new ``listRecords`` request.
+    /// - Parameters:
+    ///   - parameters: Zone and paging values.
+    ///   - body: Always `nil` for this request.
     public init(parameters: listRecordsParameters, body: Body? = nil) {
         self.parameters = parameters
         self.body = body
     }
 }
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/ClientGeneratorTests/SpecValidatorTests.swift
+++ b/Tests/ClientGeneratorTests/SpecValidatorTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import FountainCodex
+
+final class SpecValidatorTests: XCTestCase {
+    func testDuplicateOperationIdThrows() throws {
+        var op = OpenAPISpec.Operation(operationId: "op", parameters: nil, requestBody: nil, responses: nil, security: nil)
+        let item = OpenAPISpec.PathItem(get: op, post: nil, put: nil, delete: nil)
+        var spec = OpenAPISpec(title: "API", servers: nil, components: nil, paths: [
+            "/a": item,
+            "/b": item
+        ])
+        XCTAssertThrowsError(try SpecValidator.validate(spec)) { error in
+            XCTAssertTrue("\(error)".contains("duplicate operationId"))
+        }
+    }
+
+    func testUnresolvedSchemaReferenceThrows() throws {
+        var paramSchema = OpenAPISpec.Schema()
+        paramSchema.ref = "#/components/schemas/Missing"
+        let param = OpenAPISpec.Parameter(name: "id", location: "path", required: true, schema: paramSchema)
+        var op = OpenAPISpec.Operation(operationId: "get", parameters: [param], requestBody: nil, responses: nil, security: nil)
+        let item = OpenAPISpec.PathItem(get: op, post: nil, put: nil, delete: nil)
+        let components = OpenAPISpec.Components(schemas: [:], securitySchemes: nil)
+        var spec = OpenAPISpec(title: "API", servers: nil, components: components, paths: ["/item/{id}": item])
+        XCTAssertThrowsError(try SpecValidator.validate(spec)) { error in
+            XCTAssertTrue("\(error)".contains("unresolved reference"))
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/DNSTests/ListRecordsRequestTests.swift
+++ b/Tests/DNSTests/ListRecordsRequestTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import PublishingFrontend
+
+final class ListRecordsRequestTests: XCTestCase {
+    func testPathBuilderEncodesQuery() {
+        let params = listRecordsParameters(zoneId: "z", page: 2, perPage: 5)
+        let req = listRecords(parameters: params)
+        XCTAssertEqual(req.path, "/records?zone_id=z&page=2&per_page=5")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,8 @@ As modules gain documentation, brief summaries are added here.
 - **publishing-frontend CLI** – documented main entrypoint starting the static server.
 - **clientgen-service CLI** – wrapper around GeneratorCLI is now documented.
 - **GatewayServerTests** – verifies the gateway's health endpoint.
+- **SpecValidator** – checks OpenAPI documents for duplicate IDs and unresolved references.
+- **listRecords** and **listPrimaryServers** – request types now include documentation.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- document SpecValidator, Gateway main and Hetzner request types
- add SpecValidator and listRecords tests
- note progress in docs and coverage reports

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `swift test -c release --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688d1b31a8d08325af292aecae23f4d6