### PR TITLE
docs: outline toolsmith orchestration and smoke test

### DIFF
--- a/FountainAIToolsmith/Tests/SandboxRunnerTests/OrchestratorRoundTripTests.swift
+++ b/FountainAIToolsmith/Tests/SandboxRunnerTests/OrchestratorRoundTripTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+import Toolsmith
+import SandboxRunner
+
+final class OrchestratorRoundTripTests: XCTestCase {
+    func testToolsmithBwrapRoundTrip() throws {
+        try XCTSkipIf(!Self.canUseBubblewrap, "bubblewrap not functional")
+        let fm = FileManager.default
+        let work = fm.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try fm.createDirectory(at: work, withIntermediateDirectories: true)
+        let runner = BwrapRunner()
+        let toolsmith = Toolsmith()
+        var result: SandboxResult?
+        let requestID = try toolsmith.run(tool: "echo") {
+            result = try runner.run(
+                executable: "/bin/echo",
+                arguments: ["hello"],
+                inputs: [],
+                workDirectory: work,
+                allowNetwork: false,
+                timeout: 5,
+                limits: nil
+            )
+        }
+        XCTAssertFalse(requestID.isEmpty)
+        XCTAssertEqual(result?.stdout.trimmingCharacters(in: .whitespacesAndNewlines), "hello")
+        XCTAssertEqual(result?.exitCode, 0)
+    }
+
+    private static let canUseBubblewrap: Bool = {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/bwrap")
+        process.arguments = ["--ro-bind", "/", "/", "/bin/true"]
+        do {
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus == 0
+        } catch {
+            return false
+        }
+    }()
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Scripts/toolsmith-smoke-test.sh
+++ b/Scripts/toolsmith-smoke-test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+swift test --package-path FountainAIToolsmith --filter OrchestratorRoundTripTests
+
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/toolsmith-orchestration.md
+++ b/docs/toolsmith-orchestration.md
@@ -1,0 +1,64 @@
+# FountainAIToolsmith in Gateway/Codex Orchestration
+
+This guide shows how the Gateway/Codex loop imports and drives `FountainAIToolsmith` to execute sandboxed tools.
+
+## Importing and Instantiating
+
+Add the package to `Package.swift` and import the libraries in your orchestrator:
+
+```swift
+.package(path: "./FountainAIToolsmith")
+```
+
+```swift
+import Toolsmith
+import SandboxRunner
+
+let toolsmith = Toolsmith()
+let runner = BwrapRunner()
+```
+
+## Tool Call Lifecycle
+
+The snippet below demonstrates the full `start → run → shutdown` flow of a tool call.
+
+```swift
+import Toolsmith
+import SandboxRunner
+import Foundation
+
+let work = FileManager.default.temporaryDirectory.appendingPathComponent("work")
+try FileManager.default.createDirectory(at: work, withIntermediateDirectories: true)
+
+let toolsmith = Toolsmith()
+let runner = BwrapRunner()
+
+defer { try? FileManager.default.removeItem(at: work) }
+
+let requestID = toolsmith.run(tool: "echo") {
+    let result = try runner.run(
+        executable: "/bin/echo",
+        arguments: ["hello"],
+        inputs: [],
+        workDirectory: work,
+        allowNetwork: false,
+        timeout: 5,
+        limits: nil
+    )
+    print(result.stdout)
+}
+```
+
+## Client Generation
+
+Run `Scripts/generate-toolsmith-client.swift` to regenerate the `ToolsmithAPI` client from the shared `tools-factory.yml` spec. The generator copies the `Client/tools-factory` output into `FountainAIToolsmith/Sources/ToolsmithAPI`, preserving operation names like `list_tools` and `register_openapi` so interfaces mirror the Tools Factory contract and avoid naming conflicts.
+
+## Smoke Test
+
+Verify an orchestrator ↔ sandbox round-trip with:
+
+```bash
+Scripts/toolsmith-smoke-test.sh
+```
+
+> © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- document importing and instantiating FountainAIToolsmith in Gateway/Codex loop
- show full start→run→shutdown lifecycle
- add smoke-test script and round-trip test

## Testing
- `swift test --package-path FountainAIToolsmith --filter OrchestratorRoundTripTests`
- `bash Scripts/toolsmith-smoke-test.sh`


------
https://chatgpt.com/codex/tasks/task_b_68a4b2f16d6483339dfce196e8646d80