### PR TITLE
chore: streamline bootstrap endpoints and persona prompts

### DIFF
--- a/openapi/v1/bootstrap.yml
+++ b/openapi/v1/bootstrap.yml
@@ -11,12 +11,10 @@ paths:
     post:
       tags:
         - Bootstrap
-      summary: "Bootstrap: Init Corpus + Seed Roles + Default Reflection"
+      summary: "Bootstrap: Init Corpus + Seed Roles"
       description: |
         1) Creates empty corpus via `/corpus-init` on Awareness.
         2) Seeds default GPT roles via `/bootstrap/roles/seed`.
-        3) Enqueues the 'role-health-check' reflection via the Awareness
-           `/reflections` API.
       operationId: bootstrapInitializeCorpus
       requestBody:
         required: true
@@ -58,68 +56,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/RoleDefaults'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /bootstrap/corpus/reflect:
-    post:
-      tags:
-        - Bootstrap
-      summary: "Bootstrap: Enqueue Default Reflection"
-      description: >
-        Enqueues the 'role-health-check' reflection into an existing corpus.
-      operationId: bootstrapEnqueueReflection
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/InitIn'
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InitOut'
-        '422':
-          description: Validation Error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/HTTPValidationError'
-  /bootstrap/roles/promote:
-    post:
-      tags:
-        - Bootstrap
-      summary: "Bootstrap: Promote Reflection to Role"
-      description: >
-        Fetches the last 'role-health-check' reflection and
-        registers it as a new GPT role.
-      operationId: bootstrapPromoteReflection
-      parameters:
-        - name: corpusId
-          in: query
-          required: true
-          schema:
-            type: string
-            title: Corpusid
-        - name: roleName
-          in: query
-          required: true
-          schema:
-            type: string
-            title: Rolename
-      responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/RoleInfo'
         '422':
           description: Validation Error
           content:
@@ -279,33 +215,43 @@ components:
           type: string
           title: Drift
           description: Full prompt text for the drift analysis role.
+          const: |-
+            You are Drift, FountainAI’s baseline-drift detective. Compare a new baseline snapshot against prior versions to detect narrative or thematic drift and report the most significant changes.
         semantic_arc:
           type: string
           title: Semantic Arc
           description: Full prompt text for the semantic arc analysis role.
+          const: |-
+            You are Semantic Arc, tasked with tracing the corpus’s overarching narrative arc. Review the corpus history and synthesize a high-level storyline that highlights major turning points and transitions.
         patterns:
           type: string
           title: Patterns
           description: Full prompt text for the narrative patterns analysis role.
+          const: |-
+            You are Patterns, a spotter of recurring motifs, themes, or rhetorical structures. Inspect the corpus and list the strongest patterns you find.
         history:
           type: string
           title: History
           description: Full prompt text for the history and reflections role.
+          const: |-
+            You are History, the curator of past reflections and events. Maintain a chronological log showing how the corpus has grown and changed, focusing on context useful for future analysis.
         view_creator:
           type: string
           title: View Creator
           description: Full prompt text for the view-creation agent role.
+          const: |-
+            You are View Creator, responsible for assembling human-friendly views of the corpus and analyses. Produce a simple markdown or tabular view to help a human browse the information.
       x-prompts:
         drift: |-
-          You are the Drift Analyst. Compare a new baseline snapshot against prior versions to identify narrative or thematic drift. Return a short summary describing the most significant changes.
+          You are Drift, FountainAI’s baseline-drift detective. Compare a new baseline snapshot against prior versions to detect narrative or thematic drift and report the most significant changes.
         semantic_arc: |-
-          You are the Semantic Arc Synthesizer. Review the corpus history and produce a high-level arc that explains how ideas evolve over time. Emphasize major turning points and transitions.
+          You are Semantic Arc, tasked with tracing the corpus’s overarching narrative arc. Review the corpus history and synthesize a high-level storyline that highlights major turning points and transitions.
         patterns: |-
-          You are the Patterns Observer. Inspect the corpus and note recurring themes, motifs, or rhetorical structures. Output a concise list of the strongest patterns you find.
+          You are Patterns, a spotter of recurring motifs, themes, or rhetorical structures. Inspect the corpus and list the strongest patterns you find.
         history: |-
-          You are the History Curator. Maintain a chronological log of reflections and events, summarizing how the corpus has grown and changed. Focus on context useful for future analysis.
+          You are History, the curator of past reflections and events. Maintain a chronological log showing how the corpus has grown and changed, focusing on context useful for future analysis.
         view_creator: |-
-          You are the View Creator. Using the corpus and analyses, assemble a simple markdown or tabular view that helps a human browse the information. Keep the view readable and structured.
+          You are View Creator, responsible for assembling human-friendly views of the corpus and analyses. Produce a simple markdown or tabular view to help a human browse the information.
     RoleInfo:
       type: object
       title: RoleInfo


### PR DESCRIPTION
## Summary
- drop default reflection step from corpus initialization
- remove reflect/promote bootstrap endpoints
- update role prompts with persona-specific constants

## Testing
- `swift test` *(fails: DNSEngineTests.testMetricsRecordedPerType, DefaultSseIntegrationTests.testLargePayloadUsesSysEx8, ToolsmithTests.testRunExportsSpanWhenEnvSet)*

------
https://chatgpt.com/codex/tasks/task_b_68ad2cb5878c8333a6d117f3b1c2bb31