### PR TITLE
feat: plugin-based rate limiting with per-user buckets

### DIFF
--- a/Configuration/gateway.yml
+++ b/Configuration/gateway.yml
@@ -2,5 +2,6 @@ domain: gateway.fountain.coach
 certificatePath: /var/lib/gateway/certs/live/gateway.fountain.coach/fullchain.pem
 privateKeyPath: /var/lib/gateway/certs/live/gateway.fountain.coach/privkey.pem
 renewIntervalHours: 12
+rateLimitPerMinute: 60
 
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Package.swift
+++ b/Package.swift
@@ -39,7 +39,8 @@ var targets: [Target] = [
             "PublishingFrontend",
             "LLMGatewayClient",
             .product(name: "Crypto", package: "swift-crypto"),
-            .product(name: "X509", package: "swift-certificates")
+            .product(name: "X509", package: "swift-certificates"),
+            "Yams"
         ],
         path: "Sources/GatewayApp",
         exclude: ["README.md"]

--- a/Sources/GatewayApp/CredentialStore.swift
+++ b/Sources/GatewayApp/CredentialStore.swift
@@ -73,6 +73,15 @@ public struct CredentialStore: @unchecked Sendable {
               let payload = try? JSONDecoder().decode(JWTPayload.self, from: payloadData) else { return nil }
         return payload.role
     }
+
+    /// Extracts the subject claim from a verified JWT.
+    public func subject(for jwt: String) -> String? {
+        let segments = jwt.split(separator: ".")
+        guard segments.count == 3,
+              let payloadData = Data(base64URLEncoded: String(segments[1])),
+              let payload = try? JSONDecoder().decode(JWTPayload.self, from: payloadData) else { return nil }
+        return payload.sub
+    }
 }
 
 private struct JWTHeader: Encodable { let alg = "HS256"; let typ = "JWT" }

--- a/Sources/GatewayApp/GatewayConfig.swift
+++ b/Sources/GatewayApp/GatewayConfig.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Yams
+
+/// Configuration for the gateway server.
+public struct GatewayConfig: Codable {
+    /// Default per-client limit when routes omit an explicit value.
+    public var rateLimitPerMinute: Int
+
+    public init(rateLimitPerMinute: Int = 60) {
+        self.rateLimitPerMinute = rateLimitPerMinute
+    }
+}
+
+/// Loads gateway configuration from `Configuration/gateway.yml`.
+/// Lines beginning with a copyright symbol are ignored to keep YAML parseable.
+public func loadGatewayConfig() throws -> GatewayConfig {
+    let url = URL(fileURLWithPath: "Configuration/gateway.yml")
+    let raw = try String(contentsOf: url, encoding: .utf8)
+    let sanitized = raw
+        .split(separator: "\n", omittingEmptySubsequences: false)
+        .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("©") }
+        .joined(separator: "\n")
+    let yaml = try Yams.load(yaml: sanitized) as? [String: Any] ?? [:]
+    let defaults: [String: Any] = ["rateLimitPerMinute": 60]
+    let merged = defaults.merging(yaml) { _, new in new }
+    let data = try JSONSerialization.data(withJSONObject: merged)
+    return try JSONDecoder().decode(GatewayConfig.self, from: data)
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/GatewayApp/RateLimiterPlugin.swift
+++ b/Sources/GatewayApp/RateLimiterPlugin.swift
@@ -1,0 +1,55 @@
+import Foundation
+import FountainCodex
+
+/// Plugin implementing a token bucket rate limiter with per-client buckets.
+public final actor RateLimiterPlugin: GatewayPlugin {
+    private struct Bucket { var tokens: Double; var lastRefill: TimeInterval; let capacity: Double; let rate: Double }
+    private var buckets: [String: Bucket] = [:]
+    private var allowed = 0
+    private var throttled = 0
+    private let defaultLimit: Int
+
+    /// Creates a new rate limiter plugin.
+    /// - Parameter defaultLimit: Fallback limit per minute when a route lacks an explicit limit.
+    public init(defaultLimit: Int = 60) {
+        self.defaultLimit = defaultLimit
+    }
+
+    /// Returns accumulated allowed and throttled counts.
+    public func stats() -> (allowed: Int, throttled: Int) { (allowed, throttled) }
+
+    /// Checks and consumes a token for the given route and client.
+    /// - Parameters:
+    ///   - routeId: Identifier of the route being accessed.
+    ///   - clientId: Authenticated subject or API key. "anonymous" when unavailable.
+    ///   - limitPerMinute: Optional override limit for this specific route.
+    /// - Returns: ``true`` if the request should proceed, ``false`` when throttled.
+    public func allow(routeId: String, clientId: String, limitPerMinute: Int?) -> Bool {
+        let limit = limitPerMinute ?? defaultLimit
+        if limit <= 0 {
+            allowed += 1
+            Task { await DNSMetrics.shared.recordRateLimit(allowed: true) }
+            return true
+        }
+        let key = "\(routeId)#\(clientId)"
+        let ratePerSecond = Double(limit) / 60.0
+        let now = Date().timeIntervalSince1970
+        var bucket = buckets[key] ?? Bucket(tokens: Double(limit), lastRefill: now, capacity: Double(limit), rate: ratePerSecond)
+        let elapsed = max(0, now - bucket.lastRefill)
+        bucket.tokens = min(bucket.capacity, bucket.tokens + elapsed * bucket.rate)
+        bucket.lastRefill = now
+        if bucket.tokens >= 1.0 {
+            bucket.tokens -= 1.0
+            buckets[key] = bucket
+            allowed += 1
+            Task { await DNSMetrics.shared.recordRateLimit(allowed: true) }
+            return true
+        }
+        buckets[key] = bucket
+        throttled += 1
+        Task { await DNSMetrics.shared.recordRateLimit(allowed: false) }
+        return false
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/IntegrationRuntimeTests/GatewayServerTests.swift
+++ b/Tests/IntegrationRuntimeTests/GatewayServerTests.swift
@@ -45,7 +45,8 @@ final class GatewayServerTests: XCTestCase {
     @MainActor
     func testRenewCertificateReturnsConfirmation() async throws {
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let server = GatewayServer(manager: manager, plugins: [])
+        let rl = RateLimiterPlugin()
+        let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9125) }
         try await Task.sleep(nanoseconds: 100_000_000)
         var request = URLRequest(url: URL(string: "http://127.0.0.1:9125/certificates/renew")!)
@@ -157,7 +158,8 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
     /// Unknown paths should yield a `404` status.
     func testUnknownPathReturns404() async throws {
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let server = GatewayServer(manager: manager, plugins: [])
+        let rl = RateLimiterPlugin()
+        let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9103) }
         try await Task.sleep(nanoseconds: 100_000_000)
         let url = URL(string: "http://127.0.0.1:9103/unknown")!
@@ -234,7 +236,8 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
     /// Health endpoint should emit the JSON content type header.
     func testHealthEndpointSetsJSONContentType() async throws {
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let server = GatewayServer(manager: manager, plugins: [])
+        let rl = RateLimiterPlugin()
+        let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9106) }
         try await Task.sleep(nanoseconds: 100_000_000)
         let url = URL(string: "http://127.0.0.1:9106/health")!
