### PR TITLE
Use toolsmith CLI for PDF pipeline

### DIFF
--- a/Scripts/verify_pipeline.sh
+++ b/Scripts/verify_pipeline.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# SPS pipeline is deprecated; verification skipped.
-echo "[verify] SPS pipeline deprecated; skipping."
+INDEX=$(mktemp)
+trap 'rm -f "$INDEX"' EXIT
+
+toolsmith-cli pdf-scan sps/Samples/extraction_sample.pdf > "$INDEX"
+toolsmith-cli pdf-index-validate "$INDEX" >/dev/null
+toolsmith-cli pdf-query "$INDEX" annotated 1 >/dev/null
+toolsmith-cli pdf-export-matrix "$INDEX" >/dev/null
+
+echo "[verify] Toolsmith PDF pipeline OK"
 
 # © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/sps-usage-guide.md
+++ b/docs/sps-usage-guide.md
@@ -2,48 +2,33 @@
 
 # SPS Usage Guide
 
-This guide demonstrates end-to-end workflows with the Semantic PDF Scanner CLI, including page range queries and validation hooks.
+This guide demonstrates end-to-end PDF processing using the sandboxed Tool Server and `toolsmith-cli`.
 
-## 0. Install PDF dependencies
-Before building, install required PDF libraries (PDFium, Tesseract) using the helper script:
+## 0. Launch the sandbox Tool Server
 ```bash
-make -C sps deps
+swift run ToolServer --port 8080 &
+export TOOLSERVER_URL=http://localhost:8080
 ```
 
 ## 1. Scan PDFs into an index
 ```bash
-swift build -c release
-.build/release/sps scan sps/Samples/extraction_sample.pdf sps/Samples/table_detection_sample.pdf --out index.json --include-text --page-range 1-2
+toolsmith-cli pdf-scan sps/Samples/extraction_sample.pdf sps/Samples/table_detection_sample.pdf > index.json
 ```
-
-## 1a. Run scans asynchronously
-The `scan` command now enqueues work and returns a ticket immediately:
-```bash
-.build/release/sps scan sps/Samples/extraction_sample.pdf --out async-index.json
-# -> SPS: enqueued scan job -> <ticket>
-```
-
-Check progress with rotating motivational messages:
-```bash
-.build/release/sps status <ticket>
-```
-States include `pending`, `running`, `completed`, and `failed`. When completed, the status command prints the result path.
 
 ## 2. Validate the generated index
 ```bash
-.build/release/sps index validate index.json
+toolsmith-cli pdf-index-validate index.json
 ```
 
 ## 3. Query the index with page ranges
 ```bash
-.build/release/sps query index.json --q "annotated" --page-range 1
+toolsmith-cli pdf-query index.json annotated 1
 ```
 
 ## 4. Export a matrix with validation hooks
 ```bash
-.build/release/sps export-matrix index.json --out matrix.json --validate
+toolsmith-cli pdf-export-matrix index.json > matrix.json
 ```
-The `--page-range` flag accepts comma-separated ranges such as `1-3,5`,
-while `--validate` emits `matrix.json.validation.json` summarizing coverage and reserved-bit checks.
+The `pdf-query` command accepts an optional page range such as `1-3,5`, and `pdf-export-matrix` produces a `matrix.json` compatible with Midi2Swift generators.
 
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/sps-shim
+++ b/sps-shim
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "sps is deprecated; use toolsmith-cli pdf-$1" >&2; exec toolsmith-cli pdf-"$1" "${@:2}"


### PR DESCRIPTION
## Summary
- swap deprecated SPS pipeline script for toolsmith-cli PDF commands
- document sandbox-based PDF processing with toolsmith-cli
- add `sps-shim` transitional helper

## Testing
- `Scripts/run-tests.sh` *(fails: build fetching dependencies and did not complete)*

------
https://chatgpt.com/codex/tasks/task_b_68a56ed203c88333b6cb26fd03c3a3dd