### PR TITLE
Add certificate file parsing for GatewayServer

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.21.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
+        .package(url: "https://github.com/apple/swift-certificates.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0")
     ],
     targets: [
@@ -43,7 +44,12 @@ let package = Package(
         ),
         .executableTarget(
             name: "gateway-server",
-            dependencies: ["FountainCodex", "PublishingFrontend", .product(name: "Crypto", package: "swift-crypto")],
+            dependencies: [
+                "FountainCodex",
+                "PublishingFrontend",
+                .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "X509", package: "swift-certificates")
+            ],
             path: "Sources/GatewayApp"
         ),
         .target(


### PR DESCRIPTION
## Summary
- parse TLS certificates from a configurable path and expose issuer/expiry
- add unit tests for certificate parsing, missing files, and invalid data
- include X509 dependency for certificate handling

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_6899c17e373483338869df4dd976bde6