@@ -248,7 +251,8 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
     /// Metrics endpoint should emit the JSON content type header.
     func testMetricsEndpointSetsJSONContentType() async throws {
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let server = GatewayServer(manager: manager, plugins: [])
+        let rl = RateLimiterPlugin()
+        let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9107) }
         try await Task.sleep(nanoseconds: 100_000_000)
         let url = URL(string: "http://127.0.0.1:9107/metrics")!
@@ -263,7 +267,8 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
     func testMetricsEndpointReturnsZeroCounters() async throws {
         await DNSMetrics.shared.reset()
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let server = GatewayServer(manager: manager, plugins: [])
+        let rl = RateLimiterPlugin()
+        let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9108) }
         try await Task.sleep(nanoseconds: 100_000_000)
         let url = URL(string: "http://127.0.0.1:9108/metrics")!
@@ -327,7 +332,8 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
     @MainActor
     func testZonesRequireManager() async throws {
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let server = GatewayServer(manager: manager, plugins: [])
+        let rl = RateLimiterPlugin()
+        let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9131) }
         try await Task.sleep(nanoseconds: 100_000_000)
         let url = URL(string: "http://127.0.0.1:9131/zones")!
@@ -420,7 +426,8 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
         setenv("GATEWAY_ROLE_admin", "admin", 1)
         setenv("GATEWAY_JWT_SECRET", "topsecret", 1)
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let server = GatewayServer(manager: manager, plugins: [])
+        let rl = RateLimiterPlugin()
+        let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9113) }
         try await Task.sleep(nanoseconds: 100_000_000)
         let base = URL(string: "http://127.0.0.1:9113")!
@@ -485,7 +492,8 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
     @MainActor
     func testRoutesCRUD() async throws {
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let server = GatewayServer(manager: manager, plugins: [])
+        let rl = RateLimiterPlugin()
+        let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9114) }
         try await Task.sleep(nanoseconds: 100_000_000)
         let base = URL(string: "http://127.0.0.1:9114")!
@@ -594,7 +602,8 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
         let upstreamPort = try await upstream.start(port: 0)
 
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let server = GatewayServer(manager: manager, plugins: [])
+        let rl = RateLimiterPlugin()
+        let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9116) }
         try await Task.sleep(nanoseconds: 500_000_000)
 
@@ -625,7 +634,8 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
         let upstreamPort = try await upstream.start(port: 0)
 
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let server = GatewayServer(manager: manager, plugins: [])
+        let rl = RateLimiterPlugin()
+        let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9120) }
         try await Task.sleep(nanoseconds: 500_000_000)
 


### PR DESCRIPTION
## Summary
- add `RateLimiterPlugin` for per-identity token buckets and metrics
- load rate-limit defaults from gateway config
- wire plugin into gateway server and tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68a368129d908333931660946d17f3d8