### PR TITLE
Add validation hooks for SPS matrix export

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -44,6 +44,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | Coverage in CI | `.github/workflows/*` | Publish coverage artifacts/badge | ✅ | — | ci, test |
 | opId→handler audit | repo-wide | Script to diff specs vs code | ✅ | — | tooling, docs |
 | Spec↔code drift | specs & servers | Track/close gaps per service | ✅ | — | process |
+| SPS validation hooks | `sps/Sources/Validation/*`, `sps/Sources/SPSCLI/main.swift` | Add coverage + reserved-bit checks | ✅ | — | sps |
 
 ---
 

--- a/sps/AGENT.md
+++ b/sps/AGENT.md
@@ -83,7 +83,19 @@ swift build -c release
 .build/release/sps query spec/index.json --q "Note On"
 
 # 4) Export matrix for Midi2Swift generators
-.build/release/sps export-matrix spec/index.json --out spec/matrix.json
+.build/release/sps export-matrix spec/index.json --out spec/matrix.json --validate
+```
+
+The `--validate` flag runs coverage analysis and reserved-bit checks.
+It emits a report alongside the matrix at `spec/matrix.json.validation.json`.
+Sample report:
+
+```
+{
+  "coveragePassed": true,
+  "reservedBitsPassed": true,
+  "issues": []
+}
 ```
 
 ## Non-goals (for now)
@@ -102,3 +114,5 @@ swift build -c release
 ### Notes for Midi2Swift integration
 - The produced `matrix.json` must slot into `tools/MatrixBuilder` without manual edits.
 - When `STRICT_FULL_SPEC=1` in downstream CI, missing fields should surface as validation errors, not crashes.
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sps/Package.swift
+++ b/sps/Package.swift
@@ -16,11 +16,16 @@ let package = Package(
         .executableTarget(
             name: "SPSCLI",
             dependencies: [
+                "Validation",
                 .product(name: "ArgumentParser", package: "swift-argument-parser")
             ],
             path: "Sources/SPSCLI",
             exclude: ["Resources"],
             resources: []
+        ),
+        .target(
+            name: "Validation",
+            path: "Sources/Validation"
         ),
         .testTarget(
             name: "SPSCLITests",

--- a/sps/Sources/SPSCLI/main.swift
+++ b/sps/Sources/SPSCLI/main.swift
@@ -7,6 +7,7 @@ import CoreGraphics
 import CoreText
 #endif
 import ArgumentParser
+import Validation
 
 struct IndexDoc: Codable {
     var id: String
@@ -436,6 +437,9 @@ extension SPS {
         @Flag(name: [.customShort("e"), .long], help: "Include enum section")
         var enums: Bool = false
 
+        @Flag(name: [.customShort("v"), .long], help: "Run validation hooks and emit report JSON")
+        var validate: Bool = false
+
         func run() throws {
             let data = try Data(contentsOf: URL(fileURLWithPath: index))
             let index = try JSONDecoder().decode(IndexRoot.self, from: data)
@@ -457,6 +461,15 @@ extension SPS {
             let outData = try enc.encode(matrix)
             try outData.write(to: URL(fileURLWithPath: out))
             print("SPS: wrote matrix skeleton -> \(out)")
+            if validate {
+                let report = Validator.validate(matrixData: outData)
+                let reportURL = URL(fileURLWithPath: out + ".validation.json")
+                let reportEnc = JSONEncoder()
+                reportEnc.outputFormatting = [.prettyPrinted, .sortedKeys]
+                let reportData = try reportEnc.encode(report)
+                try reportData.write(to: reportURL)
+                print("SPS: validation report -> \(reportURL.path)")
+            }
         }
     }
 }

--- a/sps/Sources/Validation/Validation.swift
+++ b/sps/Sources/Validation/Validation.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+public struct ValidationResult: Codable {
+    public let coveragePassed: Bool
+    public let reservedBitsPassed: Bool
+    public let issues: [String]
+}
+
+public enum Validator {
+    public static func validate(matrixData: Data) -> ValidationResult {
+        let decoder = JSONDecoder()
+        guard let matrix = try? decoder.decode(Matrix.self, from: matrixData) else {
+            return ValidationResult(coveragePassed: false, reservedBitsPassed: false, issues: ["Invalid matrix JSON"])
+        }
+        var issues: [String] = []
+        let coverage = coverageAnalysis(matrix: matrix)
+        issues.append(contentsOf: coverage.1)
+        let reserved = reservedBitCheck(matrix: matrix)
+        issues.append(contentsOf: reserved.1)
+        return ValidationResult(coveragePassed: coverage.0, reservedBitsPassed: reserved.0, issues: issues)
+    }
+
+    private static func coverageAnalysis(matrix: Matrix) -> (Bool, [String]) {
+        let passed = !matrix.messages.isEmpty && !matrix.terms.isEmpty
+        return (passed, passed ? [] : ["Matrix missing messages or terms"])
+    }
+
+    private static func reservedBitCheck(matrix: Matrix) -> (Bool, [String]) {
+        guard let bitfields = matrix.bitfields else { return (true, []) }
+        var issues: [String] = []
+        var passed = true
+        for bf in bitfields {
+            for bit in bf.bits where bit < 0 {
+                passed = false
+                issues.append("Bitfield \(bf.name) has reserved bit \(bit)")
+            }
+        }
+        return (passed, issues)
+    }
+}
+
+private struct Matrix: Codable {
+    var messages: [MatrixEntry]
+    var terms: [MatrixEntry]
+    var bitfields: [BitField]?
+}
+
+private struct MatrixEntry: Codable {
+    var text: String
+    var page: Int
+    var x: Int
+    var y: Int
+}
+
+private struct BitField: Codable {
+    var name: String
+    var bits: [Int]
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sps/Tests/SPSCLITests/ValidationTests.swift
+++ b/sps/Tests/SPSCLITests/ValidationTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+import Validation
+
+final class ValidationTests: XCTestCase {
+    func testValidationPasses() throws {
+        let matrix: [String: Any] = [
+            "messages": [["text": "Message", "page": 1, "x": 0, "y": 0]],
+            "terms": [["text": "Term", "page": 1, "x": 0, "y": 1]],
+            "bitfields": [["name": "Flags", "bits": [0, 1, 2]]]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: matrix, options: [])
+        let report = Validator.validate(matrixData: data)
+        XCTAssertTrue(report.coveragePassed)
+        XCTAssertTrue(report.reservedBitsPassed)
+        XCTAssertTrue(report.issues.isEmpty)
+    }
+
+    func testValidationFails() throws {
+        let matrix: [String: Any] = [
+            "messages": [],
+            "terms": [],
+            "bitfields": [["name": "Flags", "bits": [0, -1, 2]]]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: matrix, options: [])
+        let report = Validator.validate(matrixData: data)
+        XCTAssertFalse(report.coveragePassed)
+        XCTAssertFalse(report.reservedBitsPassed)
+        XCTAssertEqual(report.issues.count, 2)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add Validation module with coverage and reserved-bit checks
- integrate optional --validate flag in matrix export CLI producing JSON report
- document validation workflow and update agent matrix

## Testing
- `cd sps && swift test`
- `swift test --skip-build`


------
https://chatgpt.com/codex/tasks/task_b_689a0f26a178833388e548ea90ca6e93