### PR TITLE
Add MIDI2 package scaffolding and tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 var products: [Product] = [
     .library(name: "FountainCore", targets: ["FountainCore"]),
     .library(name: "FountainCodex", targets: ["FountainCodex"]),
+    .library(name: "MIDI2", targets: ["MIDI2"]),
     .executable(name: "clientgen-service", targets: ["clientgen-service"]),
     .executable(name: "gateway-server", targets: ["gateway-server"]),
     .executable(name: "publishing-frontend", targets: ["publishing-frontend"])
@@ -50,13 +51,15 @@ var targets: [Target] = [
         dependencies: ["PublishingFrontend"],
         path: "Sources/publishing-frontend"
     ),
+    .target(name: "MIDI2", path: "Sources/MIDI2"),
     .testTarget(name: "FountainCoreTests", dependencies: ["FountainCore"], path: "Tests/FountainCoreTests"),
     .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainCodex"], path: "Tests/ClientGeneratorTests"),
     .testTarget(name: "PublishingFrontendTests", dependencies: ["PublishingFrontend"], path: "Tests/PublishingFrontendTests"),
     .testTarget(name: "DNSTests", dependencies: ["PublishingFrontend", "FountainCodex", .product(name: "Crypto", package: "swift-crypto"), .product(name: "NIOEmbedded", package: "swift-nio"), .product(name: "NIO", package: "swift-nio")], path: "Tests/DNSTests"),
     .testTarget(name: "IntegrationRuntimeTests", dependencies: ["gateway-server", "FountainCodex"], path: "Tests/IntegrationRuntimeTests"),
     .testTarget(name: "DNSPerfTests", dependencies: ["FountainCodex", .product(name: "NIOCore", package: "swift-nio")], path: "Tests/DNSPerfTests"),
-    .testTarget(name: "NormativeLinkerTests", dependencies: ["FountainCodex"], path: "Tests/NormativeLinkerTests")
+    .testTarget(name: "NormativeLinkerTests", dependencies: ["FountainCodex"], path: "Tests/NormativeLinkerTests"),
+    .testTarget(name: "MIDI2Tests", dependencies: ["MIDI2"], path: "Tests/MIDI2Tests")
 ]
 
 #if os(Linux)

--- a/Sources/MIDI2/ModelIndex.swift
+++ b/Sources/MIDI2/ModelIndex.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+public struct MIDIModelIndex: Codable {
+    public struct Document: Codable {
+        public let fileName: String
+        public let id: String
+        public let pages: [Page]
+        public let sha256: String
+        public let size: Int
+        public init(fileName: String, id: String, pages: [Page], sha256: String, size: Int) {
+            self.fileName = fileName
+            self.id = id
+            self.pages = pages
+            self.sha256 = sha256
+            self.size = size
+        }
+    }
+
+    public struct Page: Codable {
+        public let lines: [String]
+        public let number: Int
+        public let text: String
+        public init(lines: [String], number: Int, text: String) {
+            self.lines = lines
+            self.number = number
+            self.text = text
+        }
+    }
+
+    public let documents: [Document]
+    public init(documents: [Document]) {
+        self.documents = documents
+    }
+
+    public static func load(from path: String = "midi/models/index.json") throws -> MIDIModelIndex {
+        let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath).appendingPathComponent(path)
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(MIDIModelIndex.self, from: data)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/MIDI2Tests/MIDI2Tests.swift
+++ b/Tests/MIDI2Tests/MIDI2Tests.swift
@@ -1,0 +1,11 @@
+import XCTest
+@testable import MIDI2
+
+final class MIDI2Tests: XCTestCase {
+    func testLoadIndex() throws {
+        let index = try MIDIModelIndex.load()
+        XCTAssertFalse(index.documents.isEmpty)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/agent.md
+++ b/agent.md
@@ -46,7 +46,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | Spec↔code drift | specs & servers | Track/close gaps per service | ✅ | — | process |
 | SPS validation hooks | `sps/Sources/Validation/*`, `sps/Sources/SPSCLI/main.swift` | Add coverage + reserved-bit checks | ✅ | — | sps |
 | SPS samples & usage docs | `sps/Samples`, `docs/sps-usage-guide.md` | Provide annotated sample PDFs and usage guide with page-range queries & validation hooks | ✅ | — | docs, sps |
-| MIDI 2 library | `midi/*`, `sps/*`, `Sources/MIDI2/*` | Parse MIDI 2 spec via SPS and expose Swift Package module | 🚧 | Models generated; need package scaffolding | midi, sps, spm |
+| MIDI 2 library | `midi/*`, `sps/*`, `Sources/MIDI2/*` | Parse MIDI 2 spec via SPS and expose Swift Package module | 🚧 | Basic package scaffolding added; expand coverage | midi, sps, spm |
 
 ---
 

--- a/midi/agent.md
+++ b/midi/agent.md
@@ -23,10 +23,10 @@
 |---|---------------------------|-------------------------------------------|--------|----------|---------|--------|
 | 1 | Spec ingestion pipeline   | `midi/specs/`, `sps/*`                     | Ingest MIDI 2.0 specification documents via SPS parsing pipeline using `SPSJobQueue` for asynchronous processing | – | – | TODO |
 | 2 | Data model generation     | `midi/models/`                             | Emit normalized machine-readable models from ingested specs | – | – | TODO |
-| 3 | Swift package scaffolding | `Sources/MIDI2/*`, `Package.swift`         | Generate Swift sources for a `MIDI2` module and expose via Swift Package Manager | – | – | TODO |
-| 4 | Test suite                | `Tests/MIDI2Tests/*`                       | Provide tests covering generated MIDI 2 functionality | – | – | TODO |
+| 3 | Swift package scaffolding | `Sources/MIDI2/*`, `Package.swift`         | Generate Swift sources for a `MIDI2` module and expose via Swift Package Manager | – | Package and tests scaffolded | DONE |
+| 4 | Test suite                | `Tests/MIDI2Tests/*`                       | Provide tests covering generated MIDI 2 functionality | – | Basic index loading test added | TODO |
 | 5 | Reproducibility tooling   | `midi/*`                                   | Ensure artifacts are reproducible and regeneratable when specs change | – | – | TODO |
-| 6 | Verification              | `swift test`                               | Run full `swift test` after changes | – | – | TODO |
+| 6 | Verification              | `swift test`                               | Run full `swift test` after changes | `DNSPerformanceTests.testConcurrentQueries` failed | – | TODO |
 
 
 > © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add MIDIModelIndex and loading helper
- scaffold MIDI2 test target and hook into Package.swift
- record progress in MIDI agent manifests

## Testing
- `swift test` (fails: DNSPerformanceTests.testConcurrentQueries)

------
https://chatgpt.com/codex/tasks/task_b_689add0efdb88333be3232cc5cf01534