### PR TITLE
feat: add pre-deployment container verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
+env:
+  CONTAINER_IMAGE: ghcr.io/${{ github.repository }}:latest
+
 jobs:
   lint:
     runs-on: ubuntu-22.04
@@ -58,6 +61,17 @@ jobs:
           path: |
             coverage.lcov
             coverage-badge.svg
+      - name: Install supply chain tools
+        if: runner.os == 'Linux'
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/sigstore/cosign/main/install.sh | sudo sh -s -- -b /usr/local/bin
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sudo sh -s -- -b /usr/local/bin
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sudo sh -s -- -b /usr/local/bin
+      - name: Pre-deployment verification
+        if: runner.os == 'Linux'
+        env:
+          COSIGN_PUBLIC_KEY: ${{ secrets.COSIGN_PUBLIC_KEY }}
+        run: Scripts/predeploy.sh "$CONTAINER_IMAGE"
 
 
 # © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SECURITY/README.md
+++ b/SECURITY/README.md
@@ -57,6 +57,12 @@
 - Apply patches promptly and keep infrastructure as code under version control.
 - Isolate the model runtime (e.g., in sandboxed environments) so any compromise remains contained.
 
+## Pre-deployment Verification
+- Place the Cosign public key for container images at `SECURITY/cosign.pub`.
+- Run `Scripts/predeploy.sh <image-ref>` before releasing any container.
+- The script verifies signatures, scans dependencies with Grype, and records an SBOM via Syft in `logs/`.
+- Unsigned images or high-severity vulnerabilities cause the script to abort and block deployment.
+
 ## Roadmap Status
 
 The following recommendations remain unimplemented and are tracked for future work:

--- a/Scripts/predeploy.sh
+++ b/Scripts/predeploy.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pre-deployment verification for container images.
+# Usage: Scripts/predeploy.sh <image-ref>
+# Requires COSIGN_PUBLIC_KEY to point to the verifying key.
+# Tools: cosign, grype, syft.
+
+IMAGE="${1:-}"
+if [[ -z "$IMAGE" ]]; then
+  echo "Usage: $0 <image-ref>" >&2
+  exit 64
+fi
+
+COSIGN_KEY="${COSIGN_PUBLIC_KEY:-SECURITY/cosign.pub}"
+if [[ ! -f "$COSIGN_KEY" ]]; then
+  echo "[predeploy] Public key not found: $COSIGN_KEY" >&2
+  exit 1
+fi
+
+echo "[predeploy] Verifying signature for $IMAGE"
+cosign verify --key "$COSIGN_KEY" "$IMAGE"
+
+echo "[predeploy] Scanning for vulnerabilities"
+grype --fail-on high "$IMAGE"
+
+echo "[predeploy] Generating SBOM"
+SBOM_DIR="${SBOM_DIR:-logs}"
+mkdir -p "$SBOM_DIR"
+SBOM_FILE="$SBOM_DIR/sbom-$(echo "$IMAGE" | tr '/:' '_').json"
+syft "$IMAGE" -o json > "$SBOM_FILE"
+
+echo "[predeploy] SBOM saved to $SBOM_FILE"
+
+echo "[predeploy] All checks passed"
+
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add script to verify container signatures, scan dependencies, and generate SBOMs
- run pre-deployment verification in CI using cosign, syft, and grype
- document key placement and usage in `SECURITY/README.md`

## Testing
- `swift test`
- `bash -n Scripts/predeploy.sh`


------
https://chatgpt.com/codex/tasks/task_b_68a3759fd9a88333989bf6b2bbd889de