### PR TITLE
docs: reference SPSJobQueue in MIDI agent

### DIFF
--- a/midi/agent.md
+++ b/midi/agent.md
@@ -6,6 +6,7 @@
 
 ## 🎯 Tasks
 - Use the SPS parsing pipeline under `/sps` to ingest MIDI 2.0 specification documents placed in `midi/specs/`.
+- Queue long-running scans through `SPSJobQueue` and poll `status` for progress.
 - Emit normalized machine-readable models to `midi/models/`.
 - Generate Swift sources for a `MIDI2` package under `Sources/MIDI2` driven by the data models.
 - Expose the package via `Package.swift` and provide corresponding tests under `Tests/MIDI2Tests`.
@@ -20,7 +21,7 @@
 
 | # | Feature / Component        | Files / Area                              | Action                                                | Status |
 |---|---------------------------|-------------------------------------------|-------------------------------------------------------|--------|
-| 1 | Spec ingestion pipeline   | `midi/specs/`, `sps/*`                     | Ingest MIDI 2.0 specification documents via SPS parsing pipeline | ✅ |
+| 1 | Spec ingestion pipeline   | `midi/specs/`, `sps/*`                     | Ingest MIDI 2.0 specification documents via SPS parsing pipeline using `SPSJobQueue` for asynchronous processing | ✅ |
 | 2 | Data model generation     | `midi/models/`                             | Emit normalized machine-readable models from ingested specs | ✅ |
 | 3 | Swift package scaffolding | `Sources/MIDI2/*`, `Package.swift`         | Generate Swift sources for a `MIDI2` module and expose via Swift Package Manager | TODO |
 | 4 | Test suite                | `Tests/MIDI2Tests/*`                       | Provide tests covering generated MIDI 2 functionality | TODO |


### PR DESCRIPTION
## Summary
- note that MIDI spec scans should be queued via SPSJobQueue
- update task matrix to reflect asynchronous ingestion

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_689ad19ac0f0833397519f3c0f06c771