### PR TITLE
Fix RTP MIDI CI negotiation closure type

### DIFF
--- a/Sources/MIDI2Transports/RTPMidiSession.swift
+++ b/Sources/MIDI2Transports/RTPMidiSession.swift
@@ -169,7 +169,7 @@ public final class RTPMidiSession: MIDITransport, @unchecked Sendable {
         msg.append(contentsOf: [negotiatedGroup, negotiatedChannel])
 
         let sem = DispatchSemaphore(value: 0)
-        connection.receiveMessage { [weak self] (data: Data?, _: NWConnection.ContentContext?, _: Bool, _: NWError?) in
+        connection.receiveMessage { [weak self] data, _, _, _ in
             if let data = data, data.count >= 21 {
                 self?.protocolVersion = data[2]
                 var uuidBytes = uuid_t()


### PR DESCRIPTION
## Summary
- fix ambiguous receiveMessage closure in RTPMidiSession CI negotiation

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68abde3a718483338f9a5c9215387f29