### PR TITLE
feat: add table model detection

### DIFF
--- a/sps/Sources/SPSCLI/TableDetector.swift
+++ b/sps/Sources/SPSCLI/TableDetector.swift
@@ -7,6 +7,22 @@ struct MatrixEntry: Codable {
     var y: Int
 }
 
+struct TableCell: Codable {
+    var row: Int
+    var column: Int
+    var x: Double
+    var y: Double
+    var width: Double
+    var height: Double
+    var text: String
+}
+
+struct TableModel: Codable {
+    var rows: Int
+    var columns: Int
+    var cells: [TableCell]
+}
+
 struct TableDetector {
     static func detect(from index: IndexRoot) -> (messages: [MatrixEntry], terms: [MatrixEntry]) {
         var messages: [MatrixEntry] = []
@@ -28,6 +44,48 @@ struct TableDetector {
             }
         }
         return (messages, terms)
+    }
+
+    static func detectTables(from index: IndexRoot, threshold: Double = 5.0) -> [TableModel] {
+        var tables: [TableModel] = []
+        for doc in index.documents {
+            for page in doc.pages {
+                let lines = page.lines
+                guard !lines.isEmpty else { continue }
+                let rowCenters = cluster(lines.map { $0.y }, threshold: threshold)
+                let columnCenters = cluster(lines.map { $0.x }, threshold: threshold)
+                var cells: [TableCell] = []
+                for (ri, ry) in rowCenters.enumerated() {
+                    for (ci, cx) in columnCenters.enumerated() {
+                        if let match = lines.first(where: { abs($0.y - ry) <= threshold && abs($0.x - cx) <= threshold }) {
+                            cells.append(TableCell(row: ri, column: ci, x: match.x, y: match.y, width: match.width, height: match.height, text: match.text))
+                        } else {
+                            cells.append(TableCell(row: ri, column: ci, x: cx, y: ry, width: 0, height: 0, text: ""))
+                        }
+                    }
+                }
+                tables.append(TableModel(rows: rowCenters.count, columns: columnCenters.count, cells: cells))
+            }
+        }
+        return tables
+    }
+
+    private static func cluster(_ values: [Double], threshold: Double) -> [Double] {
+        let sorted = values.sorted()
+        var centers: [Double] = []
+        var counts: [Int] = []
+        for v in sorted {
+            if let last = centers.last, abs(v - last) <= threshold {
+                let count = counts.removeLast()
+                let newCenter = (last * Double(count) + v) / Double(count + 1)
+                centers[centers.count - 1] = newCenter
+                counts.append(count + 1)
+            } else {
+                centers.append(v)
+                counts.append(1)
+            }
+        }
+        return centers
     }
 }
 

--- a/sps/Tests/SPSCLITests/TableDetectorTests.swift
+++ b/sps/Tests/SPSCLITests/TableDetectorTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import SPSCLI
+
+final class TableDetectorTests: XCTestCase {
+    func testDetectTablesFillsGaps() throws {
+        let lines = [
+            TextLine(text: "A", x: 10, y: 10, width: 10, height: 10),
+            TextLine(text: "C", x: 50, y: 10, width: 10, height: 10),
+            TextLine(text: "1", x: 10, y: 30, width: 10, height: 10),
+            TextLine(text: "2", x: 30, y: 30, width: 10, height: 10),
+            TextLine(text: "3", x: 50, y: 30, width: 10, height: 10)
+        ]
+        let page = IndexPage(number: 1, text: "", lines: lines)
+        let doc = IndexDoc(id: "1", fileName: "test.pdf", size: 0, sha256: nil, pages: [page])
+        let index = IndexRoot(documents: [doc])
+        let tables = TableDetector.detectTables(from: index, threshold: 1.0)
+        XCTAssertEqual(tables.count, 1)
+        let table = tables[0]
+        XCTAssertEqual(table.rows, 2)
+        XCTAssertEqual(table.columns, 3)
+        let missing = table.cells.first { $0.row == 0 && $0.column == 1 }
+        XCTAssertEqual(missing?.text, "")
+        let present = table.cells.first { $0.row == 0 && $0.column == 0 }
+        XCTAssertEqual(present?.text, "A")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- model table cells and tables
- cluster text lines into table rows and columns
- ensure gaps create empty cells
- cover table detection with unit tests

## Testing
- `cd sps && swift test`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_689a060bcc488333847b0660b555c8a9