### PR TITLE
Call Security Sentinel on risky CoT traces

### DIFF
--- a/Sources/GatewayApp/main.swift
+++ b/Sources/GatewayApp/main.swift
@@ -11,7 +11,8 @@ if publishingConfig == nil {
     FileHandle.standardError.write(Data("[gateway] Warning: failed to load Configuration/publishing.yml; using defaults for static content.\n".utf8))
 }
 
-let server = GatewayServer(plugins: [SecuritySentinelPlugin(), CoTLogger(), LoggingPlugin(), PublishingFrontendPlugin(rootPath: publishingConfig?.rootPath ?? "./Public")])
+let sentinel = SecuritySentinelPlugin()
+let server = GatewayServer(plugins: [sentinel, CoTLogger(sentinel: sentinel), LoggingPlugin(), PublishingFrontendPlugin(rootPath: publishingConfig?.rootPath ?? "./Public")])
 Task { @MainActor in
     try await server.start(port: 8080)
 }

--- a/Tests/IntegrationRuntimeTests/CoTLoggerTests.swift
+++ b/Tests/IntegrationRuntimeTests/CoTLoggerTests.swift
@@ -1,6 +1,10 @@
 import XCTest
 @testable import gateway_server
 @testable import FountainCodex
+import LLMGatewayClient
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 final class CoTLoggerTests: XCTestCase {
     /// Ensures reasoning steps are logged when include_cot is true.
@@ -29,6 +33,35 @@ final class CoTLoggerTests: XCTestCase {
         let response = HTTPResponse(status: 200, body: respBody)
         _ = try await plugin.respond(response, for: request)
         XCTAssertFalse(FileManager.default.fileExists(atPath: url.path))
+    }
+
+    /// Ensures sentinel decision is logged when risky operations appear.
+    func testLogsSentinelDecisionForRiskyCoT() async throws {
+        let cotURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let sentinelLog = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+
+        struct StubSession: HTTPSession {
+            func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+                let body = "{\"decision\":\"deny\"}".data(using: .utf8)!
+                let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+                return (body, response)
+            }
+        }
+
+        let client = APIClient(baseURL: URL(string: "http://example.com")!, session: StubSession())
+        let sentinel = SecuritySentinelPlugin(client: client, logURL: sentinelLog)
+        let plugin = CoTLogger(logURL: cotURL, sentinel: sentinel)
+
+        let reqBody = try JSONSerialization.data(withJSONObject: ["include_cot": true])
+        let request = HTTPRequest(method: "POST", path: "/chat", body: reqBody)
+        let respBody = try JSONSerialization.data(withJSONObject: ["id": "chat-2", "cot": "delete file.txt"])
+        let response = HTTPResponse(status: 200, body: respBody)
+        _ = try await plugin.respond(response, for: request)
+
+        let logged = try String(contentsOf: cotURL, encoding: .utf8)
+        let lineData = Data(logged.trimmingCharacters(in: .whitespacesAndNewlines).utf8)
+        let obj = try JSONSerialization.jsonObject(with: lineData) as? [String: Any]
+        XCTAssertEqual(obj?["sentinel_decision"] as? String, "deny")
     }
 }
 


### PR DESCRIPTION
## Summary
- expose SecuritySentinelPlugin consult helper and reuse in request pipeline
- invoke sentinel from CoTLogger when CoT text contains risky operations and log decision
- wire up shared sentinel instance in main server
- test logging of sentinel decisions for risky CoT traces

## Testing
- `swift test` *(fails: process did not complete due to resource limits)*

------
https://chatgpt.com/codex/tasks/task_b_68a34951ce748333b5250fc941b37a4c