### PR TITLE
Fix type annotation for RTP MIDI session receive closure

### DIFF
--- a/Sources/MIDI2Transports/RTPMidiSession.swift
+++ b/Sources/MIDI2Transports/RTPMidiSession.swift
@@ -169,7 +169,7 @@ public final class RTPMidiSession: MIDITransport, @unchecked Sendable {
         msg.append(contentsOf: [negotiatedGroup, negotiatedChannel])
 
         let sem = DispatchSemaphore(value: 0)
-        connection.receiveMessage { [weak self] data, _, _, _ in
+        connection.receiveMessage { [weak self] (data: Data?, _: NWConnection.ContentContext?, _: Bool, _: NWError?) in
             if let data = data, data.count >= 21 {
                 self?.protocolVersion = data[2]
                 var uuidBytes = uuid_t()


### PR DESCRIPTION
## Summary
- Specify explicit parameter types in `RTPMidiSession`'s `receiveMessage` closure to resolve Swift 6 ambiguity

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68abdbdf2174833383defdb9e11313d1