### PR TITLE
Handle plutil exit codes in LibPlist test

### DIFF
--- a/Tests/FountainAIToolsmithTests/AdapterTests.swift
+++ b/Tests/FountainAIToolsmithTests/AdapterTests.swift
@@ -50,7 +50,8 @@ final class AdapterTests: XCTestCase {
         try XCTSkipIf(!FileManager.default.isExecutableFile(atPath: "/usr/bin/plutil"), "plutil missing")
         let adapter = LibPlistAdapter()
         let (data, code) = try adapter.run(args: ["-help"])
-        XCTAssertEqual(code, 1) // plutil -help exits 1
+        XCTAssertTrue([0, 1].contains(code), "Unexpected exit code: \(code)")
+        // plutil -help exits 0 on some platforms and 1 on others
         XCTAssertTrue(String(data: data, encoding: .utf8)?.contains("plutil") ?? false)
     }
 }

--- a/agent.md
+++ b/agent.md
@@ -52,6 +52,7 @@ This agent maintains an up-to-date view of outstanding development tasks across 
 | MIDI 2 library | `midi/*`, `sps/*`, `Sources/MIDI2/*` | Parse MIDI 2 spec via SPS and expose Swift Package module | ✅ | — | midi, sps, spm |
 | Semantic browser & dissector | `sb/*` | Wire CLI commands and integrate Typesense indexer | ✅ | — | sb, cli, cdp, typesense, semantics |
 | Toolsmith package | `FountainAIToolsmith/*` | Scaffold Toolsmith orchestration package with CLI | ✅ | — | toolsmith |
+| LibPlist adapter tests | `Tests/FountainAIToolsmithTests/AdapterTests.swift` | Handle plutil help exit codes 0 or 1 | ✅ | — | toolsmith, test |
 
 
 ---

--- a/logs/agent-20250820042330.log
+++ b/logs/agent-20250820042330.log
@@ -1,0 +1,3 @@
+[2025-08-20T04:23:30Z] Adjusted LibPlistAdapter test to handle plutil exit codes across platforms.
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- accept plutil exit codes 0 or 1 in LibPlist adapter test
- log LibPlist adapter test fix in agent manifest

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68a54c40a5508333a43e559fab9f3cfd