### PR TITLE
docs: document security sentinel consult

### DIFF
--- a/Sources/FountainOps/FountainAi/openAPI/v1/gateway.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v1/gateway.yml
@@ -37,6 +37,32 @@ paths:
                   type: integer
       security:
         - bearerAuth: []
+  /sentinel/consult:
+    post:
+      summary: Consult Security Sentinel
+      description: >
+        Sends a summary of a potentially destructive operation to the security sentinel
+        service for an allow/deny/escalate decision.
+      operationId: sentinelConsult
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SecurityCheckRequest'
+      responses:
+        '200':
+          description: Decision
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SecurityDecision'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
   /auth/token:
     post:
       summary: Issue Authentication Token
@@ -246,6 +272,29 @@ components:
         proxyEnabled:
           type: boolean
           description: Indicates if proxying to the upstream is enabled
+    SecurityCheckRequest:
+      type: object
+      required:
+        - summary
+        - user
+        - resources
+      properties:
+        summary:
+          type: string
+        user:
+          type: string
+        resources:
+          type: array
+          items:
+            type: string
+    SecurityDecision:
+      type: object
+      required:
+        - decision
+      properties:
+        decision:
+          type: string
+          enum: [allow, deny, escalate]
     ErrorResponse:
       type: object
       required:


### PR DESCRIPTION
## Summary
- document `/sentinel/consult` in gateway API
- add security check request and decision schemas

## Testing
- `swift test` *(fails: SentinelConsultHandlerTests)*

------
https://chatgpt.com/codex/tasks/task_b_68a2b0bb3c248333ada105bfd8b65146