### PR TITLE
Add DestructiveGuardianPlugin requiring approval or tokens

### DIFF
--- a/Sources/GatewayApp/DestructiveGuardianPlugin.swift
+++ b/Sources/GatewayApp/DestructiveGuardianPlugin.swift
@@ -1,0 +1,64 @@
+import Foundation
+import FountainCodex
+
+/// Plugin that blocks destructive requests unless manually approved or authorized via service token.
+public struct DestructiveGuardianPlugin: GatewayPlugin {
+    private let sensitivePaths: [String]
+    private let privilegedTokens: Set<String>
+    private let auditURL: URL
+
+    /// Creates a new guardian plugin.
+    /// - Parameters:
+    ///   - sensitivePaths: Paths requiring additional authorization.
+    ///   - privilegedTokens: Service tokens allowing bypass.
+    ///   - auditURL: Destination file for the immutable audit trail.
+    public init(sensitivePaths: [String] = ["/"],
+                privilegedTokens: [String] = [],
+                auditURL: URL = URL(fileURLWithPath: "logs/guardian.log")) {
+        self.sensitivePaths = sensitivePaths
+        self.privilegedTokens = Set(privilegedTokens)
+        self.auditURL = auditURL
+    }
+
+    /// Inspects incoming requests and enforces manual approval or token authorization.
+    /// - Parameter request: The request to evaluate.
+    /// - Returns: The original request if authorized.
+    public func prepare(_ request: HTTPRequest) async throws -> HTTPRequest {
+        guard isProtected(request) else { return request }
+        let manual = request.headers["X-Manual-Approval"] != nil
+        let token = request.headers["X-Service-Token"]
+        let tokenValid = token.map { privilegedTokens.contains($0) } ?? false
+        let allowed = manual || tokenValid
+        log(request: request, allowed: allowed, reason: manual ? "manual" : tokenValid ? "token" : "missing")
+        guard allowed else { throw GuardianDeniedError() }
+        return request
+    }
+
+    private func isProtected(_ request: HTTPRequest) -> Bool {
+        let method = request.method.uppercased()
+        guard ["DELETE", "PUT", "PATCH"].contains(method) else { return false }
+        return sensitivePaths.contains { request.path.hasPrefix($0) }
+    }
+
+    private func log(request: HTTPRequest, allowed: Bool, reason: String) {
+        let line = "\(request.method) \(request.path) -> \(allowed ? "allow" : "deny") [\(reason)]\n"
+        do {
+            let dir = auditURL.deletingLastPathComponent()
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            if !FileManager.default.fileExists(atPath: auditURL.path) {
+                _ = FileManager.default.createFile(atPath: auditURL.path, contents: nil)
+            }
+            let handle = try FileHandle(forWritingTo: auditURL)
+            defer { try? handle.close() }
+            try handle.seekToEnd()
+            try handle.write(contentsOf: Data(line.utf8))
+        } catch {
+            // ignore audit logging errors
+        }
+    }
+}
+
+/// Error thrown when a destructive request lacks authorization.
+public struct GuardianDeniedError: Error {}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/GatewayAppTests/DestructiveGuardianPluginTests.swift
+++ b/Tests/GatewayAppTests/DestructiveGuardianPluginTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+import Foundation
+@testable import gateway_server
+import FountainCodex
+
+final class DestructiveGuardianPluginTests: XCTestCase {
+    private func makePlugin(logURL: URL, tokens: [String] = []) -> DestructiveGuardianPlugin {
+        DestructiveGuardianPlugin(sensitivePaths: ["/secret"], privilegedTokens: tokens, auditURL: logURL)
+    }
+
+    func testDeniesWithoutApproval() async throws {
+        let logURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let plugin = makePlugin(logURL: logURL, tokens: ["t1"])
+        let request = HTTPRequest(method: "DELETE", path: "/secret")
+        do {
+            _ = try await plugin.prepare(request)
+            XCTFail("expected deny")
+        } catch is GuardianDeniedError {
+            let log = try String(contentsOf: logURL, encoding: .utf8)
+            XCTAssertTrue(log.contains("deny"))
+        }
+    }
+
+    func testAllowsWithManualApproval() async throws {
+        let logURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let plugin = makePlugin(logURL: logURL)
+        var request = HTTPRequest(method: "PUT", path: "/secret")
+        request.headers["X-Manual-Approval"] = "ok"
+        _ = try await plugin.prepare(request)
+        let log = try String(contentsOf: logURL, encoding: .utf8)
+        XCTAssertTrue(log.contains("allow"))
+    }
+
+    func testAllowsWithServiceToken() async throws {
+        let logURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let plugin = makePlugin(logURL: logURL, tokens: ["abc"])
+        var request = HTTPRequest(method: "PATCH", path: "/secret")
+        request.headers["X-Service-Token"] = "abc"
+        _ = try await plugin.prepare(request)
+        let log = try String(contentsOf: logURL, encoding: .utf8)
+        XCTAssertTrue(log.contains("allow"))
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/agent.md
+++ b/agent.md
@@ -35,6 +35,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | Typesense API | `openAPI/typesense.yml` | Decide proxy vs native subset | ✅ | — | server, design |
 | Static site | `Sources/PublishingFrontend/*`, `Configuration/publishing.yml` | Serve docs/static; keep defaults | ✅ | — | server, docs |
 | Gateway plugins | `LoggingPlugin`, `PublishingFrontendPlugin` | Keep logging & HTML fallback | ✅ | — | server |
+| DestructiveGuardianPlugin | `Sources/GatewayApp/DestructiveGuardianPlugin.swift` | Guard destructive ops w/ approval or tokens | ✅ | — | server, security |
 | Certificate renewal | `Sources/GatewayApp/CertificateManager.swift` | Schedule/trigger renewal | ✅ | — | ops, tls |
 | DNSSEC | `Sources/FountainCodex/DNSSECSigner.swift` | Integrate signer into engine | ✅ | — | security, dns |
 | Metrics & logging | `GatewayServer`, `DNSMetrics` | Expose Prometheus-style metrics | ✅ | — | observability |

--- a/logs/agent-20250818181235.log
+++ b/logs/agent-20250818181235.log
@@ -1,0 +1,2 @@
+[PR-TBD] Added DestructiveGuardianPlugin enforcing approvals for destructive requests.
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- enforce manual approval or privileged tokens for destructive HTTP requests
- log allow/deny decisions to an append-only audit trail
- document plugin in repository task matrix and tests for approval/token paths

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68a36c7a05808333bdf48f1fa7680111