### PR TITLE
Add rate limiter gateway plugin and spec

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,7 @@ var targets: [Target] = [
             "PublishingFrontend",
             "LLMGatewayPlugin",
             "AuthGatewayPlugin",
+            "RateLimiterGatewayPlugin",
             .product(name: "Crypto", package: "swift-crypto"),
             .product(name: "X509", package: "swift-certificates"),
             "Yams"
@@ -56,6 +57,11 @@ var targets: [Target] = [
         name: "AuthGatewayPlugin",
         dependencies: ["FountainCodex", .product(name: "Crypto", package: "swift-crypto")],
         path: "libs/GatewayPlugins/AuthGatewayPlugin"
+    ),
+    .target(
+        name: "RateLimiterGatewayPlugin",
+        dependencies: ["FountainCodex"],
+        path: "libs/GatewayPlugins/RateLimiterGatewayPlugin",
     ),
     .target(
         name: "PublishingFrontend",
@@ -108,7 +114,7 @@ var targets: [Target] = [
     .testTarget(name: "DNSTests", dependencies: ["PublishingFrontend", "FountainCodex", .product(name: "Crypto", package: "swift-crypto"), .product(name: "NIOEmbedded", package: "swift-nio"), .product(name: "NIO", package: "swift-nio")], path: "Tests/DNSTests"),
     .testTarget(
         name: "IntegrationRuntimeTests",
-        dependencies: ["gateway-server", "FountainCodex", "LLMGatewayPlugin"],
+        dependencies: ["gateway-server", "FountainCodex", "LLMGatewayPlugin", "RateLimiterGatewayPlugin"],
         path: "Tests/IntegrationRuntimeTests",
         resources: [.process("Fixtures")]
     ),

--- a/Tests/IntegrationRuntimeTests/GatewayServerTests.swift
+++ b/Tests/IntegrationRuntimeTests/GatewayServerTests.swift
@@ -5,6 +5,7 @@ import FoundationNetworking
 #endif
 @testable import gateway_server
 @testable import FountainCodex
+import RateLimiterGatewayPlugin
 
 final class GatewayServerTests: XCTestCase {
 
@@ -45,7 +46,7 @@ final class GatewayServerTests: XCTestCase {
     @MainActor
     func testRenewCertificateReturnsConfirmation() async throws {
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let rl = RateLimiterPlugin()
+        let rl = RateLimiterGatewayPlugin()
         let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9125) }
         try await Task.sleep(nanoseconds: 100_000_000)
@@ -158,7 +159,7 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
     /// Unknown paths should yield a `404` status.
     func testUnknownPathReturns404() async throws {
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let rl = RateLimiterPlugin()
+        let rl = RateLimiterGatewayPlugin()
         let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9103) }
         try await Task.sleep(nanoseconds: 100_000_000)
@@ -267,7 +268,7 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
     /// Health endpoint should emit the JSON content type header.
     func testHealthEndpointSetsJSONContentType() async throws {
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let rl = RateLimiterPlugin()
+        let rl = RateLimiterGatewayPlugin()
         let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9106) }
         try await Task.sleep(nanoseconds: 100_000_000)
@@ -282,7 +283,7 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
     /// Metrics endpoint should emit the JSON content type header.
     func testMetricsEndpointSetsJSONContentType() async throws {
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let rl = RateLimiterPlugin()
+        let rl = RateLimiterGatewayPlugin()
         let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9107) }
         try await Task.sleep(nanoseconds: 100_000_000)
@@ -298,7 +299,7 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
     func testMetricsEndpointReturnsZeroCounters() async throws {
         await DNSMetrics.shared.reset()
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let rl = RateLimiterPlugin()
+        let rl = RateLimiterGatewayPlugin()
         let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9108) }
         try await Task.sleep(nanoseconds: 100_000_000)
@@ -363,7 +364,7 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
     @MainActor
     func testZonesRequireManager() async throws {
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let rl = RateLimiterPlugin()
+        let rl = RateLimiterGatewayPlugin()
         let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9131) }
         try await Task.sleep(nanoseconds: 100_000_000)
@@ -457,7 +458,7 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
         setenv("GATEWAY_ROLE_admin", "admin", 1)
         setenv("GATEWAY_JWT_SECRET", "topsecret", 1)
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let rl = RateLimiterPlugin()
+        let rl = RateLimiterGatewayPlugin()
         let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9113) }
         try await Task.sleep(nanoseconds: 100_000_000)
@@ -523,7 +524,7 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
     @MainActor
     func testRoutesCRUD() async throws {
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let rl = RateLimiterPlugin()
+        let rl = RateLimiterGatewayPlugin()
         let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9114) }
         try await Task.sleep(nanoseconds: 100_000_000)
