### PR TITLE
Document DNS requests and add update tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -5,20 +5,20 @@
 Running `swift test --enable-code-coverage` and analysing with `llvm-cov` produced the following totals:
 
 ```
-TOTAL                                          31766   26565    16.37%   14290 11503    19.50%   99364 81455    18.02%
+TOTAL                                          31782   26533    16.52%   14306 11485    19.72%   99392 81299    18.20%
 ```
 
-The repository contains **99,364** executable lines, with **17,909** lines covered (approx. **18.02%** line coverage).
+The repository contains **99,392** executable lines, with **18,093** lines covered (approx. **18.20%** line coverage).
 
 ### Repository source coverage
 
 Ignoring third-party packages under `.build/checkouts`, the totals are:
 
 ```
-TOTAL                                           590     269    54.41%     173     46    73.41%    1366     508    62.81%
+TOTAL                                           590     262    55.59%     173     40    76.88%    1366     491    64.06%
 ```
 
-Within repository sources there are **1,366** lines, with **858** covered, giving **62.81%** line coverage.
+Within repository sources there are **1,366** lines, with **875** covered, giving **64.06%** line coverage.
 
 Coverage results are recalculated after each test run to monitor progress. The project strives for ever more comprehensive test suites across all modules. Recent additions include unit tests for ``APIClient``. New tests now verify ``URLSessionHTTPClient`` behavior and the ``Supervisor`` process termination logic.
 Additional tests now cover ``OpenAPISpec.swiftType`` and the ``camelCased`` string helper. A new ``GatewayServerTests`` suite raises total tests to **27**.
@@ -62,6 +62,8 @@ The new ``SpecValidator`` missing parameter, required flag, and security scheme 
 The new ``GatewayPlugin`` default behavior tests and ``PublishingFrontendPlugin`` header check raise the total test count to **103**.
 
 The new ``DeletePrimaryServerRequestTests`` raise the total test count to **105**.
+
+- The new ``bulkUpdateRecords`` and ``updateZone`` request tests raise the total test count to **109**.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/PublishingFrontend/HetznerDNSClient/Requests/DeleteRecord.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Requests/DeleteRecord.swift
@@ -2,15 +2,21 @@ import Foundation
 
 /// Identifies the DNS record to remove.
 public struct DeleteRecordParameters: Codable {
+    /// Unique identifier of the record to delete.
     public let recordid: String
 }
 
 /// Request wrapper for deleting a specific DNS record.
 public struct DeleteRecord: APIRequest {
+    /// Empty body for delete operations.
     public typealias Body = NoBody
+    /// API returns no content on success.
     public typealias Response = NoBody
+    /// HTTP method used to remove the record.
     public var method: String { "DELETE" }
+    /// Parameters identifying which record to delete.
     public var parameters: DeleteRecordParameters
+    /// API endpoint path with the record ID substituted.
     public var path: String {
         var path = "/records/{RecordID}"
         let query: [String] = []
@@ -18,8 +24,13 @@ public struct DeleteRecord: APIRequest {
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path
     }
+    /// Optional request body, always `nil` for deletions.
     public var body: Body?
 
+    /// Creates a new delete record request.
+    /// - Parameters:
+    ///   - parameters: Wrapper containing the record identifier.
+    ///   - body: Unused body parameter, defaults to `nil`.
     public init(parameters: DeleteRecordParameters, body: Body? = nil) {
         self.parameters = parameters
         self.body = body

--- a/Sources/PublishingFrontend/HetznerDNSClient/Requests/bulkUpdateRecords.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Requests/bulkUpdateRecords.swift
@@ -6,8 +6,11 @@ public struct bulkUpdateRecords: APIRequest {
     public typealias Body = BulkRecordsUpdateRequest
     /// Response summarizing the update results.
     public typealias Response = BulkRecordsUpdateResponse
+    /// HTTP method used for the bulk update operation.
     public var method: String { "PUT" }
+    /// Endpoint path targeting the bulk record update API.
     public var path: String { "/records/bulk" }
+    /// Optional payload describing the records to update.
     public var body: Body?
 
     /// Creates a new bulk update request.

--- a/Sources/PublishingFrontend/HetznerDNSClient/Requests/updateZone.swift
+++ b/Sources/PublishingFrontend/HetznerDNSClient/Requests/updateZone.swift
@@ -12,8 +12,11 @@ public struct updateZone: APIRequest {
     public typealias Body = ZoneUpdateRequest
     /// Response containing the updated zone representation.
     public typealias Response = ZoneResponse
+    /// HTTP method used when updating a DNS zone.
     public var method: String { "PUT" }
+    /// Identifier parameters selecting which zone to modify.
     public var parameters: updateZoneParameters
+    /// API path with the zone identifier substituted.
     public var path: String {
         var path = "/zones/{ZoneID}"
         let query: [String] = []
@@ -21,6 +24,7 @@ public struct updateZone: APIRequest {
         if !query.isEmpty { path += "?" + query.joined(separator: "&") }
         return path
     }
+    /// Optional request body describing updated zone configuration.
     public var body: Body?
 
     /// Creates a new zone update request.

--- a/Tests/PublishingFrontendTests/HetznerDNSRequestTests.swift
+++ b/Tests/PublishingFrontendTests/HetznerDNSRequestTests.swift
@@ -65,6 +65,30 @@ final class HetznerDNSRequestTests: XCTestCase {
         let req = createZone()
         XCTAssertEqual(req.path, "/zones")
     }
+
+    /// Verifies the bulk record update request uses PUT.
+    func testBulkUpdateRecordsMethodIsPut() {
+        let req = bulkUpdateRecords()
+        XCTAssertEqual(req.method, "PUT")
+    }
+
+    /// Ensures the bulk record update request hits the correct endpoint.
+    func testBulkUpdateRecordsPath() {
+        let req = bulkUpdateRecords()
+        XCTAssertEqual(req.path, "/records/bulk")
+    }
+
+    /// Verifies the update zone request uses PUT.
+    func testUpdateZoneMethodIsPut() {
+        let req = updateZone(parameters: updateZoneParameters(zoneid: "abc"))
+        XCTAssertEqual(req.method, "PUT")
+    }
+
+    /// Ensures the update zone request path includes the zone ID.
+    func testUpdateZonePathIncludesID() {
+        let req = updateZone(parameters: updateZoneParameters(zoneid: "abc"))
+        XCTAssertEqual(req.path, "/zones/abc")
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -66,6 +66,7 @@ As modules gain documentation, brief summaries are added here.
 - **HTTPKernel.handle** – now documents error propagation from routing closures.
 - **run-tests.sh** – helper script bundling release build and coverage test steps.
 - **PublishingFrontendPlugin.respond** – documents parameters and emitted `Content-Type` header when serving files.
+- **bulkUpdateRecords.method** and **path**, **updateZone.method** and **path** – request properties now describe HTTP verbs and endpoint resolution.
 
 Documentation coverage will expand alongside test coverage.
 


### PR DESCRIPTION
## Summary
- document `bulkUpdateRecords`, `updateZone`, and `DeleteRecord` request properties
- add tests for bulk record updates and zone updates
- record coverage and documentation progress

## Testing
- `Scripts/run-tests.sh`
- `llvm-cov-19 report .build/release/FountainCoachPackageTests.xctest -instr-profile=.build/release/codecov/default.profdata`
- `llvm-cov-19 report .build/release/FountainCoachPackageTests.xctest -instr-profile=.build/release/codecov/default.profdata --ignore-filename-regex='/(\.build|Tests)/'`


------
https://chatgpt.com/codex/tasks/task_e_689005520c8083258e4e3481eff1343f