### PR TITLE
Add role health check gateway OpenAPI spec

### DIFF
--- a/openapi/README.md
+++ b/openapi/README.md
@@ -13,6 +13,7 @@ Versioned service definitions live here. Each YAML file describes a FountainAI s
 | Persistence Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/persist.yml](v1/persist.yml) |
 | Planner Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/planner.yml](v1/planner.yml) |
 | Planner Service (legacy alias) | 1.0.0 | Contexter alias Benedikt Eickhoff | [v0/planner.yml](v0/planner.yml) |
+| Role Health Check Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/role-health-check-gateway.yml](v1/role-health-check-gateway.yml) |
 | Semantic Browser & Dissector API | 0.2.0 | Contexter alias Benedikt Eickhoff | [v1/semantic-browser.yml](v1/semantic-browser.yml) |
 | Tools Factory Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/tools-factory.yml](v1/tools-factory.yml) |
 | Typesense API | 28.0 | Contexter alias Benedikt Eickhoff | [typesense.yml](typesense.yml) |

--- a/openapi/v1/role-health-check-gateway.yml
+++ b/openapi/v1/role-health-check-gateway.yml
@@ -1,0 +1,133 @@
+---
+openapi: 3.1.0
+info:
+  title: Role Health Check Gateway Plugin
+  description: >
+    Verifies seeded roles and promotes validated reflections.
+  version: 1.0.0
+servers:
+  - url: http://role-health-check.fountain.coach/api/v1
+x-prompts:
+  system: |-
+    You are the Role Health Check Gateway Plugin. Validate the five default GPT roles: drift, semantic_arc, patterns, history, and view_creator.
+paths:
+  /role-health-check/reflect:
+    post:
+      tags:
+        - RoleHealthCheck
+      summary: Enqueue Role Health-Check Reflection
+      description: Enqueues the health-check reflection in the corpus.
+      operationId: roleHealthCheckReflect
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RoleHealthCheckRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoleInfo'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /role-health-check/promote:
+    post:
+      tags:
+        - RoleHealthCheck
+      summary: Promote Role Health-Check Reflection
+      description: Promotes the latest health-check reflection to a role.
+      operationId: roleHealthCheckPromote
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RoleHealthCheckRequest'
+      responses:
+        '200':
+          description: Successful Response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RoleInfo'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    RoleHealthCheckRequest:
+      title: RoleHealthCheckRequest
+      description: |
+        Request model for processing role health-check reflections.
+        corpusId: The target corpus identifier.
+        roleName: The role under health check.
+      type: object
+      required:
+        - corpusId
+        - roleName
+      properties:
+        corpusId:
+          type: string
+          title: Corpusid
+        roleName:
+          type: string
+          title: Rolename
+    RoleInfo:
+      title: RoleInfo
+      description: |
+        Represents a dynamically registered or promoted GPT role.
+        name: Identifier for the role (e.g., "security_audit").
+        prompt: Full system prompt text defining the role's analysis behavior.
+      type: object
+      required:
+        - name
+        - prompt
+      properties:
+        name:
+          type: string
+          title: Name
+        prompt:
+          type: string
+          title: Prompt
+    HTTPValidationError:
+      title: HTTPValidationError
+      type: object
+      properties:
+        detail:
+          type: array
+          title: Detail
+          items:
+            $ref: '#/components/schemas/ValidationError'
+    ValidationError:
+      title: ValidationError
+      type: object
+      required:
+        - loc
+        - msg
+        - type
+      properties:
+        loc:
+          type: array
+          title: Location
+          items:
+            anyOf:
+              - type: string
+              - type: integer
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add Role Health Check Gateway Plugin OpenAPI spec for reflecting and promoting role health checks
- document new spec in OpenAPI index

## Testing
- `python scripts/validate_openapi.py`


------
https://chatgpt.com/codex/tasks/task_b_68ad2f0df26c8333adafd50352d64000