@@ -633,7 +634,7 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
         let upstreamPort = try await upstream.start(port: 0)
 
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let rl = RateLimiterPlugin()
+        let rl = RateLimiterGatewayPlugin()
         let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9116) }
         try await Task.sleep(nanoseconds: 500_000_000)
@@ -665,7 +666,7 @@ aAhFmOl1mcUedOydNA87ZDbQXd7VqSw5mi4cqymNnbpPfjjsy9vG/+xqCMFdnFQd
         let upstreamPort = try await upstream.start(port: 0)
 
         let manager = CertificateManager(scriptPath: "/usr/bin/true", interval: 3600)
-        let rl = RateLimiterPlugin()
+        let rl = RateLimiterGatewayPlugin()
         let server = GatewayServer(manager: manager, plugins: [rl], rateLimiter: rl)
         Task { try await server.start(port: 9120) }
         try await Task.sleep(nanoseconds: 500_000_000)

--- a/apps/GatewayServer/GatewayApp/GatewayServer.swift
+++ b/apps/GatewayServer/GatewayApp/GatewayServer.swift
@@ -6,6 +6,7 @@ import Crypto
 import X509
 import LLMGatewayPlugin
 import AuthGatewayPlugin
+import RateLimiterGatewayPlugin
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
@@ -29,7 +30,7 @@ public final class GatewayServer {
     private var routes: [String: RouteInfo]
     private let routesURL: URL?
     private let certificatePath: String?
-    private let rateLimiter: RateLimiterPlugin?
+    private let rateLimiter: RateLimiterGatewayPlugin?
 
     private struct ZoneCreateRequest: Codable { let name: String }
     private struct ZonesResponse: Codable { let zones: [ZoneManager.Zone] }
@@ -76,7 +77,7 @@ public final class GatewayServer {
                 zoneManager: ZoneManager? = nil,
                 routeStoreURL: URL? = nil,
                 certificatePath: String? = nil,
-                rateLimiter: RateLimiterPlugin? = nil) {
+                rateLimiter: RateLimiterGatewayPlugin? = nil) {
         self.manager = manager
         self.plugins = plugins
         self.zoneManager = zoneManager

--- a/apps/GatewayServer/GatewayApp/RateLimiterGatewayPlugin+GatewayPlugin.swift
+++ b/apps/GatewayServer/GatewayApp/RateLimiterGatewayPlugin+GatewayPlugin.swift
@@ -1,0 +1,5 @@
+import RateLimiterGatewayPlugin
+
+extension RateLimiterGatewayPlugin: GatewayPlugin {}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/apps/GatewayServer/GatewayApp/main.swift
+++ b/apps/GatewayServer/GatewayApp/main.swift
@@ -4,6 +4,7 @@ import PublishingFrontend
 import FountainCodex
 import LLMGatewayPlugin
 import AuthGatewayPlugin
+import RateLimiterGatewayPlugin
 
 /// Launches ``GatewayServer`` with the publishing plugin enabled.
 /// The server stays running until the process is terminated.
@@ -17,7 +18,7 @@ let gatewayConfig = try? loadGatewayConfig()
 if gatewayConfig == nil {
     FileHandle.standardError.write(Data("[gateway] Warning: failed to load Configuration/gateway.yml; using defaults for rate limiting.\n".utf8))
 }
-let rateLimiter = RateLimiterPlugin(defaultLimit: gatewayConfig?.rateLimitPerMinute ?? 60)
+let rateLimiter = RateLimiterGatewayPlugin(defaultLimit: gatewayConfig?.rateLimitPerMinute ?? 60)
 let cotLogPath = ProcessInfo.processInfo.environment["COT_LOG_PATH"].map { URL(fileURLWithPath: $0) }
 let llmPlugin = LLMGatewayPlugin(cotLogURL: cotLogPath)
 let authPlugin = AuthGatewayPlugin()

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -20,7 +20,7 @@ The authentication gateway plugin validates OAuth2/OIDC bearer tokens and enforc
 [`CoTLogger`](../../Sources/GatewayApp/CoTLogger.swift) captures reasoning when `include_cot` is set, sanitizes secrets, and optionally checks risky entries with the sentinel before persisting them.
 
 ### Rate limiting
-[`RateLimiterPlugin`](../../Sources/GatewayApp/RateLimiterPlugin.swift) implements per‑client token buckets to throttle excessive requests and records allowance metrics.
+[`RateLimiterGatewayPlugin`](../../libs/GatewayPlugins/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin.swift) implements per‑client token buckets to throttle excessive requests and records allowance metrics.
 
 ### Pre‑deployment verification
 [`Scripts/predeploy.sh`](../../Scripts/predeploy.sh) verifies container image signatures with Cosign, scans for high‑severity vulnerabilities via Grype, and generates an SBOM using Syft before release.

--- a/libs/GatewayPlugins/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin/Handlers.swift
+++ b/libs/GatewayPlugins/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin/Handlers.swift
@@ -1,29 +1,19 @@
 import Foundation
 import FountainCodex
 
-/// Plugin implementing a token bucket rate limiter with per-client buckets.
-public final actor RateLimiterPlugin: GatewayPlugin {
+/// Collection of handlers for rate limiter gateway endpoints.
+public actor Handlers {
     private struct Bucket { var tokens: Double; var lastRefill: TimeInterval; let capacity: Double; let rate: Double }
     private var buckets: [String: Bucket] = [:]
     private var allowed = 0
     private var throttled = 0
     private let defaultLimit: Int
 
-    /// Creates a new rate limiter plugin.
-    /// - Parameter defaultLimit: Fallback limit per minute when a route lacks an explicit limit.
     public init(defaultLimit: Int = 60) {
         self.defaultLimit = defaultLimit
     }
 
-    /// Returns accumulated allowed and throttled counts.
-    public func stats() -> (allowed: Int, throttled: Int) { (allowed, throttled) }
-
     /// Checks and consumes a token for the given route and client.
-    /// - Parameters:
-    ///   - routeId: Identifier of the route being accessed.
-    ///   - clientId: Authenticated subject or API key. "anonymous" when unavailable.
-    ///   - limitPerMinute: Optional override limit for this specific route.
-    /// - Returns: ``true`` if the request should proceed, ``false`` when throttled.
     public func allow(routeId: String, clientId: String, limitPerMinute: Int?) -> Bool {
         let limit = limitPerMinute ?? defaultLimit
         if limit <= 0 {
@@ -49,6 +39,26 @@ public final actor RateLimiterPlugin: GatewayPlugin {
         throttled += 1
         Task { await DNSMetrics.shared.recordRateLimit(allowed: false) }
         return false
+    }
+
+    /// Returns accumulated allowed and throttled counts.
+    public func stats() -> (allowed: Int, throttled: Int) { (allowed, throttled) }
+
+    /// Handler for rate limit checks.
+    public func rateLimitCheck(_ request: HTTPRequest, body: RateLimitCheckRequest?) async throws -> HTTPResponse {
+        guard let body else { return HTTPResponse(status: 400) }
+        let permitted = allow(routeId: body.routeId, clientId: body.clientId, limitPerMinute: body.limitPerMinute)
+        let resp = RateLimitCheckResponse(allowed: permitted)
+        let data = try JSONEncoder().encode(resp)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+    }
+
+    /// Handler returning aggregated statistics.
+    public func rateLimitStats(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
+        let (allowed, throttled) = stats()
+        let resp = RateLimitStatsResponse(allowed: allowed, throttled: throttled)
+        let data = try JSONEncoder().encode(resp)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
     }
 }
 

--- a/libs/GatewayPlugins/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin/Models.swift
+++ b/libs/GatewayPlugins/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin/Models.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Request to check a route's rate limit.
+public struct RateLimitCheckRequest: Codable {
+    public let routeId: String
+    public let clientId: String
+    public let limitPerMinute: Int?
+    public init(routeId: String, clientId: String, limitPerMinute: Int? = nil) {
+        self.routeId = routeId
+        self.clientId = clientId
+        self.limitPerMinute = limitPerMinute
+    }
+}
+
+/// Response indicating if a request is allowed.
+public struct RateLimitCheckResponse: Codable {
+    public let allowed: Bool
+    public init(allowed: Bool) { self.allowed = allowed }
+}
+
+/// Response containing aggregate rate limiter statistics.
+public struct RateLimitStatsResponse: Codable {
+    public let allowed: Int
+    public let throttled: Int
+    public init(allowed: Int, throttled: Int) {
+        self.allowed = allowed
+        self.throttled = throttled
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin.swift
+++ b/libs/GatewayPlugins/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin.swift
@@ -1,0 +1,24 @@
+import Foundation
+import FountainCodex
+
+/// Plugin implementing a token bucket rate limiter with per-client buckets.
+public struct RateLimiterGatewayPlugin: Sendable {
+    public let router: Router
+    private let handlers: Handlers
+
+    public init(defaultLimit: Int = 60) {
+        let h = Handlers(defaultLimit: defaultLimit)
+        self.handlers = h
+        self.router = Router(handlers: h)
+    }
+
+    public func allow(routeId: String, clientId: String, limitPerMinute: Int?) async -> Bool {
+        await handlers.allow(routeId: routeId, clientId: clientId, limitPerMinute: limitPerMinute)
+    }
+
+    public func stats() async -> (allowed: Int, throttled: Int) {
+        await handlers.stats()
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin/Router.swift
+++ b/libs/GatewayPlugins/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin/Router.swift
@@ -1,0 +1,23 @@
+import Foundation
+import FountainCodex
+
+/// Router for rate limiter gateway endpoints.
+public struct Router: Sendable {
+    public var handlers: Handlers
+    public init(handlers: Handlers = Handlers()) { self.handlers = handlers }
+
+    /// Routes requests to handlers.
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse? {
+        switch (request.method, request.path) {
+        case ("POST", "/rate-limit/check"):
+            let body = try? JSONDecoder().decode(RateLimitCheckRequest.self, from: request.body)
+            return try await handlers.rateLimitCheck(request, body: body)
+        case ("GET", "/rate-limit/stats"):
+            return try await handlers.rateLimitStats(request, body: nil)
+        default:
+            return nil
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -18,5 +18,6 @@ Versioned service definitions live here. Each YAML file describes a FountainAI s
 | Semantic Browser & Dissector API | 0.2.0 | Contexter alias Benedikt Eickhoff | [v1/semantic-browser.yml](v1/semantic-browser.yml) |
 | Tools Factory Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/tools-factory.yml](v1/tools-factory.yml) |
 | Typesense API | 28.0 | Contexter alias Benedikt Eickhoff | [typesense.yml](typesense.yml) |
+| Rate Limiter Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/rate-limiter-gateway.yml](v1/rate-limiter-gateway.yml) |
 
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/rate-limiter-gateway.yml
+++ b/openapi/v1/rate-limiter-gateway.yml
@@ -1,0 +1,122 @@
+---
+openapi: 3.1.0
+info:
+  title: Rate Limiter Gateway Plugin
+  description: >
+    Token bucket rate limiter for FountainAI gateway.
+  version: 1.0.0
+servers:
+  - url: http://rate-limiter.fountain.coach/api/v1
+paths:
+  /rate-limit/check:
+    post:
+      tags:
+        - RateLimiter
+      summary: Check rate limit
+      description: Checks and consumes a rate limit token.
+      operationId: rateLimitCheck
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RateLimitCheckRequest'
+      responses:
+        '200':
+          description: Result of rate limit check
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitCheckResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+  /rate-limit/stats:
+    get:
+      tags:
+        - RateLimiter
+      summary: Retrieve rate limiter statistics
+      operationId: rateLimitStats
+      responses:
+        '200':
+          description: Aggregated allowed/throttled counts
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RateLimitStatsResponse'
+components:
+  schemas:
+    RateLimitCheckRequest:
+      title: RateLimitCheckRequest
+      type: object
+      required:
+        - routeId
+        - clientId
+      properties:
+        routeId:
+          type: string
+          title: Routeid
+        clientId:
+          type: string
+          title: Clientid
+        limitPerMinute:
+          type: integer
+          title: Limitperminute
+          nullable: true
+    RateLimitCheckResponse:
+      title: RateLimitCheckResponse
+      type: object
+      required:
+        - allowed
+      properties:
+        allowed:
+          type: boolean
+          title: Allowed
+    RateLimitStatsResponse:
+      title: RateLimitStatsResponse
+      type: object
+      required:
+        - allowed
+        - throttled
+      properties:
+        allowed:
+          type: integer
+          title: Allowed
+        throttled:
+          type: integer
+          title: Throttled
+    HTTPValidationError:
+      title: HTTPValidationError
+      type: object
+      properties:
+        detail:
+          type: array
+          title: Detail
+          items:
+            $ref: '#/components/schemas/ValidationError'
+    ValidationError:
+      title: ValidationError
+      type: object
+      required:
+        - loc
+        - msg
+        - type
+      properties:
+        loc:
+          type: array
+          title: Location
+          items:
+            anyOf:
+              - type: string
+              - type: integer
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- define rate limiter gateway OpenAPI spec and index it
- add RateLimiterGatewayPlugin library and register with gateway server
- replace in-process rate limiter and update security docs

## Testing
- `python3 scripts/validate_openapi.py`
- `swift test` *(fails: ToolsmithTests.testRunExportsSpanWhenEnvSet timeout; DefaultSseIntegrationTests.testLargePayloadUsesSysEx8 timeout and assertions)*

------
https://chatgpt.com/codex/tasks/task_b_68ad4b6c5adc8333805fe0ee4b49c89c