### PR TITLE
Ensure LLMGateway service is available to integration tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -99,7 +99,7 @@ var targets: [Target] = [
     .testTarget(name: "DNSTests", dependencies: ["PublishingFrontend", "FountainCodex", .product(name: "Crypto", package: "swift-crypto"), .product(name: "NIOEmbedded", package: "swift-nio"), .product(name: "NIO", package: "swift-nio")], path: "Tests/DNSTests"),
     .testTarget(
         name: "IntegrationRuntimeTests",
-        dependencies: ["gateway-server", "FountainCodex"],
+        dependencies: ["gateway-server", "FountainCodex", "LLMGatewayService"],
         path: "Tests/IntegrationRuntimeTests",
         resources: [.process("Fixtures")]
     ),


### PR DESCRIPTION
## Summary
- allow IntegrationRuntimeTests to import `LLMGatewayService`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68a33f9be85c8333950a5950c4f091a5