### PR TITLE
Add CoT retrieval endpoint with role-based access

### DIFF
--- a/Sources/FountainOps/FountainAi/openAPI/v2/llm-gateway.yml
+++ b/Sources/FountainOps/FountainAi/openAPI/v2/llm-gateway.yml
@@ -54,6 +54,34 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
+  /chat/{id}/cot:
+    get:
+      summary: Fetch stored Chain-of-Thought
+      operationId: getChatCoT
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Retrieved reasoning
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                  cot:
+                    type: string
+                  cot_summary:
+                    type: string
+        "404":
+          description: Not Found
+      security:
+        - bearerAuth: []
   /sentinel/consult:
     post:
       tags:

--- a/Sources/FountainOps/Generated/Server/llm-gateway/Router.swift
+++ b/Sources/FountainOps/Generated/Server/llm-gateway/Router.swift
@@ -18,6 +18,9 @@ public struct Router {
         case ("POST", "/chat"):
             let body = try? JSONDecoder().decode(ChatRequest.self, from: request.body)
             return try await handlers.chatwithobjective(request, body: body)
+        case ("GET", let path) where path.hasPrefix("/chat/") && path.hasSuffix("/cot"):
+            let body = try? JSONDecoder().decode(NoBody.self, from: request.body)
+            return try await handlers.chatcot(request, body: body)
         default:
             return HTTPResponse(status: 404)
         }

--- a/Sources/GatewayApp/AuthPlugin.swift
+++ b/Sources/GatewayApp/AuthPlugin.swift
@@ -14,7 +14,7 @@ public struct AuthPlugin: GatewayPlugin {
     ///   - store: Credential store used to verify JWTs.
     ///   - protected: Path prefixes requiring authorization.
     public init(store: CredentialStore = CredentialStore(),
-                protected: [String] = ["/metrics", "/certificates", "/routes", "/zones"]) {
+                protected: [String] = ["/metrics", "/certificates", "/routes", "/zones", "/chat/"]) {
         self.store = store
         self.protected = protected
     }
@@ -31,6 +31,10 @@ public struct AuthPlugin: GatewayPlugin {
         }
         let token = String(auth.dropFirst(7))
         guard store.verify(jwt: token) else { throw UnauthorizedError() }
+        var request = request
+        if let role = store.role(for: token) {
+            request.headers["X-User-Role"] = role
+        }
         return request
     }
 }

--- a/Sources/GatewayApp/CoTLogger.swift
+++ b/Sources/GatewayApp/CoTLogger.swift
@@ -23,8 +23,10 @@ public struct CoTLogger: GatewayPlugin {
         guard let reqJSON = try? JSONSerialization.jsonObject(with: request.body) as? [String: Any],
               (reqJSON["include_cot"] as? Bool) == true else { return response }
         guard let respJSON = try? JSONSerialization.jsonObject(with: response.body) as? [String: Any],
-              let cot = respJSON["cot"] else { return response }
-        let line = "\(cot)\n"
+              let cot = respJSON["cot"],
+              let id = respJSON["id"] as? String else { return response }
+        let entry: [String: Any] = ["id": id, "cot": sanitize(cot)]
+        guard let data = try? JSONSerialization.data(withJSONObject: entry) else { return response }
         do {
             let dir = logURL.deletingLastPathComponent()
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -34,11 +36,35 @@ public struct CoTLogger: GatewayPlugin {
             let handle = try FileHandle(forWritingTo: logURL)
             defer { try? handle.close() }
             try handle.seekToEnd()
-            try handle.write(contentsOf: Data(line.utf8))
+            try handle.write(contentsOf: data)
+            try handle.write(contentsOf: Data("\n".utf8))
         } catch {
             // ignore logging errors
         }
         return response
+    }
+
+    private func sanitize(_ value: Any) -> Any {
+        if let str = value as? String {
+            return sanitizeString(str)
+        } else if let arr = value as? [Any] {
+            return arr.map { sanitize($0) }
+        } else if let dict = value as? [String: Any] {
+            var result: [String: Any] = [:]
+            for (k, v) in dict { result[k] = sanitize(v) }
+            return result
+        } else {
+            return value
+        }
+    }
+
+    private func sanitizeString(_ input: String) -> String {
+        var output = input
+        let patterns = ["secret", "password", "api_key"]
+        for p in patterns {
+            output = output.replacingOccurrences(of: p, with: "[REDACTED]", options: .caseInsensitive)
+        }
+        return output
     }
 }
 

