### PR TITLE
Fix ambiguous types in NWConnection receiveMessage handlers

### DIFF
--- a/Sources/MIDI2Transports/RTPMidiSession.swift
+++ b/Sources/MIDI2Transports/RTPMidiSession.swift
@@ -126,7 +126,7 @@ public final class RTPMidiSession: MIDITransport, @unchecked Sendable {
     }
 
     private func configureReceive(on connection: NWConnection) {
-        connection.receiveMessage { [weak self] data, _, _, _ in
+        connection.receiveMessage { [weak self] (data: Data?, _: NWConnection.ContentContext?, _: Bool, _: NWError?) in
             if let data = data, data.count >= 12 {
                 let payload = data.subdata(in: 12..<data.count)
                 var umps: [[UInt32]] = []
@@ -169,7 +169,7 @@ public final class RTPMidiSession: MIDITransport, @unchecked Sendable {
         msg.append(contentsOf: [negotiatedGroup, negotiatedChannel])
 
         let sem = DispatchSemaphore(value: 0)
-        connection.receiveMessage { [weak self] data, _, _, _ in
+        connection.receiveMessage { [weak self] (data: Data?, _: NWConnection.ContentContext?, _: Bool, _: NWError?) in
             if let data = data, data.count >= 21 {
                 self?.protocolVersion = data[2]
                 var uuidBytes = uuid_t()


### PR DESCRIPTION
## Summary
- specify parameter types for `NWConnection.receiveMessage` closures in `RTPMidiSession`

## Testing
- `swift build --target MIDI2Transports` *(fails: build process interrupted due to time constraints)*

------
https://chatgpt.com/codex/tasks/task_b_68abe29962648333a6b7d6b99174b3bd