### PR TITLE
Resolve ambiguous receive callbacks in RTPMidiSession

### DIFF
--- a/Sources/MIDI2Transports/RTPMidiSession.swift
+++ b/Sources/MIDI2Transports/RTPMidiSession.swift
@@ -126,7 +126,7 @@ public final class RTPMidiSession: MIDITransport, @unchecked Sendable {
     }
 
     private func configureReceive(on connection: NWConnection) {
-        connection.receiveMessage(completion: { [weak self] (data: Data?, _: NWConnection.ContentContext?, _: Bool, _: NWError?) in
+        connection.receiveMessage { [weak self] data, _, _, _ in
             if let data = data, data.count >= 12 {
                 let payload = data.subdata(in: 12..<data.count)
                 var umps: [[UInt32]] = []
@@ -144,7 +144,7 @@ public final class RTPMidiSession: MIDITransport, @unchecked Sendable {
                 self?.onReceiveUmps?(umps)
             }
             self?.configureReceive(on: connection)
-        })
+        }
     }
 
     private func startBonjourDiscovery() {
@@ -169,7 +169,7 @@ public final class RTPMidiSession: MIDITransport, @unchecked Sendable {
         msg.append(contentsOf: [negotiatedGroup, negotiatedChannel])
 
         let sem = DispatchSemaphore(value: 0)
-        connection.receiveMessage(completion: { [weak self] (data: Data?, _: NWConnection.ContentContext?, _: Bool, _: NWError?) in
+        connection.receiveMessage { [weak self] data, _, _, _ in
             if let data = data, data.count >= 21 {
                 self?.protocolVersion = data[2]
                 var uuidBytes = uuid_t()
@@ -181,7 +181,7 @@ public final class RTPMidiSession: MIDITransport, @unchecked Sendable {
                 self?.negotiatedChannel = data[20]
             }
             sem.signal()
-        })
+        }
         connection.send(content: msg, completion: .contentProcessed { _ in })
         sem.wait()
     }


### PR DESCRIPTION
## Summary
- avoid type inference ambiguity by using trailing closures in `RTPMidiSession` receive handlers

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68abd7ebc3f08333b2f72dfa640b5a18