### PR TITLE
Document test runner and extend publishing plugin tests

### DIFF
--- a/COVERAGE.md
+++ b/COVERAGE.md
@@ -89,5 +89,7 @@ The new ``DeletePrimaryServerRequestTests`` raise the total test count to **105*
 - The new ``UpdateRecordSetsAuthHeader`` and ``DeleteRecordSetsAuthHeader`` tests raise the total test count to **147**.
 - The new ``AsyncHTTPClientDriver`` unreachable host test and metrics endpoint header and body tests raise the total test count to **150**.
 - The new ``LoggingPlugin`` header and body preservation tests raise the total test count to **152**.
+
+- The new ``PublishingFrontendPlugin`` nested-file and header-preservation tests raise the total test count to **154**.
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Scripts/run-tests.sh
+++ b/Scripts/run-tests.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 set -euo pipefail
+
+# Timestamp used to differentiate successive log files.
 TS=$(date +"%Y%m%d%H%M%S")
-swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors 2>&1 | tee "logs/build-$TS.log"
-swift test -c release --enable-code-coverage 2>&1 | tee "logs/test-$TS.log"
+
+# Build the package in release mode while treating warnings as errors.
+# Output is tee'd into a log under the `logs` directory for later inspection.
+swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors \
+  2>&1 | tee "logs/build-$TS.log"
+
+# Execute the test suite with code coverage enabled and capture the results.
+swift test -c release --enable-code-coverage \
+  2>&1 | tee "logs/test-$TS.log"
 
 # © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/IntegrationRuntimeTests/PublishingFrontendPluginTests.swift
+++ b/Tests/IntegrationRuntimeTests/PublishingFrontendPluginTests.swift
@@ -52,6 +52,34 @@ final class PublishingFrontendPluginTests: XCTestCase {
         let resp = try await plugin.respond(HTTPResponse(status: 404, headers: [:]), for: req)
         XCTAssertEqual(resp.headers["Content-Type"], "text/html")
     }
+
+    /// Serves files located in nested directories relative to ``rootPath``.
+    func testPluginServesNestedFile() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("static-nested")
+        try? FileManager.default.removeItem(at: dir)
+        let nested = dir.appendingPathComponent("pages")
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        let fileURL = nested.appendingPathComponent("about.html")
+        try "nested".write(to: fileURL, atomically: true, encoding: .utf8)
+        let plugin = PublishingFrontendPlugin(rootPath: dir.path)
+        let req = HTTPRequest(method: "GET", path: "/pages/about.html")
+        let resp = try await plugin.respond(HTTPResponse(status: 404), for: req)
+        XCTAssertEqual(resp.status, 200)
+        XCTAssertEqual(String(data: resp.body, encoding: .utf8), "nested")
+    }
+
+    /// Preserves existing headers when passing through a missing file response.
+    func testPluginPreservesHeadersOnPassThrough() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent("static-headers")
+        try? FileManager.default.removeItem(at: dir)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let plugin = PublishingFrontendPlugin(rootPath: dir.path)
+        let req = HTTPRequest(method: "GET", path: "/missing.html")
+        let original = HTTPResponse(status: 404, headers: ["X-Test": "1"])
+        let resp = try await plugin.respond(original, for: req)
+        XCTAssertEqual(resp.status, 404)
+        XCTAssertEqual(resp.headers["X-Test"], "1")
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -69,7 +69,7 @@ As modules gain documentation, brief summaries are added here.
 - **HTTPResponse.status**, **headers**, and **body** – properties now clarify response components.
 - **HetznerDNSClient.createRecord**, **updateRecord**, and **deleteRecord** – methods now detail parameters for zone, record name, type, and value.
 - **HTTPKernel.handle** – now documents error propagation from routing closures.
-- **run-tests.sh** – helper script bundling release build and coverage test steps.
+- **run-tests.sh** – helper script bundling release build and coverage test steps with inline comments explaining log generation.
 - **PublishingFrontendPlugin.respond** – documents parameters and emitted `Content-Type` header when serving files.
 - **bulkUpdateRecords.method** and **path**, **updateZone.method** and **path** – request properties now describe HTTP verbs and endpoint resolution.
 - **GatewayServer.plugins** – documents plugin execution order for request preparation and response processing.


### PR DESCRIPTION
## Summary
- document test runner steps to clarify build and coverage logging
- cover nested file serving and header preservation in PublishingFrontendPlugin
- record progress in docs and coverage tracking

## Testing
- `Scripts/run-tests.sh` *(failed: build terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_6890b7c46d4c8325abb439b9875ea282