### PR TITLE
Add SwiftLint and coverage reporting to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,14 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: norio-nomura/action-swiftlint@v4
+        with:
+          args: --config .swiftlint.yml
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -17,5 +25,17 @@ jobs:
         run: swift build
       - name: Test
         run: swift test --enable-code-coverage
+      - name: Generate Coverage
+        run: |
+          llvm-cov-19 export -format=lcov .build/x86_64-unknown-linux-gnu/debug/FountainCoachPackageTests.xctest -instr-profile .build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata > coverage.lcov
+          COVERAGE=$(lcov --summary coverage.lcov 2>/dev/null | grep lines | awk '{print $2}' | sed 's/%//')
+          curl -s "https://img.shields.io/badge/Coverage-${COVERAGE}%25-blue" -o coverage-badge.svg
+      - name: Upload Coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: |
+            coverage.lcov
+            coverage-badge.svg
 
 # © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/agent.md
+++ b/agent.md
@@ -38,8 +38,8 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | Metrics & logging | `GatewayServer`, `DNSMetrics` | Expose Prometheus-style metrics | ✅ | — | observability |
 | Integration tests | `Tests/*` | E2E tests for generated servers | ✅ | — | test |
 | DNS perf tests | `Tests/*` | UDP/TCP load & concurrency tests | ✅ | — | test, dns |
-| SwiftLint in CI | `.swiftlint.yml`, `.github/workflows/*` | Add lint job to Actions | ⏳ | CI updates | ci, lint |
-| Coverage in CI | `.github/workflows/*` | Publish coverage artifacts/badge | ⏳ | Coverage tooling | ci, test |
+| SwiftLint in CI | `.swiftlint.yml`, `.github/workflows/*` | Add lint job to Actions | ✅ | — | ci, lint |
+| Coverage in CI | `.github/workflows/*` | Publish coverage artifacts/badge | ✅ | — | ci, test |
 | opId→handler audit | repo-wide | Script to diff specs vs code | ⏳ | Tooling, conventions | tooling, docs |
 | Spec↔code drift | specs & servers | Track/close gaps per service | ⏳ | Bandwidth | process |
 


### PR DESCRIPTION
## Summary
- run SwiftLint via dedicated CI job
- export test coverage and publish badge artifact
- mark SwiftLint and coverage tasks complete in agent manifest

## Testing
- `Scripts/lint.sh` *(fails: swiftlint is not installed. Skipping lint.)*
- `swift test --enable-code-coverage`
- `lcov --summary coverage.lcov`


------
https://chatgpt.com/codex/tasks/task_b_6892f8ef10d8833393f91d86d135458d