### PR TITLE
Reset MIDI2 task matrix

### DIFF
--- a/midi/agent.md
+++ b/midi/agent.md
@@ -1,7 +1,7 @@
 # MIDI 2 Development Agent
 
-**Last Updated:** August 11, 2025  
-**Scope:** `midi/` and generated Swift MIDI 2 modules  
+**Last Updated:** August 11, 2025
+**Scope:** `midi/` and generated Swift MIDI 2 modules
 **Purpose:** Guide conversion of the official MIDI 2.0 specification into machine-readable data models using the SPS API and surface them as Swift Package Manager libraries.
 
 ## 🎯 Tasks
@@ -18,13 +18,13 @@
 
 ## 🗂 Task Matrix
 
-| # | Feature / Component        | Files / Area                              | Action                                                                                           | Status |
-|---|---------------------------|-------------------------------------------|--------------------------------------------------------------------------------------------------|--------|
-| 1 | Spec ingestion pipeline   | `midi/specs/`, `sps/*`                     | Ingest MIDI 2.0 specification documents via SPS parsing pipeline                                 | ✅     |
-| 2 | Data model generation     | `midi/models/`                             | Emit normalized machine-readable models from ingested specs                                      | ✅   |
-| 3 | Swift package scaffolding | `Sources/MIDI2/*`, `Package.swift`         | Generate Swift sources for a `MIDI2` module and expose via Swift Package Manager                 | TODO   |
-| 4 | Test suite                | `Tests/MIDI2Tests/*`                       | Provide tests covering generated MIDI 2 functionality                                            | TODO   |
-| 5 | Reproducibility tooling   | `midi/*`                                   | Ensure artifacts are reproducible and regeneratable when specs change                            | TODO   |
-| 6 | Verification              | `swift test`                               | Run full `swift test` after changes                                                              | TODO   |
+| # | Feature / Component        | Files / Area                              | Action                                                | Status |
+|---|---------------------------|-------------------------------------------|-------------------------------------------------------|--------|
+| 1 | Spec ingestion pipeline   | `midi/specs/`, `sps/*`                     | Ingest MIDI 2.0 specification documents via SPS parsing pipeline | TODO |
+| 2 | Data model generation     | `midi/models/`                             | Emit normalized machine-readable models from ingested specs | TODO |
+| 3 | Swift package scaffolding | `Sources/MIDI2/*`, `Package.swift`         | Generate Swift sources for a `MIDI2` module and expose via Swift Package Manager | TODO |
+| 4 | Test suite                | `Tests/MIDI2Tests/*`                       | Provide tests covering generated MIDI 2 functionality | TODO |
+| 5 | Reproducibility tooling   | `midi/*`                                   | Ensure artifacts are reproducible and regeneratable when specs change | TODO |
+| 6 | Verification              | `swift test`                               | Run full `swift test` after changes | TODO |
 
 > © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- remove premature MIDI2 library and tests from package manifest
- delete unused MIDI2 source and test scaffolding
- reset MIDI agent task matrix to restart at spec ingestion

## Testing
- `swift test` *(terminated early due to long build)*

------
https://chatgpt.com/codex/tasks/task_b_689a4208b9488333b7bd04c1b16bf3ae