--- a/Tests/IntegrationRuntimeTests/CoTEndpointTests.swift
+++ b/Tests/IntegrationRuntimeTests/CoTEndpointTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import LLMGatewayService
+
+final class CoTEndpointTests: XCTestCase {
+    func testDeveloperGetsFullCoT() async throws {
+        let logURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let entry = ["id": "chat-1", "cot": "my secret plan"]
+        let data = try JSONSerialization.data(withJSONObject: entry)
+        let line = String(data: data, encoding: .utf8)! + "\n"
+        try line.write(to: logURL, atomically: true, encoding: .utf8)
+        let request = HTTPRequest(method: "GET", path: "/chat/chat-1/cot", headers: ["X-User-Role": "developer"])
+        let handlers = Handlers(cotLogURL: logURL)
+        let response = try await handlers.chatcot(request, body: nil)
+        let obj = try JSONSerialization.jsonObject(with: response.body) as? [String: Any]
+        XCTAssertEqual(obj?["cot"] as? String, "my [REDACTED] plan")
+    }
+
+    func testUserGetsSummary() async throws {
+        let logURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let entry = ["id": "chat-2", "cot": "top secret steps"]
+        let data = try JSONSerialization.data(withJSONObject: entry)
+        let line = String(data: data, encoding: .utf8)! + "\n"
+        try line.write(to: logURL, atomically: true, encoding: .utf8)
+        let request = HTTPRequest(method: "GET", path: "/chat/chat-2/cot", headers: ["X-User-Role": "user"])
+        let handlers = Handlers(cotLogURL: logURL)
+        let response = try await handlers.chatcot(request, body: nil)
+        let obj = try JSONSerialization.jsonObject(with: response.body) as? [String: Any]
+        XCTAssertNotNil(obj?["cot_summary"] as? String)
+        XCTAssertNil(obj?["cot"])
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/IntegrationRuntimeTests/CoTLoggerTests.swift
+++ b/Tests/IntegrationRuntimeTests/CoTLoggerTests.swift
@@ -9,11 +9,15 @@ final class CoTLoggerTests: XCTestCase {
         let plugin = CoTLogger(logURL: url)
         let reqBody = try JSONSerialization.data(withJSONObject: ["include_cot": true])
         let request = HTTPRequest(method: "POST", path: "/chat", body: reqBody)
-        let respBody = try JSONSerialization.data(withJSONObject: ["cot": ["step1", "step2"]])
+        let respBody = try JSONSerialization.data(withJSONObject: ["id": "chat-1", "cot": "use secret key"])
         let response = HTTPResponse(status: 200, body: respBody)
         _ = try await plugin.respond(response, for: request)
         let logged = try String(contentsOf: url, encoding: .utf8)
-        XCTAssertTrue(logged.contains("step1"))
+        let lineData = Data(logged.trimmingCharacters(in: .whitespacesAndNewlines).utf8)
+        let obj = try JSONSerialization.jsonObject(with: lineData) as? [String: Any]
+        XCTAssertEqual(obj?["id"] as? String, "chat-1")
+        let cot = obj?["cot"] as? String
+        XCTAssertEqual(cot, "use [REDACTED] key")
     }
 
     /// Verifies no log is written when the flag is absent.


### PR DESCRIPTION
## Summary
- log CoT with request id and sanitize sensitive content
- expose `GET /chat/{id}/cot` to fetch stored reasoning with role-aware access control
- extend credential and auth utilities to carry and propagate user roles

## Testing
- `swift test` *(fails: SentinelConsultHandlerTests.testEscalate, DNSEngineTests.testMetricsRecordedPerType)*
- `swift test --filter CoTLoggerTests`
- `swift test --filter CoTEndpointTests`


------
https://chatgpt.com/codex/tasks/task_b_68a34540274483339c55881f797163a4