### PR TITLE
Add security components to Architecture Pillars

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ FountainAI assembles a family of Swift services that work together to run a secu
 - **FountainCodex** – Libraries for loading OpenAPI specs and emitting Swift clients and servers, powering both gateway and publishing services.
 - **PublishingFrontend** – Static file host for generated documentation and artifacts, configured through YAML in `Configuration/`.
 - **FountainAiLauncher** – A minimal supervisor binary that starts and watches other services; it is an entrypoint, not the core architecture.
+- **Security Components** – Harden the platform with `AuthPlugin`, `SecuritySentinelPlugin`, `CoTLogger`, and route rate limiting. For configuration details, refer to the [GatewayApp README](Sources/GatewayApp/README.md) and [security docs](SECURITY/README.md).
 
 ## Security Architecture
 

--- a/Sources/FountainOps/Generated/Server/llm-gateway/Handlers.swift
+++ b/Sources/FountainOps/Generated/Server/llm-gateway/Handlers.swift
@@ -6,8 +6,11 @@ import ServiceShared
 
 public struct Handlers {
     private let cotLogURL: URL
-    public init(cotLogURL: URL = URL(fileURLWithPath: "logs/cot.log")) {
+    private let session: URLSession
+
+    public init(cotLogURL: URL = URL(fileURLWithPath: "logs/cot.log"), session: URLSession = .shared) {
         self.cotLogURL = cotLogURL
+        self.session = session
     }
     public func metricsMetricsGet(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
         let text = await PrometheusAdapter.shared.exposition()
@@ -32,7 +35,7 @@ public struct Handlers {
         urlRequest.httpBody = data
         urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
         urlRequest.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        let (respData, _) = try await URLSession.shared.data(for: urlRequest)
+        let (respData, _) = try await session.data(for: urlRequest)
         struct OpenAIResponse: Decodable {
             struct Choice: Decodable {
                 struct Message: Decodable { let content: String }


### PR DESCRIPTION
## Summary
- highlight AuthPlugin, SecuritySentinelPlugin, CoTLogger, and route rate limiting as security components
- link to GatewayApp README and security docs for configuration details
- allow Handlers to inject custom URLSession for stubbing and update tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68a359576b3c83338f39cadb5911ff16