### PR TITLE
Add JSON logging and observability

### DIFF
--- a/FountainAIToolsmith/Sources/Toolsmith/JSONLogger.swift
+++ b/FountainAIToolsmith/Sources/Toolsmith/JSONLogger.swift
@@ -1,0 +1,43 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public struct JSONLogger {
+    public init() {}
+
+    public func log(_ entry: LogEntry) {
+        if let data = try? JSONEncoder().encode(entry), let line = String(data: data, encoding: .utf8) {
+            print(line)
+        }
+    }
+
+    public func exportSpan(_ span: Span) {
+        guard let urlString = ProcessInfo.processInfo.environment["OTEL_EXPORT_URL"],
+              let url = URL(string: urlString) else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONEncoder().encode(span)
+        URLSession.shared.dataTask(with: request).resume()
+    }
+}
+
+public struct LogEntry: Codable {
+    public let request_id: String
+    public let tool: String
+    public let duration_ms: Int
+    public let metadata: [String: String]
+}
+
+public struct Span: Codable {
+    public let trace_id: String
+    public let span_id: String
+    public let parent_id: String?
+    public let name: String
+    public let start: Date
+    public let end: Date
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+

--- a/FountainAIToolsmith/Sources/Toolsmith/Toolsmith.swift
+++ b/FountainAIToolsmith/Sources/Toolsmith/Toolsmith.swift
@@ -1,5 +1,27 @@
+import Foundation
+
 public struct Toolsmith {
+    let logger = JSONLogger()
+
     public init() {}
+
+    @discardableResult
+    public func run(tool: String, metadata: [String: String] = [:], requestID: String = UUID().uuidString, operation: () throws -> Void) rethrows -> String {
+        let start = Date()
+        try operation()
+        let end = Date()
+        let duration = Int(end.timeIntervalSince(start) * 1000)
+        var meta = metadata
+        if ProcessInfo.processInfo.environment["OTEL_EXPORT_URL"] != nil {
+            let spanID = UUID().uuidString
+            let span = Span(trace_id: requestID, span_id: spanID, parent_id: nil, name: tool, start: start, end: end)
+            logger.exportSpan(span)
+            meta["span_id"] = spanID
+        }
+        let entry = LogEntry(request_id: requestID, tool: tool, duration_ms: duration, metadata: meta)
+        logger.log(entry)
+        return requestID
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAIToolsmith/Sources/toolsmith-cli/main.swift
+++ b/FountainAIToolsmith/Sources/toolsmith-cli/main.swift
@@ -3,7 +3,11 @@ import Toolsmith
 @main
 struct ToolsmithCLI {
     static func main() {
-        print("Toolsmith CLI")
+        let args = Array(CommandLine.arguments.dropFirst())
+        let toolsmith = Toolsmith()
+        _ = toolsmith.run(tool: "toolsmith-cli", metadata: ["args": args.joined(separator: " ")]) {
+            print("Toolsmith CLI")
+        }
     }
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -107,7 +107,7 @@ var targets: [Target] = [
         name: "tools-factory-server",
         dependencies: ["ToolServer"],
         path: "Sources/ToolServer",
-        exclude: ["Dockerfile", "Service", "Adapters", "Router.swift", "Validation.swift", "SandboxPolicy.swift", "HTTPTypes.swift", "openapi.yaml"],
+        exclude: ["Dockerfile", "Service", "Adapters", "Router.swift", "Validation.swift", "SandboxPolicy.swift", "HTTPTypes.swift", "openapi.yaml", "JSONLogger.swift"],
         sources: ["main.swift"]
     ),
     .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainCodex"], path: "Tests/ClientGeneratorTests"),

--- a/Sources/ToolServer/JSONLogger.swift
+++ b/Sources/ToolServer/JSONLogger.swift
@@ -1,0 +1,41 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+struct JSONLogger {
+    func log(_ entry: LogEntry) {
+        if let data = try? JSONEncoder().encode(entry), let line = String(data: data, encoding: .utf8) {
+            print(line)
+        }
+    }
+
+    func exportSpan(_ span: Span) {
+        guard let urlString = ProcessInfo.processInfo.environment["OTEL_EXPORT_URL"],
+              let url = URL(string: urlString) else { return }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try? JSONEncoder().encode(span)
+        URLSession.shared.dataTask(with: request).resume()
+    }
+}
+
+struct LogEntry: Codable {
+    let request_id: String
+    let tool: String
+    let duration_ms: Int
+    let metadata: [String: String]
+}
+
+struct Span: Codable {
+    let trace_id: String
+    let span_id: String
+    let parent_id: String?
+    let name: String
+    let start: Date
+    let end: Date
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+

--- a/Sources/ToolServer/Router.swift
+++ b/Sources/ToolServer/Router.swift
@@ -15,10 +15,22 @@ public struct Router {
     }
 
     public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
-        if request.method == "GET" && request.path == "/openapi.yaml" {
-            let url = URL(fileURLWithPath: "Sources/ToolServer/openapi.yaml")
-            let data = try Data(contentsOf: url)
-            return HTTPResponse(status: 200, headers: ["Content-Type": "application/yaml"], body: data)
+        if request.method == "GET" {
+            switch request.path {
+            case "/openapi.yaml":
+                let url = URL(fileURLWithPath: "Sources/ToolServer/openapi.yaml")
+                let data = try Data(contentsOf: url)
+                return HTTPResponse(status: 200, headers: ["Content-Type": "application/yaml"], body: data)
+            case "/_health":
+                let data = Data("{\"status\":\"ok\"}".utf8)
+                return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+            case "/metrics":
+                let uptime = Int(ProcessInfo.processInfo.systemUptime)
+                let body = Data("uptime_seconds \(uptime)\n".utf8)
+                return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: body)
+            default:
+                break
+            }
         }
 
         guard request.method == "POST" else { return HTTPResponse(status: 405) }
@@ -29,10 +41,19 @@ public struct Router {
         try validator.validate(args: payload.args)
         let start = Date()
         let (output, code) = try adapter.run(args: payload.args)
-        let duration = Int(Date().timeIntervalSince(start) * 1000)
+        let end = Date()
+        let duration = Int(end.timeIntervalSince(start) * 1000)
         let hash = SHA256.hash(data: Data(payload.args.joined(separator: " ").utf8)).compactMap { String(format: "%02x", $0) }.joined()
-        let log = LogEntry(request_id: payload.request_id ?? UUID().uuidString, tool: adapter.tool, args_hash: hash, duration_ms: duration, exit_code: code)
-        if let logData = try? JSONEncoder().encode(log) { print(String(data: logData, encoding: .utf8)!) }
+        var metadata = ["args_hash": hash, "exit_code": String(code)]
+        let logger = JSONLogger()
+        if let trace = request.headers["X-Trace-ID"] {
+            let spanID = UUID().uuidString
+            let span = Span(trace_id: trace, span_id: spanID, parent_id: request.headers["X-Span-ID"], name: adapter.tool, start: start, end: end)
+            logger.exportSpan(span)
+            metadata["span_id"] = spanID
+        }
+        let log = LogEntry(request_id: payload.request_id ?? UUID().uuidString, tool: adapter.tool, duration_ms: duration, metadata: metadata)
+        logger.log(log)
         return HTTPResponse(status: Int(code == 0 ? 200 : 500), body: output)
     }
 }
@@ -40,14 +61,6 @@ public struct Router {
 public struct ToolRequest: Codable {
     public let args: [String]
     public let request_id: String?
-}
-
-public struct LogEntry: Codable {
-    let request_id: String
-    let tool: String
-    let args_hash: String
-    let duration_ms: Int
-    let exit_code: Int32
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add lightweight JSON logger with optional OpenTelemetry span export
- tag Toolsmith and ToolServer logs with request IDs, tool metadata, and timing info
- expose `/metrics` and `/_health` endpoints in ToolServer

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68a49ac8d2488333860ac810718bfae6