### PR TITLE
Add rate limiter gateway spec to OpenAPI listing

### DIFF
--- a/openapi/README.md
+++ b/openapi/README.md
@@ -14,6 +14,7 @@ Versioned service definitions live here. Each YAML file describes a FountainAI s
 | Persistence Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/persist.yml](v1/persist.yml) |
 | Planner Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/planner.yml](v1/planner.yml) |
 | Planner Service (legacy alias) | 1.0.0 | Contexter alias Benedikt Eickhoff | [v0/planner.yml](v0/planner.yml) |
+| Rate Limiter Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/rate-limiter-gateway.yml](v1/rate-limiter-gateway.yml) |
 | Role Health Check Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/role-health-check-gateway.yml](v1/role-health-check-gateway.yml) |
 | Semantic Browser & Dissector API | 0.2.0 | Contexter alias Benedikt Eickhoff | [v1/semantic-browser.yml](v1/semantic-browser.yml) |
 | Tools Factory Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/tools-factory.yml](v1/tools-factory.yml) |


### PR DESCRIPTION
## Summary
- document Rate Limiter Gateway Plugin in OpenAPI catalog

## Testing
- `swift test` *(fails: 52 failures)*

------
https://chatgpt.com/codex/tasks/task_b_68ad401689308333ae8f12995da1eaca