### PR TITLE
Add environment example and load it in boot script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,37 @@
+# Example environment variables for FountainAI
+# Copy to .env and replace values with your secrets.
+
+# OpenAI configuration
+OPENAI_API_KEY=your_openai_api_key
+OPENAI_API_BASE=https://api.openai.com/v1
+
+# Typesense configuration
+TYPESENSE_URL=http://localhost:8108
+TYPESENSE_API_KEY=your_typesense_api_key
+TYPESENSE_PROXY_KEY=your_typesense_proxy_key
+
+# Gateway credentials
+GATEWAY_JWT_SECRET=change_me
+GATEWAY_OAUTH2_INTROSPECTION_URL=
+GATEWAY_OAUTH2_CLIENT_ID=
+GATEWAY_OAUTH2_CLIENT_SECRET=
+
+# Service authentication tokens
+BASELINE_AUTH_TOKEN=
+BOOTSTRAP_AUTH_TOKEN=
+FUNCTION_CALLER_AUTH_TOKEN=
+PLANNER_AUTH_TOKEN=
+TOOLS_FACTORY_AUTH_TOKEN=
+
+# Service URLs
+LLM_GATEWAY_URL=
+FUNCTION_CALLER_URL=
+TOOLSERVER_URL=http://localhost:8080
+
+# Paths and miscellaneous
+FUNCTIONS_CACHE_PATH=
+FOUNTAINAI_SERVICES_DIR=
+OTEL_EXPORT_URL=
+QEMU_TEST_IMAGE=
+PORT=8080
+

--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ swift Examples/SSEOverMIDI/TwoSessions.swift
 
 See [docs/sse-over-midi-guide.md](docs/sse-over-midi-guide.md) for setup details.
 
+### Configure environment
+
+Copy the example environment file and fill in your secrets:
+
+```bash
+cp .env.example .env
+# edit .env and provide real values
+```
+
+`Scripts/boot.sh` and other utilities will automatically load variables from `.env`.
+
 ---
 
 ## 🎹 Identity

--- a/Scripts/boot.sh
+++ b/Scripts/boot.sh
@@ -5,15 +5,22 @@ set -euo pipefail
 # Each major step can be disabled by setting its control variable to 0.
 # Example: `BUILD=0 Scripts/boot.sh` skips the Swift build.
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+
+# Load environment variables from .env if present
+if [[ -f "$REPO_ROOT/.env" ]]; then
+  set -a
+  source "$REPO_ROOT/.env"
+  set +a
+fi
+
 # Toggle variables (1=enable, 0=disable)
 CHECK_ENV="${CHECK_ENV:-1}"
 RUN_DIAGNOSTICS="${RUN_DIAGNOSTICS:-1}"
 BUILD="${BUILD:-1}"
 INSTALL_BINARIES="${INSTALL_BINARIES:-1}"
 LAUNCH_DEMO="${LAUNCH_DEMO:-1}"
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$SCRIPT_DIR/.."
 
 # Step 1: verify required environment variables
 if [[ "$CHECK_ENV" == "1" ]]; then


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholders for required configuration variables
- source `.env` automatically in `Scripts/boot.sh`
- document creating `.env` from the example in `README.md`

## Testing
- `Scripts/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_b_68a95978b4f8833398bbfd9fac59ccd9