### PR TITLE
Fix ambiguous receiveMessage closures in RTPMidiSession

### DIFF
--- a/Sources/MIDI2Transports/RTPMidiSession.swift
+++ b/Sources/MIDI2Transports/RTPMidiSession.swift
@@ -126,7 +126,7 @@ public final class RTPMidiSession: MIDITransport, @unchecked Sendable {
     }
 
     private func configureReceive(on connection: NWConnection) {
-        connection.receiveMessage(completion: { [weak self] data, _, _, _ in
+        connection.receiveMessage(completion: { [weak self] (data: Data?, _: NWConnection.ContentContext?, _: Bool, _: NWError?) in
             if let data = data, data.count >= 12 {
                 let payload = data.subdata(in: 12..<data.count)
                 var umps: [[UInt32]] = []
@@ -169,7 +169,7 @@ public final class RTPMidiSession: MIDITransport, @unchecked Sendable {
         msg.append(contentsOf: [negotiatedGroup, negotiatedChannel])
 
         let sem = DispatchSemaphore(value: 0)
-        connection.receiveMessage(completion: { [weak self] data, _, _, _ in
+        connection.receiveMessage(completion: { [weak self] (data: Data?, _: NWConnection.ContentContext?, _: Bool, _: NWError?) in
             if let data = data, data.count >= 21 {
                 self?.protocolVersion = data[2]
                 var uuidBytes = uuid_t()


### PR DESCRIPTION
## Summary
- Specify full parameter types in `NWConnection.receiveMessage` closures to remove ambiguity errors.

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68abe9e259988333b9a0e19d16512dfd