### PR TITLE
Document primary server requests and add tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31394   26693    14.97%   13996 11553    17.45%   98620   81771    17.08%
+TOTAL                                          31410   26686    15.04%   14012 11547    17.59%   98652   81754    17.13%
 ```
 
-The repository contains **98,620** executable lines, with **16,849** lines covered (approx. **17.08%** line coverage).
+The repository contains **98,652** executable lines, with **16,898** lines covered (approx. **17.13%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                           1016     404    60.24%     464   114    75.43%    2273     789    65.29%
+TOTAL                                           1032     397    61.53%     480   108    77.50%    2305     772    66.51%
 ```
 
-Within repository sources there are **2,273** lines, with **1,484** covered, giving **65.29%** line coverage.
+Within repository sources there are **2,305** lines, with **1,533** covered, giving **66.51%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -32,7 +32,7 @@ The new ``TodoEncodingRoundTrip`` test brings the total test count to **36**.
 The new ``SecurityRequirementTests`` bring the total test count to **38**.
 The new ``HTTPResponseDefaultsTests`` increase the total test count to **40**.
 The new ``AsyncHTTPClientDriverTests`` bring the total test count to **41**.
-The new ``Route53ClientTests`` raise the total test count to **45**.
+The new ``CreatePrimaryServerRequestTests`` and ``GetPrimaryServerRequestTests`` raise the total test count to **49**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/HetznerDNSClient/Requests/createPrimaryServer.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Requests/createPrimaryServer.swift
@@ -1,13 +1,23 @@
 import Foundation
 
+/// Request creating a new primary DNS server.
 public struct createPrimaryServer: APIRequest {
+    /// Payload describing the server to create.
     public typealias Body = PrimaryServerCreate
+    /// Hetzner's response contains no structured body.
     public typealias Response = Data
+    /// HTTP method used for the request.
     public var method: String { "POST" }
+    /// API endpoint path for creating primary servers.
     public var path: String { "/primary_servers" }
+    /// Optional request body sent to the API.
     public var body: Body?
 
+    /// Creates a new request optionally carrying a body.
+    /// - Parameter body: Attributes describing the primary server.
     public init(body: Body? = nil) {
         self.body = body
     }
 }
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/HetznerDNSClient/Requests/getPrimaryServer.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Requests/getPrimaryServer.swift
@@ -1,14 +1,22 @@
 import Foundation
 
+/// Parameters used when retrieving a specific primary server.
 public struct getPrimaryServerParameters: Codable {
+    /// Identifier of the primary server to fetch.
     public let primaryserverid: String
 }
 
+/// Request returning details for a primary DNS server.
 public struct getPrimaryServer: APIRequest {
+    /// Request body is unused for this endpoint.
     public typealias Body = NoBody
+    /// Structured response describing the server.
     public typealias Response = PrimaryServerResponse
+    /// HTTP method used to fetch the server.
     public var method: String { "GET" }
+    /// Path parameters specifying the server identifier.
     public var parameters: getPrimaryServerParameters
+    /// API endpoint path rendered with parameters.
     public var path: String {
         var path = "/primary_servers/{PrimaryServerID}"
         let query: [String] = []
@@ -16,8 +24,13 @@ public struct getPrimaryServer: APIRequest {
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path
     }
+    /// Body is always `nil` for GET requests.
     public var body: Body?
 
+    /// Creates a request configured with path parameters.
+    /// - Parameters:
+    ///   - parameters: Identifier for the primary server.
+    ///   - body: Optional request body (unused).
     public init(parameters: getPrimaryServerParameters, body: Body? = nil) {
         self.parameters = parameters
         self.body = body

--- a/Tests/DNSTests/CreatePrimaryServerRequestTests.swift
+++ b/Tests/DNSTests/CreatePrimaryServerRequestTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import PublishingFrontend
+
+final class CreatePrimaryServerRequestTests: XCTestCase {
+    func testPathIsCorrect() {
+        let req = createPrimaryServer()
+        XCTAssertEqual(req.path, "/primary_servers")
+    }
+
+    func testMethodIsPOST() {
+        let req = createPrimaryServer()
+        XCTAssertEqual(req.method, "POST")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/DNSTests/GetPrimaryServerRequestTests.swift
+++ b/Tests/DNSTests/GetPrimaryServerRequestTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import PublishingFrontend
+
+final class GetPrimaryServerRequestTests: XCTestCase {
+    func testPathBuilderReplacesId() {
+        let params = getPrimaryServerParameters(primaryserverid: "123")
+        let req = getPrimaryServer(parameters: params)
+        XCTAssertEqual(req.path, "/primary_servers/123")
+    }
+
+    func testMethodIsGET() {
+        let params = getPrimaryServerParameters(primaryserverid: "123")
+        let req = getPrimaryServer(parameters: params)
+        XCTAssertEqual(req.method, "GET")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ As modules gain documentation, brief summaries are added here.
 - **OpenAPISpec** – root model now documents components, servers, security schemes, and requirements.
 - **Route53Client** – stub methods now describe the unimplemented error responses.
 - **FountainOps Todo** – generated model now documents its properties.
+- **createPrimaryServer** and **getPrimaryServer** – request types now document server creation and retrieval.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- document Hetzner DNS primary server requests
- verify primary server request paths and methods
- record updated coverage and documentation progress

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `swift test -c release --enable-code-coverage`

------
https://chatgpt.com/codex/tasks/task_e_688dcd6cbcf88325a52a32341d95baf6