### PR TITLE
Add PDF tool adapters

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -109,7 +109,7 @@ var targets: [Target] = [
         name: "tools-factory-server",
         dependencies: ["ToolServer"],
         path: "Sources/ToolServer",
-        exclude: ["Dockerfile", "Service", "Adapters", "Router.swift", "Validation.swift", "SandboxPolicy.swift", "HTTPTypes.swift", "openapi.yaml", "JSONLogger.swift", "ToolManifest.swift"],
+        exclude: ["Dockerfile", "Service", "Adapters", "Router.swift", "Validation.swift", "SandboxPolicy.swift", "HTTPTypes.swift", "openapi.yaml", "JSONLogger.swift", "ToolManifest.swift", "PDFTools"],
         sources: ["main.swift"]
     ),
     .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainCodex"], path: "Tests/ClientGeneratorTests"),

--- a/Sources/ToolServer/PDFTools/ExportMatrixAdapter.swift
+++ b/Sources/ToolServer/PDFTools/ExportMatrixAdapter.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public struct PDFExportMatrixAdapter: ToolAdapter {
+    private let base = ProcessAdapter(tool: "pdf-export-matrix", executable: "/usr/bin/pdf-export-matrix")
+    public init() {}
+    public var tool: String { base.tool }
+    public func run(args: [String]) throws -> (Data, Int32) { try base.run(args: args) }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/PDFTools/IndexAdapter.swift
+++ b/Sources/ToolServer/PDFTools/IndexAdapter.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public struct PDFIndexAdapter: ToolAdapter {
+    private let base = ProcessAdapter(tool: "pdf-index", executable: "/usr/bin/pdf-index")
+    public init() {}
+    public var tool: String { base.tool }
+    public func run(args: [String]) throws -> (Data, Int32) { try base.run(args: args) }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/PDFTools/QueryAdapter.swift
+++ b/Sources/ToolServer/PDFTools/QueryAdapter.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public struct PDFQueryAdapter: ToolAdapter {
+    private let base = ProcessAdapter(tool: "pdf-query", executable: "/usr/bin/pdf-query")
+    public init() {}
+    public var tool: String { base.tool }
+    public func run(args: [String]) throws -> (Data, Int32) { try base.run(args: args) }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/PDFTools/ScanAdapter.swift
+++ b/Sources/ToolServer/PDFTools/ScanAdapter.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public struct PDFScanAdapter: ToolAdapter {
+    private let base = ProcessAdapter(tool: "pdf-scan", executable: "/usr/bin/pdf-scan")
+    public init() {}
+    public var tool: String { base.tool }
+    public func run(args: [String]) throws -> (Data, Int32) { try base.run(args: args) }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Sources/ToolServer/main.swift
+++ b/Sources/ToolServer/main.swift
@@ -12,7 +12,11 @@ let adapters: [String: ToolAdapter] = [
     "ffmpeg": FFmpegAdapter(),
     "exiftool": ExifToolAdapter(),
     "pandoc": PandocAdapter(),
-    "libplist": LibPlistAdapter()
+    "libplist": LibPlistAdapter(),
+    "scan": PDFScanAdapter(),
+    "index": PDFIndexAdapter(),
+    "query": PDFQueryAdapter(),
+    "export-matrix": PDFExportMatrixAdapter()
 ]
 let manifestURL = URL(fileURLWithPath: "tools.json")
 let manifest = (try? ToolManifest.load(from: manifestURL)) ?? ToolManifest(image: .init(name: "", tarball: "", sha256: "", qcow2: "", qcow2_sha256: ""), tools: [:], operations: [])


### PR DESCRIPTION
## Summary
- add PDFTool adapters for scan, index, query and export-matrix operations
- register PDF adapters with ToolServer routing
- adjust Package.swift to exclude PDFTools from tools-factory-server

## Testing
- `swift test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_b_68a55e417f588333a5c9eff630c3e979