### PR TITLE
Load sandbox manifest and verify checksums

### DIFF
--- a/FountainAIToolsmith/Package.swift
+++ b/FountainAIToolsmith/Package.swift
@@ -12,13 +12,16 @@ let package = Package(
         .library(name: "ToolsmithAPI", targets: ["ToolsmithAPI"]),
         .executable(name: "toolsmith-cli", targets: ["toolsmith-cli"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0")
+    ],
     targets: [
-        .target(name: "Toolsmith", dependencies: []),
-        .target(name: "SandboxRunner", dependencies: [], resources: [.process("Profiles")]),
+        .target(name: "ToolsmithSupport", dependencies: [.product(name: "Crypto", package: "swift-crypto")]),
+        .target(name: "Toolsmith", dependencies: ["ToolsmithSupport"]),
+        .target(name: "SandboxRunner", dependencies: ["ToolsmithSupport"], resources: [.process("Profiles")]),
         .target(name: "ToolsmithAPI", dependencies: []),
         .executableTarget(name: "toolsmith-cli", dependencies: ["Toolsmith"]),
-        .testTarget(name: "SandboxRunnerTests", dependencies: ["SandboxRunner"])
+        .testTarget(name: "SandboxRunnerTests", dependencies: ["SandboxRunner", "Toolsmith", "ToolsmithSupport"])
     ]
 )
 

--- a/FountainAIToolsmith/Sources/SandboxRunner/QemuRunner.swift
+++ b/FountainAIToolsmith/Sources/SandboxRunner/QemuRunner.swift
@@ -1,14 +1,18 @@
 import Foundation
+import ToolsmithSupport
 
 public final class QemuRunner: SandboxRunner {
     private let qemu: URL
     private let image: URL
+    private let manifest: ToolManifest?
     public private(set) var forwardedPort: UInt16?
 
     public init(qemu: URL = URL(fileURLWithPath: "/usr/bin/qemu-system-x86_64"),
-                image: URL) {
+                image: URL,
+                manifest: ToolManifest? = nil) {
         self.qemu = qemu
         self.image = image
+        self.manifest = manifest
     }
 
     @discardableResult
@@ -24,6 +28,9 @@ public final class QemuRunner: SandboxRunner {
         _ = inputs
         _ = limits
         try guardWritePaths(arguments: arguments, workDirectory: workDirectory)
+        if let manifest = manifest {
+            try manifest.verify(fileAt: image)
+        }
         var args: [String] = []
         #if os(macOS)
         args += ["-accel", "hvf"]

--- a/FountainAIToolsmith/Sources/Toolsmith/Toolsmith.swift
+++ b/FountainAIToolsmith/Sources/Toolsmith/Toolsmith.swift
@@ -1,9 +1,14 @@
 import Foundation
+import ToolsmithSupport
 
 public struct Toolsmith {
     let logger = JSONLogger()
+    public let manifest: ToolManifest?
 
-    public init() {}
+    public init(imageDirectory: URL = URL(fileURLWithPath: ".")) {
+        let manifestURL = imageDirectory.appendingPathComponent("tools.json")
+        self.manifest = try? ToolManifest.load(from: manifestURL)
+    }
 
     @discardableResult
     public func run(tool: String, metadata: [String: String] = [:], requestID: String = UUID().uuidString, operation: () throws -> Void) rethrows -> String {

--- a/FountainAIToolsmith/Sources/ToolsmithSupport/ToolManifest.swift
+++ b/FountainAIToolsmith/Sources/ToolsmithSupport/ToolManifest.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Crypto
+
+public struct ToolManifest: Codable {
+    public struct Image: Codable {
+        public let name: String
+        public let tarball: String
+        public let sha256: String
+        public let qcow2: String
+        public let qcow2_sha256: String
+
+        public init(name: String, tarball: String, sha256: String, qcow2: String, qcow2_sha256: String) {
+            self.name = name
+            self.tarball = tarball
+            self.sha256 = sha256
+            self.qcow2 = qcow2
+            self.qcow2_sha256 = qcow2_sha256
+        }
+    }
+    public let image: Image
+    public let tools: [String: String]
+    public let operations: [String]
+
+    public init(image: Image, tools: [String: String], operations: [String]) {
+        self.image = image
+        self.tools = tools
+        self.operations = operations
+    }
+
+    public enum ManifestError: Error, Equatable {
+        case imageNotListed
+        case checksumMismatch(expected: String, actual: String)
+    }
+
+    public static func load(from url: URL) throws -> ToolManifest {
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(ToolManifest.self, from: data)
+    }
+
+    public static func sha256(of url: URL) throws -> String {
+        let data = try Data(contentsOf: url)
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+
+    public func verify(fileAt url: URL) throws {
+        let name = url.lastPathComponent
+        let expected: String?
+        if name == image.qcow2 {
+            expected = image.qcow2_sha256
+        } else if name == image.tarball {
+            expected = image.sha256
+        } else {
+            expected = nil
+        }
+        guard let exp = expected else { throw ManifestError.imageNotListed }
+        let actual = try Self.sha256(of: url)
+        guard actual == exp else { throw ManifestError.checksumMismatch(expected: exp, actual: actual) }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/FountainAIToolsmith/Tests/SandboxRunnerTests/ManifestChecksumTests.swift
+++ b/FountainAIToolsmith/Tests/SandboxRunnerTests/ManifestChecksumTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import Toolsmith
+@testable import SandboxRunner
+import ToolsmithSupport
+
+final class ManifestChecksumTests: XCTestCase {
+    func testChecksumMismatchDetection() throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        let image = dir.appendingPathComponent("test.qcow2")
+        try Data("hello".utf8).write(to: image)
+        let correctSha = try ToolManifest.sha256(of: image)
+        let badManifest = ToolManifest(image: .init(name: "img", tarball: "img.tar.gz", sha256: "dead", qcow2: "test.qcow2", qcow2_sha256: "bad"), tools: [:], operations: [])
+        XCTAssertThrowsError(try badManifest.verify(fileAt: image))
+        let goodManifest = ToolManifest(image: .init(name: "img", tarball: "img.tar.gz", sha256: "dead", qcow2: "test.qcow2", qcow2_sha256: correctSha), tools: [:], operations: [])
+        XCTAssertNoThrow(try goodManifest.verify(fileAt: image))
+    }
+
+    func testToolsmithLoadsManifest() throws {
+        let fm = FileManager.default
+        let dir = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+        let manifest = ToolManifest(image: .init(name: "img", tarball: "t.tar.gz", sha256: "a", qcow2: "q.qcow2", qcow2_sha256: "b"), tools: ["swift": "v"], operations: ["swiftc"])
+        let data = try JSONEncoder().encode(manifest)
+        try data.write(to: dir.appendingPathComponent("tools.json"))
+        let toolsmith = Toolsmith(imageDirectory: dir)
+        XCTAssertEqual(toolsmith.manifest?.image.name, "img")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Package.swift
+++ b/Package.swift
@@ -107,7 +107,7 @@ var targets: [Target] = [
         name: "tools-factory-server",
         dependencies: ["ToolServer"],
         path: "Sources/ToolServer",
-        exclude: ["Dockerfile", "Service", "Adapters", "Router.swift", "Validation.swift", "SandboxPolicy.swift", "HTTPTypes.swift", "openapi.yaml", "JSONLogger.swift"],
+        exclude: ["Dockerfile", "Service", "Adapters", "Router.swift", "Validation.swift", "SandboxPolicy.swift", "HTTPTypes.swift", "openapi.yaml", "JSONLogger.swift", "ToolManifest.swift"],
         sources: ["main.swift"]
     ),
     .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainCodex"], path: "Tests/ClientGeneratorTests"),
@@ -125,7 +125,8 @@ var targets: [Target] = [
     .testTarget(name: "MIDI2TransportsTests", dependencies: ["MIDI2Transports"], path: "Tests/MIDI2TransportsTests"),
     .testTarget(name: "FlexctlTests", dependencies: ["flexctl", "ResourceLoader"], path: "Tests/FlexctlTests"),
     .testTarget(name: "GatewayAppTests", dependencies: ["gateway-server", "LLMGatewayClient"], path: "Tests/GatewayAppTests"),
-    .testTarget(name: "FountainOpsTests", dependencies: ["LLMGatewayService"], path: "Tests/FountainOpsTests")
+    .testTarget(name: "FountainOpsTests", dependencies: ["LLMGatewayService"], path: "Tests/FountainOpsTests"),
+    .testTarget(name: "ToolServerTests", dependencies: ["ToolServer"], path: "Tests/ToolServerTests")
 ]
 
 #if os(Linux)

--- a/Sources/ToolServer/Router.swift
+++ b/Sources/ToolServer/Router.swift
@@ -9,9 +9,11 @@ public protocol ToolAdapter {
 public struct Router {
     let adapters: [String: ToolAdapter]
     let validator = Validation()
+    let manifest: ToolManifest
 
-    public init(adapters: [String: ToolAdapter]) {
+    public init(adapters: [String: ToolAdapter], manifest: ToolManifest) {
         self.adapters = adapters
+        self.manifest = manifest
     }
 
     public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
@@ -28,6 +30,9 @@ public struct Router {
                 let uptime = Int(ProcessInfo.processInfo.systemUptime)
                 let body = Data("uptime_seconds \(uptime)\n".utf8)
                 return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: body)
+            case "/manifest":
+                let data = try JSONEncoder().encode(manifest)
+                return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
             default:
                 break
             }

--- a/Sources/ToolServer/ToolManifest.swift
+++ b/Sources/ToolServer/ToolManifest.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public struct ToolManifest: Codable {
+    public struct Image: Codable {
+        public let name: String
+        public let tarball: String
+        public let sha256: String
+        public let qcow2: String
+        public let qcow2_sha256: String
+
+        public init(name: String, tarball: String, sha256: String, qcow2: String, qcow2_sha256: String) {
+            self.name = name
+            self.tarball = tarball
+            self.sha256 = sha256
+            self.qcow2 = qcow2
+            self.qcow2_sha256 = qcow2_sha256
+        }
+    }
+    public let image: Image
+    public let tools: [String: String]
+    public let operations: [String]
+
+    public init(image: Image, tools: [String: String], operations: [String]) {
+        self.image = image
+        self.tools = tools
+        self.operations = operations
+    }
+
+    public static func load(from url: URL) throws -> ToolManifest {
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(ToolManifest.self, from: data)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/main.swift
+++ b/Sources/ToolServer/main.swift
@@ -14,7 +14,9 @@ let adapters: [String: ToolAdapter] = [
     "pandoc": PandocAdapter(),
     "libplist": LibPlistAdapter()
 ]
-let router = Router(adapters: adapters)
+let manifestURL = URL(fileURLWithPath: "tools.json")
+let manifest = (try? ToolManifest.load(from: manifestURL)) ?? ToolManifest(image: .init(name: "", tarball: "", sha256: "", qcow2: "", qcow2_sha256: ""), tools: [:], operations: [])
+let router = Router(adapters: adapters, manifest: manifest)
 
 final class SimpleHTTPRuntime: @unchecked Sendable {
     enum RuntimeError: Error { case socket, bind, listen }

--- a/Tests/ToolServerTests/ManifestEndpointTests.swift
+++ b/Tests/ToolServerTests/ManifestEndpointTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+@testable import ToolServer
+
+final class ManifestEndpointTests: XCTestCase {
+    func testManifestEndpoint() async throws {
+        let manifest = ToolManifest(image: .init(name: "img", tarball: "t.tar", sha256: "a", qcow2: "q.qcow2", qcow2_sha256: "b"), tools: ["swift": "1"], operations: ["swiftc"])
+        let router = Router(adapters: [:], manifest: manifest)
+        let resp = try await router.route(HTTPRequest(method: "GET", path: "/manifest"))
+        XCTAssertEqual(resp.status, 200)
+        let decoded = try JSONDecoder().decode(ToolManifest.self, from: resp.body)
+        XCTAssertEqual(decoded.tools["swift"], "1")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- load `tools.json` manifest during Toolsmith startup
- verify sandbox image checksums before QEMU boot
- expose `/manifest` endpoint from Tool Server
- add tests for manifest handling and checksum mismatch

## Testing
- `cd FountainAIToolsmith && swift test`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68a4a08616dc8333bd8b80e8df9cb212