### PR TITLE
Add chain-of-thought logging to LLM gateway

### DIFF
--- a/Sources/FountainOps/FountainAi/openAPI/v2/llm-gateway.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v2/llm-gateway.yml
@@ -41,6 +41,13 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  cot:
+                    title: Chain of Thought
+                    description: Reasoning steps produced by the model
+                    type: array
+                    items:
+                      type: string
         "422":
           description: Validation Error
           content:
@@ -102,6 +109,10 @@ components:
             - type: string
               enum: [auto]
             - $ref: '#/components/schemas/FunctionCallObject'
+        include_cot:
+          title: Include Chain of Thought
+          description: When true, reasoning steps are returned and logged
+          type: boolean
     SecurityCheckRequest:
       title: SecurityCheckRequest
       type: object

--- a/Sources/FountainOps/Generated/Client/llm-gateway/Models.swift
+++ b/Sources/FountainOps/Generated/Client/llm-gateway/Models.swift
@@ -5,6 +5,7 @@ public struct ChatRequest: Codable {
     public let functions: [FunctionObject]
     public let messages: [MessageObject]
     public let model: String
+    public let include_cot: Bool?
 }
 
 public struct FunctionCallObject: Codable {
@@ -43,7 +44,9 @@ public struct ValidationError: Codable {
 
 public typealias metrics_metrics_getResponse = [String: String]
 
-public typealias chatWithObjectiveResponse = [String: String]
+public struct chatWithObjectiveResponse: Codable {
+    public let cot: [String]?
+}
 
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/FountainOps/Generated/Server/llm-gateway/Models.swift
+++ b/Sources/FountainOps/Generated/Server/llm-gateway/Models.swift
@@ -5,6 +5,7 @@ public struct ChatRequest: Codable {
     public let functions: [FunctionObject]
     public let messages: [MessageObject]
     public let model: String
+    public let include_cot: Bool?
 }
 
 public struct FunctionCallObject: Codable {
@@ -43,7 +44,9 @@ public struct ValidationError: Codable {
 
 public typealias metrics_metrics_getResponse = [String: String]
 
-public typealias chatWithObjectiveResponse = [String: String]
+public struct chatWithObjectiveResponse: Codable {
+    public let cot: [String]?
+}
 
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/GatewayApp/CoTLogger.swift
+++ b/Sources/GatewayApp/CoTLogger.swift
@@ -1,0 +1,46 @@
+import Foundation
+import FountainCodex
+
+/// Plugin that logs chain-of-thought responses when requested.
+/// When a `/chat` request includes `include_cot: true`, any `cot`
+/// field returned in the response body is appended to a log file.
+public struct CoTLogger: GatewayPlugin {
+    private let logURL: URL
+
+    /// Creates a new logger.
+    /// - Parameter logURL: Destination file for captured reasoning steps.
+    public init(logURL: URL = URL(fileURLWithPath: "logs/cot.log")) {
+        self.logURL = logURL
+    }
+
+    /// Saves chain-of-thought steps when present and requested.
+    /// - Parameters:
+    ///   - response: Response returned from the routed handler.
+    ///   - request: Original request that may contain the `include_cot` flag.
+    /// - Returns: The unmodified response.
+    public func respond(_ response: HTTPResponse, for request: HTTPRequest) async throws -> HTTPResponse {
+        guard request.path == "/chat" else { return response }
+        guard let reqJSON = try? JSONSerialization.jsonObject(with: request.body) as? [String: Any],
+              (reqJSON["include_cot"] as? Bool) == true else { return response }
+        guard let respJSON = try? JSONSerialization.jsonObject(with: response.body) as? [String: Any],
+              let cot = respJSON["cot"] else { return response }
+        let line = "\(cot)\n"
+        do {
+            let dir = logURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            if !FileManager.default.fileExists(atPath: logURL.path) {
+                _ = FileManager.default.createFile(atPath: logURL.path, contents: nil)
+            }
+            let handle = try FileHandle(forWritingTo: logURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: Data(line.utf8))
+        } catch {
+            // ignore logging errors
+        }
+        return response
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+

--- a/Sources/GatewayApp/main.swift
+++ b/Sources/GatewayApp/main.swift
@@ -11,7 +11,7 @@ if publishingConfig == nil {
     FileHandle.standardError.write(Data("[gateway] Warning: failed to load Configuration/publishing.yml; using defaults for static content.\n".utf8))
 }
 
-let server = GatewayServer(plugins: [SecuritySentinelPlugin(), LoggingPlugin(), PublishingFrontendPlugin(rootPath: publishingConfig?.rootPath ?? "./Public")])
+let server = GatewayServer(plugins: [SecuritySentinelPlugin(), CoTLogger(), LoggingPlugin(), PublishingFrontendPlugin(rootPath: publishingConfig?.rootPath ?? "./Public")])
 Task { @MainActor in
     try await server.start(port: 8080)
 }

--- a/Tests/IntegrationRuntimeTests/CoTLoggerTests.swift
+++ b/Tests/IntegrationRuntimeTests/CoTLoggerTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import gateway_server
+@testable import FountainCodex
+
+final class CoTLoggerTests: XCTestCase {
+    /// Ensures reasoning steps are logged when include_cot is true.
+    func testLogsCoTWhenRequested() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let plugin = CoTLogger(logURL: url)
+        let reqBody = try JSONSerialization.data(withJSONObject: ["include_cot": true])
+        let request = HTTPRequest(method: "POST", path: "/chat", body: reqBody)
+        let respBody = try JSONSerialization.data(withJSONObject: ["cot": ["step1", "step2"]])
+        let response = HTTPResponse(status: 200, body: respBody)
+        _ = try await plugin.respond(response, for: request)
+        let logged = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertTrue(logged.contains("step1"))
+    }
+
+    /// Verifies no log is written when the flag is absent.
+    func testSkipsLoggingWithoutFlag() async throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let plugin = CoTLogger(logURL: url)
+        let request = HTTPRequest(method: "POST", path: "/chat")
+        let respBody = try JSONSerialization.data(withJSONObject: ["cot": ["x"]])
+        let response = HTTPResponse(status: 200, body: respBody)
+        _ = try await plugin.respond(response, for: request)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+


### PR DESCRIPTION
## Summary
- allow clients to request chain-of-thought via `include_cot`
- log CoT reasoning with new `CoTLogger` plugin and expose `cot` in responses

## Testing
- `swift test` *(fails: SentinelConsultHandlerTests)*
- `swift test --filter CoTLoggerTests`


------
https://chatgpt.com/codex/tasks/task_b_68a3426608a88333a65680991453d670