### PR TITLE
Create standalone SemanticBrowser SPM package

### DIFF
--- a/semantic-browser/.gitignore
+++ b/semantic-browser/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/semantic-browser/Package.swift
+++ b/semantic-browser/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "SemanticBrowser",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .library(
+            name: "SemanticBrowser",
+            targets: ["SemanticBrowser"]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Fountain-Coach/fountain-codex.git", branch: "main"),
+        .package(url: "https://github.com/typesense/typesense-swift.git", from: "1.0.1")
+    ],
+    targets: [
+        .target(
+            name: "SemanticBrowser",
+            dependencies: [
+                "FountainCodex",
+                .product(name: "Typesense", package: "typesense-swift")
+            ]
+        ),
+        .testTarget(
+            name: "SemanticBrowserTests",
+            dependencies: [
+                "SemanticBrowser",
+                "FountainCodex"
+            ]
+        )
+    ]
+)

--- a/semantic-browser/Sources/SemanticBrowser/Artifacts.swift
+++ b/semantic-browser/Sources/SemanticBrowser/Artifacts.swift
@@ -1,0 +1,166 @@
+import Foundation
+#if canImport(CryptoKit)
+import CryptoKit
+#endif
+
+public struct ArtifactRef: Sendable, Codable, Equatable {
+    public let id: String
+    public let sha256: String
+    public let size: Int
+    public let kind: String
+    public let mime: String
+    public let ext: String
+    public let refPath: String
+    public let createdAt: Date
+}
+
+public protocol ArtifactStore: Sendable {
+    func put(kind: String, ext: String, mime: String, data: Data, ttlDays: Int) throws -> ArtifactRef
+    func get(refPath: String) throws -> (data: Data, mime: String)?
+    func delete(refPath: String) throws
+    func gc(now: Date) throws -> Int
+}
+
+public final class FSArtifactStore: ArtifactStore, @unchecked Sendable {
+    let root: URL
+    let budgetBytes: Int64?
+    public init(rootPath: String, budgetBytes: Int64? = nil) throws {
+        self.root = URL(fileURLWithPath: rootPath)
+        self.budgetBytes = budgetBytes
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+    }
+
+    public func put(kind: String, ext: String, mime: String, data: Data, ttlDays: Int) throws -> ArtifactRef {
+        let sha = sha256Hex(data)
+        let now = Date()
+        let comps = Calendar.current.dateComponents([.year, .month, .day], from: now)
+        let y = String(format: "%04d", comps.year ?? 1970)
+        let m = String(format: "%02d", comps.month ?? 1)
+        let d = String(format: "%02d", comps.day ?? 1)
+        let dir = root.appendingPathComponent(kind).appendingPathComponent(y).appendingPathComponent(m).appendingPathComponent(d)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let filename = "\(sha).\(ext)"
+        let fileURL = dir.appendingPathComponent(filename)
+        try data.write(to: fileURL, options: .atomic)
+        // write sidecar meta for TTL and mime
+        let meta: [String: Any] = ["mime": mime, "ttlDays": ttlDays, "createdAt": now.timeIntervalSince1970]
+        let metaURL = dir.appendingPathComponent("\(sha).meta.json")
+        let metaData = try JSONSerialization.data(withJSONObject: meta)
+        try metaData.write(to: metaURL, options: .atomic)
+        return ArtifactRef(id: UUID().uuidString, sha256: sha, size: data.count, kind: kind, mime: mime, ext: ext, refPath: fileURL.path, createdAt: now)
+    }
+
+    public func get(refPath: String) throws -> (data: Data, mime: String)? {
+        let url = URL(fileURLWithPath: refPath)
+        let data = try Data(contentsOf: url)
+        let metaURL = url.deletingPathExtension().appendingPathExtension("meta.json")
+        var mime = "application/octet-stream"
+        if let md = try? Data(contentsOf: metaURL), let obj = try? JSONSerialization.jsonObject(with: md) as? [String: Any], let m = obj["mime"] as? String { mime = m }
+        return (data, mime)
+    }
+
+    public func delete(refPath: String) throws {
+        try FileManager.default.removeItem(atPath: refPath)
+        let metaPath = (refPath as NSString).deletingPathExtension + ".meta.json"
+        _ = try? FileManager.default.removeItem(atPath: metaPath)
+    }
+
+    public func gc(now: Date) throws -> Int {
+        var removed = 0
+        guard let enumerator = FileManager.default.enumerator(at: root, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles]) else { return 0 }
+        for case let url as URL in enumerator {
+            if url.pathExtension == "json" && url.lastPathComponent.hasSuffix("meta.json") {
+                if let md = try? Data(contentsOf: url), let obj = try? JSONSerialization.jsonObject(with: md) as? [String: Any], let created = obj["createdAt"] as? Double, let ttl = obj["ttlDays"] as? Int {
+                    let expiry = Date(timeIntervalSince1970: created).addingTimeInterval(TimeInterval(ttl * 86_400))
+                    if now >= expiry {
+                        let bin = url.deletingPathExtension().deletingPathExtension().appendingPathExtension("bin") // not used
+                        let dataPathGuess = (url.deletingPathExtension().deletingPathExtension().path)
+                        // remove corresponding data file (unknown ext), best-effort: remove any file beginning with sha.* in same dir
+                        let sha = url.deletingPathExtension().deletingPathExtension().lastPathComponent
+                        if let dirEnum = FileManager.default.enumerator(at: url.deletingLastPathComponent(), includingPropertiesForKeys: nil) {
+                            for case let f as URL in dirEnum {
+                                if f.lastPathComponent.hasPrefix(sha + ".") { _ = try? FileManager.default.removeItem(at: f); removed += 1 }
+                            }
+                        }
+                        _ = try? FileManager.default.removeItem(at: url)
+                    }
+                }
+            }
+        }
+        return removed
+    }
+
+    private func sha256Hex(_ data: Data) -> String {
+        #if canImport(CryptoKit)
+        let digest = SHA256.hash(data: data)
+        return digest.map { String(format: "%02x", $0) }.joined()
+        #else
+        // Fallback: simple hash (not cryptographic) if CryptoKit unavailable
+        return String(data.hashValue, radix: 16)
+        #endif
+    }
+}
+
+#if canImport(Typesense)
+import Typesense
+
+public final class TypesenseArtifacts: @unchecked Sendable {
+    let client: Client
+    public init(nodes: [String], apiKey: String, debug: Bool = false) {
+        let tsNodes = nodes.map { Node(url: $0) }
+        let config = Configuration(nodes: tsNodes, apiKey: apiKey, logger: Logger(debugMode: debug))
+        self.client = Client(config: config)
+        Task { try? await self.ensureCollection() }
+    }
+    private func ensureCollection() async throws {
+        let fields = [
+            Field(name: "id", type: "string"),
+            Field(name: "pageId", type: "string"),
+            Field(name: "analysisId", type: "string"),
+            Field(name: "kind", type: "string"),
+            Field(name: "mime", type: "string"),
+            Field(name: "size", type: "int64"),
+            Field(name: "sha256", type: "string"),
+            Field(name: "labels", type: "string[]"),
+            Field(name: "host", type: "string"),
+            Field(name: "lang", type: "string"),
+            Field(name: "createdAt", type: "int64"),
+            Field(name: "ttlAt", type: "int64", optional: true),
+            Field(name: "inlineBody", type: "string", optional: true),
+            Field(name: "blobRef", type: "string", optional: true)
+        ]
+        _ = try? await client.collections.create(schema: CollectionSchema(name: "artifacts", fields: fields, defaultSortingField: nil))
+    }
+    public struct ArtifactDoc: Codable {
+        public let id: String
+        public let pageId: String?
+        public let analysisId: String?
+        public let kind: String
+        public let mime: String
+        public let size: Int
+        public let sha256: String
+        public let labels: [String]?
+        public let host: String?
+        public let lang: String?
+        public let createdAt: Int64
+        public let ttlAt: Int64?
+        public let inlineBody: String?
+        public let blobRef: String?
+    }
+    public func upsert(_ doc: ArtifactDoc) {
+        if let data = try? JSONEncoder().encode(doc) {
+            Task { _ = try? await client.collection(name: "artifacts").documents().upsert(document: data) }
+        }
+    }
+
+    public func search(pageId: String? = nil, analysisId: String? = nil, kind: String? = nil, limit: Int = 50) async -> [ArtifactDoc] {
+        var filters: [String] = []
+        if let pageId, !pageId.isEmpty { filters.append("pageId:=\(pageId)") }
+        if let analysisId, !analysisId.isEmpty { filters.append("analysisId:=\(analysisId)") }
+        if let kind, !kind.isEmpty { filters.append("kind:=\(kind)") }
+        let params = SearchParameters(q: "*", queryBy: "kind,pageId,analysisId,host,lang,labels", filterBy: filters.isEmpty ? nil : filters.joined(separator: " && "), page: 1, perPage: max(1, min(limit, 200)))
+        let res = try? await client.collection(name: "artifacts").documents().search(params, for: ArtifactDoc.self)
+        return res?.0.hits?.compactMap { $0.document } ?? []
+    }
+}
+#endif

--- a/semantic-browser/Sources/SemanticBrowser/BrowserEngine.swift
+++ b/semantic-browser/Sources/SemanticBrowser/BrowserEngine.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+// Forward declaration for options type
+// Uses APIModels.WaitPolicy from ModelsAPI.swift in this module
+public struct SnapshotResult: Sendable {
+    public let html: String
+    public let text: String
+    public let finalURL: String
+    public let loadMs: Int?
+    public let network: [APIModels.Snapshot.Network.Request]?
+    public let pageStatus: Int?
+    public let pageContentType: String?
+    public let adminNetwork: [AdminNetworkRequest]?
+}
+
+public protocol BrowserEngine: Sendable {
+    func snapshotHTML(for url: String) async throws -> (html: String, text: String)
+    func snapshot(for url: String, wait: APIModels.WaitPolicy?, capture: CaptureOptions?) async throws -> SnapshotResult
+}
+
+public enum BrowserError: Error { case invalidURL, fetchFailed }
+
+public struct URLFetchBrowserEngine: BrowserEngine {
+    public init() {}
+    public func snapshotHTML(for url: String) async throws -> (html: String, text: String) {
+        let res = try await snapshot(for: url, wait: nil, capture: nil)
+        return (res.html, res.text)
+    }
+    public func snapshot(for url: String, wait: APIModels.WaitPolicy?, capture: CaptureOptions?) async throws -> SnapshotResult {
+        guard let u = URL(string: url) else { throw BrowserError.invalidURL }
+        let start = Date()
+        let (data, resp) = try await URLSession.shared.data(from: u)
+        let elapsed = Int(Date().timeIntervalSince(start) * 1000.0)
+        let html = String(data: data, encoding: .utf8) ?? ""
+        let text = html.removingHTMLTags()
+        let final = (resp.url?.absoluteString) ?? url
+        var contentType: String? = nil
+        if let http = resp as? HTTPURLResponse {
+            contentType = http.allHeaderFields["Content-Type"] as? String
+            if contentType == nil { contentType = http.value(forKey: "Content-Type") as? String }
+        }
+        if let ct = contentType, let semi = ct.firstIndex(of: ";") { contentType = String(ct[..<semi]) }
+        let status = (resp as? HTTPURLResponse)?.statusCode
+        return SnapshotResult(html: html, text: text, finalURL: final, loadMs: elapsed, network: nil, pageStatus: status, pageContentType: contentType)
+    }
+}
+
+public struct ShellBrowserEngine: BrowserEngine {
+    let binary: String
+    let args: [String]
+    public init(binary: String, args: [String] = []) { self.binary = binary; self.args = args }
+    public func snapshotHTML(for url: String) async throws -> (html: String, text: String) {
+        let res = try await snapshot(for: url, wait: nil, capture: nil)
+        return (res.html, res.text)
+    }
+    public func snapshot(for url: String, wait: APIModels.WaitPolicy?, capture: CaptureOptions?) async throws -> SnapshotResult {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: binary)
+        proc.arguments = args + [url]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        let start = Date()
+        try proc.run()
+        proc.waitUntilExit()
+        guard proc.terminationStatus == 0 else { throw BrowserError.fetchFailed }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let html = String(data: data, encoding: .utf8) ?? ""
+        let text = html.removingHTMLTags()
+        let elapsed = Int(Date().timeIntervalSince(start) * 1000.0)
+        return SnapshotResult(html: html, text: text, finalURL: url, loadMs: elapsed, network: nil, pageStatus: nil, pageContentType: nil)
+    }
+}
+
+public extension BrowserEngine {
+    func snapshot(for url: String, wait: APIModels.WaitPolicy?, capture: CaptureOptions?) async throws -> SnapshotResult {
+        let r = try await snapshotHTML(for: url)
+        return SnapshotResult(html: r.html, text: r.text, finalURL: url, loadMs: nil, network: nil, pageStatus: nil, pageContentType: nil, adminNetwork: nil)
+    }
+}
+
+public struct CaptureOptions: Sendable {
+    public let allowedMIMEs: Set<String>?
+    public let maxBodies: Int?
+    public let maxBodyBytes: Int?
+    public let maxTotalBytes: Int?
+    public init(allowedMIMEs: Set<String>? = nil, maxBodies: Int? = nil, maxBodyBytes: Int? = nil, maxTotalBytes: Int? = nil) {
+        self.allowedMIMEs = allowedMIMEs
+        self.maxBodies = maxBodies
+        self.maxBodyBytes = maxBodyBytes
+        self.maxTotalBytes = maxTotalBytes
+    }
+}
+
+public struct AdminNetworkRequest: Codable, Sendable, Equatable {
+    public let url: String
+    public let type: String?
+    public let status: Int?
+    public let method: String?
+    public let requestHeaders: [String: String]?
+    public let responseHeaders: [String: String]?
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/semantic-browser/Sources/SemanticBrowser/CDPBrowserEngine.swift
+++ b/semantic-browser/Sources/SemanticBrowser/CDPBrowserEngine.swift
@@ -1,0 +1,320 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public struct CDPBrowserEngine: BrowserEngine {
+    let wsURL: URL
+    public init(wsURL: URL) { self.wsURL = wsURL }
+
+    public func snapshotHTML(for url: String) async throws -> (html: String, text: String) {
+        if #available(macOS 14.0, *) {
+            let session = CDPSession(wsURL: wsURL)
+            try await session.open()
+            defer { Task { await session.close() } }
+            let targetId = try await session.createTarget(url: "about:blank")
+            try await session.attach(targetId: targetId)
+            try await session.enablePage()
+            try await session.navigate(url: url)
+            try await session.waitForLoadEvent(timeoutMs: 5000)
+            let html = try await session.getOuterHTML()
+            let text = html.removingHTMLTags()
+            return (html, text)
+        } else {
+            throw BrowserError.fetchFailed
+        }
+    }
+
+    public func snapshot(for url: String, wait: APIModels.WaitPolicy?, capture: CaptureOptions?) async throws -> SnapshotResult {
+        if #available(macOS 14.0, *) {
+            let session = CDPSession(wsURL: wsURL)
+            try await session.open()
+            defer { Task { await session.close() } }
+            let targetId = try await session.createTarget(url: "about:blank")
+            try await session.attach(targetId: targetId)
+            try await session.enablePage()
+            try await session.enableNetwork()
+            let start = Date()
+            try await session.navigate(url: url)
+            let strat = wait?.strategy?.lowercased()
+            if strat == "domcontentloaded" {
+                try await session.waitForDomContentLoaded(timeoutMs: wait?.maxWaitMs ?? 5000)
+            } else if strat == "networkidle" {
+                try await session.waitForLoadEvent(timeoutMs: wait?.maxWaitMs ?? 5000)
+                if let idle = wait?.networkIdleMs, idle > 0 {
+                    try await session.waitForNetworkIdle(idleMs: idle, timeoutMs: wait?.maxWaitMs ?? (idle + 3000))
+                }
+            } else {
+                try await session.waitForLoadEvent(timeoutMs: wait?.maxWaitMs ?? 5000)
+            }
+            let loadMs = Int(Date().timeIntervalSince(start) * 1000.0)
+            let html = try await session.getOuterHTML()
+            let text = html.removingHTMLTags()
+            let final = (try? await session.getCurrentURL()) ?? url
+            // Capture selected response bodies (textual types) with truncation
+            let env = ProcessInfo.processInfo.environment
+            var allowed: Set<String> = [
+                "text/html", "text/plain", "text/css",
+                "application/json", "application/javascript", "text/javascript"
+            ]
+            if let raw = env["SB_NET_BODY_MIME_ALLOW"], !raw.isEmpty {
+                for m in raw.split(separator: ",") { allowed.insert(String(m).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()) }
+            }
+            if let reqAllowed = capture?.allowedMIMEs { allowed.formUnion(reqAllowed.map { $0.lowercased() }) }
+            let maxBodies = max(capture?.maxBodies ?? (Int(env["SB_NET_BODY_MAX_COUNT"] ?? "20") ?? 20), 0)
+            let maxBytes = max(capture?.maxBodyBytes ?? (Int(env["SB_NET_BODY_MAX_BYTES"] ?? "16384") ?? 16384), 512)
+            let maxTotal = max(capture?.maxTotalBytes ?? (Int(env["SB_NET_BODY_TOTAL_MAX_BYTES"] ?? "131072") ?? 131072), maxBytes)
+            var captured: [String: String] = [:]
+            var count = 0
+            var total = 0
+            for (rid, info) in session.reqs {
+                if count >= maxBodies || total >= maxTotal { break }
+                if let mt = info.mimeType?.lowercased(), (info.status ?? 0) < 400 {
+                    if allowed.contains(mt) || mt.hasPrefix("text/") || mt.hasSuffix("+json") {
+                        if let cl = info.contentLength, cl > maxBytes { continue }
+                        if let el = info.encodedLength, el > maxBytes { continue }
+                        if let (body, b64) = try? await session.getResponseBody(requestId: rid) {
+                            var data: Data? = nil
+                            if b64 { data = Data(base64Encoded: body) } else { data = body.data(using: .utf8) }
+                            if let d = data {
+                                let truncated = d.prefix(maxBytes)
+                                if let s = String(data: truncated, encoding: .utf8) {
+                                    captured[rid] = s
+                                    count += 1
+                                    total += truncated.count
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            let requests: [APIModels.Snapshot.Network.Request] = session.reqs.map { (rid, info) in
+                APIModels.Snapshot.Network.Request(url: info.url, type: info.type, status: info.status, body: captured[rid])
+            }
+            let adminRequests: [AdminNetworkRequest] = session.reqs.map { (_, info) in
+                AdminNetworkRequest(url: info.url, type: info.type, status: info.status, method: info.method, requestHeaders: info.requestHeaders, responseHeaders: info.responseHeaders)
+            }
+            // Main document info
+            var docStatus: Int? = nil
+            var docCT: String? = nil
+            if let main = session.reqs.values.first(where: { ($0.type ?? "").lowercased() == "document" && ($0.url == final || $0.url == url) }) ?? session.reqs.values.first(where: { ($0.type ?? "").lowercased() == "document" }) {
+                docStatus = main.status
+                docCT = main.mimeType
+            }
+            return SnapshotResult(html: html, text: text, finalURL: final, loadMs: loadMs, network: requests, pageStatus: docStatus, pageContentType: docCT, adminNetwork: adminRequests)
+        } else {
+            throw BrowserError.fetchFailed
+        }
+    }
+}
+
+@available(macOS 14.0, *)
+actor CDPSession {
+    let wsURL: URL
+    var task: URLSessionWebSocketTask?
+    var nextId: Int = 1
+    // Network tracking
+    var inflight: Set<String> = []
+    struct ReqInfo { var url: String; var type: String?; var status: Int?; var mimeType: String?; var body: String?; var encodedLength: Int?; var contentLength: Int?; var method: String?; var requestHeaders: [String: String]?; var responseHeaders: [String: String]? }
+    var reqs: [String: ReqInfo] = [:]
+    init(wsURL: URL) { self.wsURL = wsURL }
+    func open() async throws {
+        let session = URLSession(configuration: .default)
+        let task = session.webSocketTask(with: wsURL)
+        self.task = task
+        task.resume()
+        try await Task.sleep(nanoseconds: 100_000_000)
+    }
+    func close() {
+        task?.cancel()
+    }
+    private func processEventObject(_ obj: [String: Any]) {
+        guard let method = obj["method"] as? String, let params = obj["params"] as? [String: Any] else { return }
+        switch method {
+        case "Network.requestWillBeSent":
+            if let rid = params["requestId"] as? String, let req = params["request"] as? [String: Any], let url = req["url"] as? String {
+                inflight.insert(rid)
+                var info = reqs[rid] ?? ReqInfo(url: url, type: nil, status: nil, mimeType: nil, body: nil, encodedLength: nil, contentLength: nil, method: nil, requestHeaders: nil, responseHeaders: nil)
+                if let t = params["type"] as? String { info.type = t }
+                if let m = req["method"] as? String { info.method = m }
+                if let hdrs = req["headers"] as? [String: Any] { var h: [String:String] = [:]; for (k,v) in hdrs { h[k] = "\(v)" }; info.requestHeaders = h }
+                reqs[rid] = info
+            }
+        case "Network.responseReceived":
+            if let rid = params["requestId"] as? String, let resp = params["response"] as? [String: Any] {
+                var info = reqs[rid] ?? ReqInfo(url: "", type: nil, status: nil, mimeType: nil, body: nil, encodedLength: nil, contentLength: nil, method: nil, requestHeaders: nil, responseHeaders: nil)
+                if let s = resp["status"] as? Int { info.status = s }
+                if let t = params["type"] as? String { info.type = t }
+                if let url = resp["url"] as? String, info.url.isEmpty { info.url = url }
+                if let mt = resp["mimeType"] as? String { info.mimeType = mt }
+                if let hdrs = resp["headers"] as? [String: Any] { var h: [String:String] = [:]; for (k,v) in hdrs { h[k] = "\(v)"; if k.lowercased()=="content-length" { if let s=v as? String, let n=Int(s){ info.contentLength=n } else if let n=v as? Int { info.contentLength=n } else if let n=v as? Double { info.contentLength=Int(n) } } }; info.responseHeaders = h }
+                reqs[rid] = info
+            }
+        case "Network.loadingFinished":
+            if let rid = params["requestId"] as? String {
+                inflight.remove(rid)
+                if let len = params["encodedDataLength"] as? Double {
+                    var info = reqs[rid] ?? ReqInfo(url: "", type: nil, status: nil, mimeType: nil, body: nil, encodedLength: nil, contentLength: nil, method: nil, requestHeaders: nil, responseHeaders: nil)
+                    info.encodedLength = Int(len)
+                    reqs[rid] = info
+                }
+            }
+        case "Network.loadingFailed":
+            if let rid = params["requestId"] as? String { inflight.remove(rid) }
+        default:
+            break
+        }
+    }
+
+    private func sendRecv<T: Decodable>(_ method: String, params: [String: Any]? = nil, result: T.Type) async throws -> T {
+        guard let task else { throw BrowserError.fetchFailed }
+        let id = nextId; nextId += 1
+        var obj: [String: Any] = ["id": id, "method": method]
+        if let params { obj["params"] = params }
+        let data = try JSONSerialization.data(withJSONObject: obj)
+        try await task.send(.data(data))
+        while true {
+            let msg = try await task.receive()
+            switch msg {
+            case .data(let d):
+                let j = try JSONSerialization.jsonObject(with: d) as? [String: Any]
+                if let m = j, m["method"] != nil { processEventObject(m) }
+                if let rid = j?["id"] as? Int, rid == id {
+                    if let res = j?["result"] {
+                        let rd = try JSONSerialization.data(withJSONObject: res)
+                        return try JSONDecoder().decode(T.self, from: rd)
+                    } else { throw BrowserError.fetchFailed }
+                }
+            case .string(let s):
+                if let d = s.data(using: .utf8) {
+                    let j = try JSONSerialization.jsonObject(with: d) as? [String: Any]
+                    if let m = j, m["method"] != nil { processEventObject(m) }
+                    if let rid = j?["id"] as? Int, rid == id {
+                        if let res = j?["result"] {
+                            let rd = try JSONSerialization.data(withJSONObject: res)
+                            return try JSONDecoder().decode(T.self, from: rd)
+                        } else { throw BrowserError.fetchFailed }
+                    }
+                }
+            @unknown default: break
+            }
+        }
+    }
+    func createTarget(url: String) async throws -> String {
+        struct R: Decodable { let targetId: String }
+        let r: R = try await sendRecv("Target.createTarget", params: ["url": url], result: R.self)
+        return r.targetId
+    }
+    func attach(targetId: String) async throws {
+        struct R: Decodable { let sessionId: String }
+        _ = try await sendRecv("Target.attachToTarget", params: ["targetId": targetId, "flatten": true], result: R.self)
+    }
+    func enablePage() async throws { struct R: Decodable {}; _ = try await sendRecv("Page.enable", params: [:], result: R.self) }
+    func enableNetwork() async throws { struct R: Decodable {}; _ = try await sendRecv("Network.enable", params: [:], result: R.self) }
+    func navigate(url: String) async throws { struct R: Decodable {}; _ = try await sendRecv("Page.navigate", params: ["url": url], result: R.self) }
+    func waitForLoadEvent(timeoutMs: Int) async throws {
+        let deadline = Date().addingTimeInterval(Double(timeoutMs)/1000.0)
+        while Date() < deadline {
+            guard let task else { throw BrowserError.fetchFailed }
+            do {
+                let msg = try await withTaskCancellationHandler(operation: {
+                    try await withTimeout(seconds: 0.5) { try await task.receive() }
+                }, onCancel: { })
+                switch msg {
+                case .data(let d):
+                    if let m = try? JSONSerialization.jsonObject(with: d) as? [String: Any] {
+                        if (m["method"] as? String) == "Page.loadEventFired" { return }
+                        processEventObject(m)
+                    }
+                case .string(let s):
+                    if let d = s.data(using: .utf8), let m = try? JSONSerialization.jsonObject(with: d) as? [String: Any] {
+                        if (m["method"] as? String) == "Page.loadEventFired" { return }
+                        processEventObject(m)
+                    }
+                @unknown default: break
+                }
+            } catch { /* ignore timeouts */ }
+        }
+    }
+    func waitForDomContentLoaded(timeoutMs: Int) async throws {
+        let deadline = Date().addingTimeInterval(Double(timeoutMs)/1000.0)
+        while Date() < deadline {
+            guard let task else { throw BrowserError.fetchFailed }
+            do {
+                let msg = try await withTaskCancellationHandler(operation: {
+                    try await withTimeout(seconds: 0.5) { try await task.receive() }
+                }, onCancel: { })
+                switch msg {
+                case .data(let d):
+                    if let m = try? JSONSerialization.jsonObject(with: d) as? [String: Any] {
+                        if (m["method"] as? String) == "Page.domContentEventFired" { return }
+                        processEventObject(m)
+                    }
+                case .string(let s):
+                    if let d = s.data(using: .utf8), let m = try? JSONSerialization.jsonObject(with: d) as? [String: Any] {
+                        if (m["method"] as? String) == "Page.domContentEventFired" { return }
+                        processEventObject(m)
+                    }
+                @unknown default: break
+                }
+            } catch { /* ignore timeouts */ }
+        }
+    }
+    func waitForNetworkIdle(idleMs: Int, timeoutMs: Int) async throws {
+        let overallDeadline = Date().addingTimeInterval(Double(timeoutMs)/1000.0)
+        var idleStart: Date? = nil
+        while Date() < overallDeadline {
+            if inflight.isEmpty {
+                if idleStart == nil { idleStart = Date() }
+                if let started = idleStart, Int(Date().timeIntervalSince(started) * 1000.0) >= idleMs { return }
+            } else {
+                idleStart = nil
+            }
+            // drain events for a short period
+            guard let task else { throw BrowserError.fetchFailed }
+            do {
+                let msg = try await withTimeout(seconds: 0.2) { try await task.receive() }
+                switch msg {
+                case .data(let d):
+                    if let m = try? JSONSerialization.jsonObject(with: d) as? [String: Any] { processEventObject(m) }
+                case .string(let s):
+                    if let d = s.data(using: .utf8), let m = try? JSONSerialization.jsonObject(with: d) as? [String: Any] { processEventObject(m) }
+                @unknown default: break
+                }
+            } catch { /* time slice idle */ }
+        }
+    }
+    func getOuterHTML() async throws -> String {
+        struct GetDoc: Decodable { let root: Node }
+        struct Node: Decodable { let nodeId: Int }
+        let doc: GetDoc = try await sendRecv("DOM.getDocument", params: ["depth": -1], result: GetDoc.self)
+        struct Outer: Decodable { let outerHTML: String }
+        let out: Outer = try await sendRecv("DOM.getOuterHTML", params: ["nodeId": doc.root.nodeId], result: Outer.self)
+        return out.outerHTML
+    }
+    func getResponseBody(requestId: String) async throws -> (String, Bool) {
+        struct BodyRes: Decodable { let body: String; let base64Encoded: Bool }
+        let r: BodyRes = try await sendRecv("Network.getResponseBody", params: ["requestId": requestId], result: BodyRes.self)
+        return (r.body, r.base64Encoded)
+    }
+    func getCurrentURL() async throws -> String? {
+        struct Hist: Decodable { let currentIndex: Int; let entries: [Entry] }
+        struct Entry: Decodable { let url: String }
+        let h: Hist = try await sendRecv("Page.getNavigationHistory", params: [:], result: Hist.self)
+        if h.currentIndex >= 0 && h.currentIndex < h.entries.count { return h.entries[h.currentIndex].url }
+        return nil
+    }
+}
+
+@available(macOS 14.0, *)
+func withTimeout<T>(seconds: Double, operation: @escaping () async throws -> T) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask { try await operation() }
+        group.addTask { try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000)); throw BrowserError.fetchFailed }
+        let result = try await group.next()!
+        group.cancelAll()
+        return result
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/semantic-browser/Sources/SemanticBrowser/HTMLParser.swift
+++ b/semantic-browser/Sources/SemanticBrowser/HTMLParser.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+public struct HTMLParser {
+    public init() {}
+
+    public struct BlockSpan: Sendable {
+        public let id: String
+        public let kind: String
+        public let level: Int?
+        public let text: String
+        public let start: Int
+        public let end: Int
+        public let table: SemanticMemoryService.FullAnalysis.Table?
+    }
+
+    public func parseTextAndBlocks(from html: String) -> (text: String, blocks: [BlockSpan]) {
+        let stripped = stripScriptsAndStyles(html)
+        var i = stripped.startIndex
+        var out = String()
+        var blocks: [BlockSpan] = []
+        var nextHeading = 0, nextPara = 0, nextCode = 0, nextTable = 0
+
+        func normalize(_ s: String) -> String {
+            var t = s
+            t = t.replacingOccurrences(of: "&nbsp;", with: " ")
+            t = t.replacingOccurrences(of: "&amp;", with: "&")
+            t = t.replacingOccurrences(of: "&lt;", with: "<")
+            t = t.replacingOccurrences(of: "&gt;", with: ">")
+            t = t.replacingOccurrences(of: "\r|\n|\t", with: " ", options: .regularExpression)
+            return t.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+        }
+
+        while i < stripped.endIndex {
+            if stripped[i] == "<" {
+                if let gt = stripped[i...].firstIndex(of: ">") {
+                    let raw = String(stripped[stripped.index(after: i)..<gt]).lowercased()
+                    if let m = raw.firstMatch(of: /^h([1-6])\b/), let lvl = Int(String(m.1)) {
+                        if let endTag = findClosingTag(in: stripped, from: gt, tag: "h\(lvl)") {
+                            let inner = String(stripped[stripped.index(after: gt)..<endTag])
+                            let text = normalize(inner.removingHTMLTags()).trimmingCharacters(in: .whitespaces)
+                            let start = out.count
+                            if !text.isEmpty { out += (start == 0 ? "" : " ") + text }
+                            let end = out.count
+                            blocks.append(BlockSpan(id: "h\(nextHeading)", kind: "heading", level: lvl, text: text, start: start, end: end, table: nil))
+                            nextHeading += 1
+                            i = stripped.index(endTag, offsetBy: 4)
+                            continue
+                        }
+                    } else if raw.hasPrefix("p") {
+                        if let endTag = findClosingTag(in: stripped, from: gt, tag: "p") {
+                            let inner = String(stripped[stripped.index(after: gt)..<endTag])
+                            let text = normalize(inner.removingHTMLTags()).trimmingCharacters(in: .whitespaces)
+                            let start = out.count
+                            if !text.isEmpty { out += (start == 0 ? "" : " ") + text }
+                            let end = out.count
+                            blocks.append(BlockSpan(id: "p\(nextPara)", kind: "paragraph", level: nil, text: text, start: start, end: end, table: nil))
+                            nextPara += 1
+                            i = stripped.index(endTag, offsetBy: 4)
+                            continue
+                        }
+                    } else if raw.hasPrefix("pre") || raw.hasPrefix("code") {
+                        let tag = raw.hasPrefix("pre") ? "pre" : "code"
+                        if let endTag = findClosingTag(in: stripped, from: gt, tag: tag) {
+                            let inner = String(stripped[stripped.index(after: gt)..<endTag])
+                            let text = normalize(inner.removingHTMLTags()).trimmingCharacters(in: .whitespaces)
+                            let start = out.count
+                            if !text.isEmpty { out += (start == 0 ? "" : " ") + text }
+                            let end = out.count
+                            blocks.append(BlockSpan(id: "c\(nextCode)", kind: "code", level: nil, text: text, start: start, end: end, table: nil))
+                            nextCode += 1
+                            i = stripped.index(endTag, offsetBy: 7)
+                            continue
+                        }
+                    } else if raw.hasPrefix("table") {
+                        if let endTag = findClosingTag(in: stripped, from: gt, tag: "table") {
+                            let tableHTML = String(stripped[stripped.index(after: gt)..<endTag])
+                            let caption = firstMatch(tableHTML, pattern: "<caption[^>]*>(.*?)</caption>")?.removingHTMLTags()
+                            var columns: [String]? = nil
+                            if let thead = firstMatch(tableHTML, pattern: "<thead[\\s\\S]*?</thead>") {
+                                let ths = allMatches(thead, pattern: "<th[^>]*>(.*?)</th>").map { $0.removingHTMLTags() }
+                                columns = ths.isEmpty ? nil : ths
+                            }
+                            let rowHTMLs = allMatches(tableHTML, pattern: "<tr[\\s\\S]*?</tr>")
+                            var rows: [[String]] = []
+                            for r in rowHTMLs {
+                                let cells = allMatches(r, pattern: "<t[dh][^>]*>(.*?)</t[dh]>").map { $0.removingHTMLTags() }
+                                if !cells.isEmpty { rows.append(cells) }
+                            }
+                            let table = SemanticMemoryService.FullAnalysis.Table(caption: caption, columns: columns, rows: rows)
+                            let flat = (columns ?? []).joined(separator: " ") + " " + rows.prefix(3).flatMap { $0 }.joined(separator: " ")
+                            let text = normalize(flat).trimmingCharacters(in: .whitespaces)
+                            let start = out.count
+                            if !text.isEmpty { out += (start == 0 ? "" : " ") + text }
+                            let end = out.count
+                            blocks.append(BlockSpan(id: "t\(nextTable)", kind: "table", level: nil, text: text, start: start, end: end, table: table))
+                            nextTable += 1
+                            i = stripped.index(endTag, offsetBy: 8)
+                            continue
+                        }
+                    }
+                    i = stripped.index(after: gt)
+                } else {
+                    i = stripped.index(after: i)
+                }
+            } else {
+                let nextLt = stripped[i...].firstIndex(of: "<") ?? stripped.endIndex
+                let chunk = String(stripped[i..<nextLt])
+                let n = chunk.replacingOccurrences(of: "\r|\n|\t", with: " ", options: .regularExpression)
+                let nt = n.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression).trimmingCharacters(in: .whitespaces)
+                if !nt.isEmpty { out += (out.isEmpty ? "" : " ") + nt }
+                i = nextLt
+            }
+        }
+        return (out.trimmingCharacters(in: .whitespaces), blocks)
+    }
+
+    public func parseBlocks(from html: String) -> [SemanticMemoryService.FullAnalysis.Block] {
+        let (_, spans) = parseTextAndBlocks(from: html)
+        return spans.map { SemanticMemoryService.FullAnalysis.Block(id: $0.id, kind: $0.kind, text: $0.text, table: $0.table) }
+    }
+
+    // MARK: - Regex helpers
+    private func matchesTwoGroups(_ s: String, pattern: String) -> [(String, String)] {
+        guard let re = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return [] }
+        let range = NSRange(s.startIndex..<s.endIndex, in: s)
+        return re.matches(in: s, options: [], range: range).compactMap { m in
+            guard m.numberOfRanges >= 3,
+                  let r1 = Range(m.range(at: 1), in: s),
+                  let r2 = Range(m.range(at: 2), in: s) else { return nil }
+            return (String(s[r1]), String(s[r2]))
+        }
+    }
+
+    private func matchesOneGroup(_ s: String, pattern: String) -> [String] {
+        guard let re = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return [] }
+        let range = NSRange(s.startIndex..<s.endIndex, in: s)
+        return re.matches(in: s, options: [], range: range).compactMap { m in
+            guard m.numberOfRanges >= 2, let r1 = Range(m.range(at: 1), in: s) else { return nil }
+            return String(s[r1])
+        }
+    }
+
+    private func allMatches(_ s: String, pattern: String) -> [String] {
+        guard let re = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return [] }
+        let range = NSRange(s.startIndex..<s.endIndex, in: s)
+        return re.matches(in: s, options: [], range: range).compactMap { m in
+            guard let r = Range(m.range(at: 0), in: s) else { return nil }
+            return String(s[r])
+        }
+    }
+
+    private func firstMatch(_ s: String, pattern: String) -> String? {
+        guard let re = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]) else { return nil }
+        let range = NSRange(s.startIndex..<s.endIndex, in: s)
+        guard let m = re.firstMatch(in: s, options: [], range: range), m.numberOfRanges >= 2, let r = Range(m.range(at: 1), in: s) else { return nil }
+        return String(s[r])
+    }
+
+    private func stripScriptsAndStyles(_ html: String) -> String {
+        var s = html.replacingOccurrences(of: "<script[\\s\\S]*?</script>", with: "", options: .regularExpression)
+        s = s.replacingOccurrences(of: "<style[\\s\\S]*?</style>", with: "", options: .regularExpression)
+        return s
+    }
+
+    private func findClosingTag(in s: String, from: String.Index, tag: String) -> String.Index? {
+        let close = "</\(tag)>"
+        return s[from...].range(of: close, options: .caseInsensitive)?.lowerBound
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/semantic-browser/Sources/SemanticBrowser/JSONLogger.swift
+++ b/semantic-browser/Sources/SemanticBrowser/JSONLogger.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum LogLevel: String { case debug, info, warn, error }
+
+func logJSON(_ level: LogLevel, _ message: String, _ fields: [String: Any] = [:]) {
+    var base: [String: Any] = [
+        "ts": ISO8601DateFormatter().string(from: Date()),
+        "level": level.rawValue,
+        "msg": message
+    ]
+    for (k, v) in fields { base[k] = v }
+    if let data = try? JSONSerialization.data(withJSONObject: base), let line = String(data: data, encoding: .utf8) {
+        print(line)
+    }
+}
+

--- a/semantic-browser/Sources/SemanticBrowser/Models.swift
+++ b/semantic-browser/Sources/SemanticBrowser/Models.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+public struct PageDoc: Codable, Sendable, Equatable {
+    public let id: String
+    public let url: String
+    public let host: String
+    public let status: Int?
+    public let contentType: String?
+    public let lang: String?
+    public let title: String?
+    public let textSize: Int?
+    public let fetchedAt: Int?
+    public let labels: [String]?
+    public init(id: String, url: String, host: String, status: Int? = nil, contentType: String? = nil, lang: String? = nil, title: String? = nil, textSize: Int? = nil, fetchedAt: Int? = nil, labels: [String]? = nil) {
+        self.id = id; self.url = url; self.host = host; self.status = status; self.contentType = contentType; self.lang = lang; self.title = title; self.textSize = textSize; self.fetchedAt = fetchedAt; self.labels = labels
+    }
+}
+
+public struct SegmentDoc: Codable, Sendable, Equatable {
+    public let id: String
+    public let pageId: String
+    public let kind: String
+    public let text: String
+    public let pathHint: String?
+    public let offsetStart: Int?
+    public let offsetEnd: Int?
+    public let entities: [String]?
+    public init(id: String, pageId: String, kind: String, text: String, pathHint: String? = nil, offsetStart: Int? = nil, offsetEnd: Int? = nil, entities: [String]? = nil) {
+        self.id = id; self.pageId = pageId; self.kind = kind; self.text = text; self.pathHint = pathHint; self.offsetStart = offsetStart; self.offsetEnd = offsetEnd; self.entities = entities
+    }
+}
+
+public struct EntityDoc: Codable, Sendable, Equatable {
+    public let id: String
+    public let name: String
+    public let type: String
+    public let pageCount: Int?
+    public let mentions: Int?
+    public init(id: String, name: String, type: String, pageCount: Int? = nil, mentions: Int? = nil) {
+        self.id = id; self.name = name; self.type = type; self.pageCount = pageCount; self.mentions = mentions
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+

--- a/semantic-browser/Sources/SemanticBrowser/ModelsAPI.swift
+++ b/semantic-browser/Sources/SemanticBrowser/ModelsAPI.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+// Minimal API models aligned to openapi/v1/semantic-browser.yml
+public enum APIModels {
+    // MARK: - Common
+    public struct WaitPolicy: Codable, Sendable {
+        public let strategy: String?
+        public let networkIdleMs: Int?
+        public let maxWaitMs: Int?
+        public init(strategy: String? = nil, networkIdleMs: Int? = nil, maxWaitMs: Int? = nil) {
+            self.strategy = strategy; self.networkIdleMs = networkIdleMs; self.maxWaitMs = maxWaitMs
+        }
+    }
+
+    // MARK: - Snapshot
+    public struct SnapshotRequest: Codable, Sendable {
+        public let url: String
+        public let wait: WaitPolicy
+        public let storeArtifacts: Bool?
+    }
+
+    public struct SnapshotResponse: Codable, Sendable {
+        public let snapshot: Snapshot
+    }
+
+    public struct Snapshot: Codable, Sendable {
+        public struct Page: Codable, Sendable {
+            public let uri: String
+            public let finalUrl: String?
+            public let fetchedAt: String
+            public let status: Int
+            public let contentType: String
+            public let navigation: Navigation?
+            public struct Navigation: Codable, Sendable { public let ttfbMs: Int?; public let loadMs: Int? }
+        }
+        public struct Rendered: Codable, Sendable {
+            public let html: String
+            public let text: String
+            public let meta: [String: String]?
+        }
+        public struct Network: Codable, Sendable {
+            public struct Request: Codable, Sendable {
+                public let url: String
+                public let type: String?
+                public let status: Int?
+                public let body: String?
+            }
+            public let requests: [Request]?
+        }
+        public let snapshotId: String
+        public let page: Page
+        public let rendered: Rendered
+        public let network: Network?
+        public let diagnostics: [String]?
+    }
+
+    // MARK: - Analyze / Analysis
+    public struct AnalyzeRequest: Codable, Sendable {
+        public struct SnapshotRef: Codable, Sendable { public let snapshotId: String }
+        public let snapshot: Snapshot?
+        public let snapshotRef: SnapshotRef?
+        public let mode: String
+    }
+
+    public struct Analysis: Codable, Sendable {
+        public struct Envelope: Codable, Sendable {
+            public struct Source: Codable, Sendable { public let uri: String?; public let fetchedAt: String? }
+            public let id: String
+            public let source: Source?
+            public let contentType: String?
+            public let language: String?
+            public let bytes: Int?
+            public let diagnostics: [String]?
+        }
+        public struct Table: Codable, Sendable { public let caption: String?; public let columns: [String]?; public let rows: [[String]] }
+        public struct Block: Codable, Sendable { public let id: String; public let kind: String; public let level: Int?; public let text: String; public let span: [Int]?; public let table: Table? }
+        public struct Entity: Codable, Sendable { public let id: String; public let name: String; public let type: String; public let mentions: [Mention]?; public struct Mention: Codable, Sendable { public let block: String?; public let span: [Int]? } }
+        public struct Claim: Codable, Sendable { public let id: String; public let text: String; public let stance: String?; public let hedge: String?; public let evidence: [Evidence]?; public struct Evidence: Codable, Sendable { public let block: String?; public let span: [Int]?; public let tableCell: [Int]? } }
+        public struct Semantics: Codable, Sendable { public let outline: [OutlineItem]?; public let entities: [Entity]?; public let claims: [Claim]?; public let relations: [Relation]?; public struct OutlineItem: Codable, Sendable { public let block: String?; public let level: Int? }; public struct Relation: Codable, Sendable { public let type: String?; public let from: String?; public let to: String? } }
+        public struct Summaries: Codable, Sendable { public let abstract: String?; public let keyPoints: [String]?; public let tl__dr: String?; enum CodingKeys: String, CodingKey { case abstract, keyPoints; case tl__dr = "tl;dr" } }
+        public struct Provenance: Codable, Sendable { public let pipeline: String?; public let model: String? }
+
+        public let envelope: Envelope
+        public let blocks: [Block]
+        public let semantics: Semantics?
+        public let summaries: Summaries
+        public let provenance: Provenance
+    }
+
+    // MARK: - Browse
+    public struct BrowseRequest: Codable, Sendable {
+        public struct IndexOptions: Codable, Sendable { public let enabled: Bool? }
+        public let url: String
+        public let wait: WaitPolicy
+        public let mode: String
+        public let index: IndexOptions?
+        public let storeArtifacts: Bool?
+        public let labels: [String]?
+    }
+
+    public struct BrowseResponse: Codable, Sendable {
+        public let snapshot: Snapshot
+        public let analysis: Analysis?
+        public let index: IndexResult?
+    }
+
+    // MARK: - Index
+    public struct IndexRequest: Codable, Sendable { public let analysis: Analysis; public struct Options: Codable, Sendable { public let enabled: Bool? }; public let options: Options? }
+    public struct IndexResult: Codable, Sendable { public let pagesUpserted: Int; public let segmentsUpserted: Int; public let entitiesUpserted: Int; public let tablesUpserted: Int }
+}
+
+// Helpers
+extension Date {
+    var iso8601String: String {
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return fmt.string(from: self)
+    }
+}

--- a/semantic-browser/Sources/SemanticBrowser/Server.swift
+++ b/semantic-browser/Sources/SemanticBrowser/Server.swift
@@ -1,0 +1,678 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+import FountainCodex
+
+actor SimpleRateLimiter {
+    private var buckets: [String: (start: TimeInterval, count: Int)] = [:]
+    func allow(id: String, limitPerMinute: Int) -> Bool {
+        let now = Date().timeIntervalSince1970
+        var entry = buckets[id] ?? (start: now, count: 0)
+        if now - entry.start >= 60 {
+            entry = (start: now, count: 0)
+        }
+        if entry.count + 1 > limitPerMinute { buckets[id] = entry; return false }
+        entry.count += 1
+        buckets[id] = entry
+        return true
+    }
+}
+
+actor ConcurrencyGate {
+    private(set) var inUse: Int = 0
+    let capacity: Int
+    init(capacity: Int) { self.capacity = max(0, capacity) }
+    func tryAcquire() -> Bool { if inUse >= capacity { return false }; inUse += 1; return true }
+    func release() { if inUse > 0 { inUse -= 1 } }
+}
+
+actor SimpleMetrics {
+    private var counts: [String: Int] = [:]
+    private var latencies: [String: [Int]] = [:]
+    private var gauges: [String: Int64] = [:]
+    func inc(_ name: String, by n: Int = 1) { counts[name, default: 0] += n }
+    func observe(_ name: String, ms: Int) { latencies[name, default: []].append(ms) }
+    func addGauge(_ name: String, by delta: Int64) { gauges[name, default: 0] += delta }
+    func setGauge(_ name: String, to value: Int64) { gauges[name] = value }
+    func renderPrometheus() -> String {
+        var out = ""
+        for (k,v) in counts { out += "# TYPE \(k) counter\n\(k) \(v)\n" }
+        for (k,arr) in latencies {
+            let sum = arr.reduce(0,+)
+            out += "# TYPE \(k)_ms summary\n\(k)_ms_count \(arr.count)\n\(k)_ms_sum \(sum)\n"
+        }
+        for (k,v) in gauges { out += "# TYPE \(k) gauge\n\(k) \(v)\n" }
+        return out
+    }
+}
+
+actor ConcurrencyGate {
+    private(set) var inUse: Int = 0
+    let capacity: Int
+    init(capacity: Int) { self.capacity = max(0, capacity) }
+    func tryAcquire() -> Bool { if inUse >= capacity { return false }; inUse += 1; return true }
+    func release() { if inUse > 0 { inUse -= 1 } }
+}
+
+actor HostGate {
+    private var inUseByHost: [String: Int] = [:]
+    private(set) var rejectedByHost: [String: Int] = [:]
+    private(set) var totalInUse: Int = 0
+    let totalCapacity: Int
+    let perHostCapacity: Int
+    init(total: Int, perHost: Int) { self.totalCapacity = max(0, total); self.perHostCapacity = max(1, perHost) }
+    func tryAcquire(host: String) -> Bool {
+        let h = host.lowercased()
+        let usedHost = inUseByHost[h] ?? 0
+        if totalInUse >= totalCapacity || usedHost >= perHostCapacity { rejectedByHost[h, default: 0] += 1; return false }
+        inUseByHost[h] = usedHost + 1
+        totalInUse += 1
+        return true
+    }
+    func release(host: String) {
+        let h = host.lowercased()
+        if let u = inUseByHost[h], u > 0 { inUseByHost[h] = u - 1 }
+        if totalInUse > 0 { totalInUse -= 1 }
+    }
+    func stats() -> (total: Int, used: Int, perHost: [String: Int], rejected: [String: Int], perHostCap: Int) {
+        return (totalCapacity, totalInUse, inUseByHost, rejectedByHost, perHostCapacity)
+    }
+}
+
+enum TimeoutError: Error { case deadlineExceeded }
+
+public func makeSemanticKernel(service: SemanticMemoryService, engine: BrowserEngine? = nil, apiKey: String? = nil, limiter: SimpleRateLimiter? = nil, limitPerMinute: Int = 60, requireAPIKey: Bool = false, reqBodyMaxBytes: Int = 1_000_000, reqTimeoutMs: Int = 15_000, metrics: SimpleMetrics? = nil, gate: ConcurrencyGate? = nil, hostGate: HostGate? = nil, artifactStore: ArtifactStore? = nil, artifactCatalog: Any? = nil) -> HTTPKernel {
+    func qp(_ path: String) -> [String: String] {
+        guard let i = path.firstIndex(of: "?") else { return [:] }
+        let q = path[path.index(after: i)...]
+        var out: [String: String] = [:]
+        for pair in q.split(separator: "&") {
+            let parts = pair.split(separator: "=", maxSplits: 1).map(String.init)
+            guard parts.count == 2 else { continue }
+            let key = parts[0].replacingOccurrences(of: "+", with: " ").removingPercentEncoding ?? parts[0]
+            let val = parts[1].replacingOccurrences(of: "+", with: " ").removingPercentEncoding ?? parts[1]
+            out[key] = val
+        }
+        return out
+    }
+    // SSRF allow/deny configuration and DNS cache
+    let env = ProcessInfo.processInfo.environment
+    func splitList(_ s: String?) -> [String] { (s ?? "").split(separator: ",").map { String($0).trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }.filter { !$0.isEmpty } }
+    let allowList = splitList(env["SB_URL_ALLOWLIST"]) // e.g., "example.com,.trusted.tld"
+    let denyList = splitList(env["SB_URL_DENYLIST"])   // e.g., "bad.com,.internal"
+    let allowCIDRs = splitList(env["SB_URL_ALLOWCIDR"]) // e.g., "1.2.3.0/24,10.0.0.0/8"
+    let denyCIDRs = splitList(env["SB_URL_DENYCIDR"])   // e.g., "127.0.0.0/8,::1/128"
+    let dnsTTL = max(Int(env["SB_DNS_CACHE_TTL"] ?? "60") ?? 60, 1)
+    var dnsCache: [String: (expires: Date, ips: [String])] = [:]
+
+    func withTimeout<T>(ms: Int, _ op: @escaping () async throws -> T) async -> Result<T, Error> {
+        await withTaskGroup(of: Result<T, Error>.self) { group in
+            let deadlineNs = UInt64(ms) * 1_000_000
+            group.addTask { do { return .success(try await op()) } catch { return .failure(error) } }
+            group.addTask { try? await Task.sleep(nanoseconds: deadlineNs); return .failure(TimeoutError.deadlineExceeded) }
+            let result = await group.next() ?? .failure(TimeoutError.deadlineExceeded)
+            group.cancelAll()
+            return result
+        }
+    }
+    return HTTPKernel { req in
+        // API key enforcement
+        if requireAPIKey {
+            if (req.headers["X-API-Key"] ?? "").isEmpty { return HTTPResponse(status: 401) }
+            if let key = apiKey, !key.isEmpty, (req.headers["X-API-Key"] ?? "") != key { return HTTPResponse(status: 401) }
+        } else if let apiKey, !apiKey.isEmpty {
+            if (req.headers["X-API-Key"] ?? "") != apiKey { return HTTPResponse(status: 401) }
+        }
+        // Request body size limit for POST
+        if req.method == "POST" && req.body.count > reqBodyMaxBytes { return HTTPResponse(status: 413) }
+        if let limiter {
+            let client = req.headers["X-Forwarded-For"] ?? req.headers["X-Client-Id"] ?? "anonymous"
+            let ok = await limiter.allow(id: client, limitPerMinute: limitPerMinute)
+            if !ok { return HTTPResponse(status: 429, headers: ["Content-Type": "text/plain"], body: Data("too many requests".utf8)) }
+        }
+        let pathOnly = req.path.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false).first.map(String.init) ?? req.path
+        let segs = pathOnly.split(separator: "/", omittingEmptySubsequences: true)
+        func urlAllowed(_ urlString: String) -> Bool {
+            guard let comp = URLComponents(string: urlString), let host = comp.host, let scheme = comp.scheme?.lowercased(), ["http","https"].contains(scheme) else { return false }
+            let h = host.lowercased()
+            if h == "localhost" { return false }
+            // allowlist/denylist host checks
+            func hostMatches(_ rule: String, host: String) -> Bool {
+                if rule.hasPrefix(".") { return host == String(rule.dropFirst()) || host.hasSuffix(rule) }
+                return host == rule
+            }
+            if !allowList.isEmpty && !allowList.contains(where: { hostMatches($0, host: h) }) { return false }
+            if denyList.contains(where: { hostMatches($0, host: h) }) { return false }
+            // IPv4 checks
+            func isPrivateIPv4(_ parts: [Int]) -> Bool {
+                if parts[0] == 10 { return true }
+                if parts[0] == 172 && parts[1] >= 16 && parts[1] <= 31 { return true }
+                if parts[0] == 192 && parts[1] == 168 { return true }
+                if parts[0] == 127 { return true }
+                if parts[0] == 169 && parts[1] == 254 { return true }
+                if parts[0] == 0 { return true }
+                return false
+            }
+            if h.split(separator: ".").count == 4, let octets = h.split(separator: ".").compactMap({ Int($0) }), octets.count == 4 {
+                if octets.contains(where: { $0 < 0 || $0 > 255 }) { return false }
+                if isPrivateIPv4(octets) { return false }
+            }
+            // IPv6 simple blocklist
+            if h.contains(":") {
+                let v6 = h
+                if v6 == "::1" { return false }
+                if v6.hasPrefix("fe80:") { return false } // link-local
+                if v6.hasPrefix("fc") || v6.hasPrefix("fd") { return false } // unique local
+                if v6 == "::" { return false }
+            }
+            // DNS resolve and block private/loopback
+            func resolveIPs(_ host: String) -> [String] {
+                if let entry = dnsCache[host], entry.expires > Date() { return entry.ips }
+                var hints = addrinfo(ai_flags: 0, ai_family: AF_UNSPEC, ai_socktype: SOCK_STREAM, ai_protocol: 0, ai_addrlen: 0, ai_canonname: nil, ai_addr: nil, ai_next: nil)
+                var res: UnsafeMutablePointer<addrinfo>? = nil
+                let rc = getaddrinfo(host, nil, &hints, &res)
+                guard rc == 0, let first = res else { return [] }
+                defer { freeaddrinfo(first) }
+                var out: [String] = []
+                var p: UnsafeMutablePointer<addrinfo>? = first
+                while let cur = p {
+                    if let sa = cur.pointee.ai_addr {
+                        var hostbuf = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                        if getnameinfo(sa, socklen_t(cur.pointee.ai_addrlen), &hostbuf, socklen_t(hostbuf.count), nil, 0, NI_NUMERICHOST) == 0 {
+                            out.append(String(cString: hostbuf))
+                        }
+                    }
+                    p = cur.pointee.ai_next
+                }
+                dnsCache[host] = (expires: Date().addingTimeInterval(TimeInterval(dnsTTL)), ips: out)
+                return out
+            }
+            func isPrivateIPv6(_ ip: String) -> Bool {
+                let low = ip.lowercased()
+                if low == "::1" || low == "::" { return true }
+                if low.hasPrefix("fe80:") { return true } // link-local
+                if low.hasPrefix("fc") || low.hasPrefix("fd") { return true } // unique local
+                return false
+            }
+            func ipv4ToInt(_ ip: String) -> UInt32? {
+                let parts = ip.split(separator: ".").compactMap { UInt32($0) }
+                guard parts.count == 4 else { return nil }
+                return (parts[0] << 24) | (parts[1] << 16) | (parts[2] << 8) | parts[3]
+            }
+            func parseCIDR(_ s: String) -> (UInt32, UInt32)? {
+                let comps = s.split(separator: "/")
+                guard comps.count == 2, let base = ipv4ToInt(String(comps[0])), let bits = Int(comps[1]), bits >= 0 && bits <= 32 else { return nil }
+                let mask = bits == 0 ? 0 : 0xFFFFFFFF << (32 - bits)
+                return (base & UInt32(mask), UInt32(mask))
+            }
+            let allowCIDRParsed: [(UInt32, UInt32)] = allowCIDRs.compactMap(parseCIDR)
+            let denyCIDRParsed: [(UInt32, UInt32)] = denyCIDRs.compactMap(parseCIDR)
+            for ip in resolveIPs(h) {
+                if ip.contains(":") { if isPrivateIPv6(ip) { return false } }
+                else {
+                    let parts = ip.split(separator: ".").compactMap { Int($0) }
+                    if parts.count == 4 && isPrivateIPv4(parts) { return false }
+                    if let v = ipv4ToInt(ip) {
+                        for (base, mask) in denyCIDRParsed { if (v & mask) == base { return false } }
+                        if !allowCIDRParsed.isEmpty {
+                            var ok = false
+                            for (base, mask) in allowCIDRParsed { if (v & mask) == base { ok = true; break } }
+                            if !ok { return false }
+                        }
+                    }
+                }
+            }
+            return true
+        }
+
+        func withTimeout<T>(ms: Int, _ op: @escaping () async throws -> T) async -> Result<T, Error> {
+            await withTaskGroup(of: Result<T, Error>.self) { group in
+                let deadlineNs = UInt64(ms) * 1_000_000
+                group.addTask { do { return .success(try await op()) } catch { return .failure(error) } }
+                group.addTask { try? await Task.sleep(nanoseconds: deadlineNs); return .failure(TimeoutError.deadlineExceeded) }
+                let result = await group.next() ?? .failure(TimeoutError.deadlineExceeded)
+                group.cancelAll()
+                return result
+            }
+        }
+
+        switch (req.method, segs) {
+        case ("GET", ["v1", "health"]):
+            let cap = await gate?.capacity ?? 0
+            let used = await gate?.inUse ?? 0
+            let body = try? JSONSerialization.data(withJSONObject: ["status": "ok", "version": "0.2.0", "browserPool": ["capacity": cap, "inUse": used]])
+            return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: body ?? Data())
+        case ("GET", ["v1", "admin", "healthx"]):
+            // Verbose, non-spec health
+            var allowed: Set<String> = [
+                "text/html", "text/plain", "text/css",
+                "application/json", "application/javascript", "text/javascript"
+            ]
+            if let raw = env["SB_NET_BODY_MIME_ALLOW"], !raw.isEmpty {
+                for m in raw.split(separator: ",") { allowed.insert(String(m).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()) }
+            }
+            let maxBodies = max(Int(env["SB_NET_BODY_MAX_COUNT"] ?? "20") ?? 20, 0)
+            let maxBytes = max(Int(env["SB_NET_BODY_MAX_BYTES"] ?? "16384") ?? 16384, 512)
+            let maxTotal = max(Int(env["SB_NET_BODY_TOTAL_MAX_BYTES"] ?? "131072") ?? 131072, maxBytes)
+            var verbose: [String: Any] = [
+                "status": "ok",
+                "version": "0.2.0",
+                "browserPool": ["capacity": cap, "inUse": used],
+                "capture": [
+                    "allowedMIMEs": Array(allowed).sorted(),
+                    "maxBodies": maxBodies,
+                    "maxBodyBytes": maxBytes,
+                    "maxTotalBytes": maxTotal
+                ],
+                "ssrf": [
+                    "allowList": allowList,
+                    "denyList": denyList,
+                    "dnsCacheTTL": dnsTTL
+                ]
+            ]
+            if let hg = hostGate { let s = await hg.stats(); verbose["hostGate"] = ["total": s.total, "used": s.used, "perHostUsed": s.perHost, "perHostCapacity": s.perHostCap, "rejected": s.rejected] }
+            if let st = artifactStore { let removed = (try? st.gc(now: Date())) ?? 0; if let m = metrics { await m.inc("artifact_gc_runs_total"); await m.inc("artifact_gc_deleted_total", by: removed) } }
+            let body = try? JSONSerialization.data(withJSONObject: verbose)
+            return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: body ?? Data())
+        case ("GET", ["v1", "admin", "artifacts"]):
+            let params = qp(req.path)
+            let pageId = params["pageId"]
+            let analysisId = params["analysisId"] ?? params["pageId"]
+            let kind = params["kind"]
+            let limit = min(max(Int(params["limit"] ?? "20") ?? 20, 1), 200)
+            #if canImport(Typesense)
+            if let catalog = artifactCatalog as? TypesenseArtifacts {
+                let docs = await catalog.search(pageId: pageId, analysisId: analysisId, kind: kind, limit: limit)
+                if let data = try? JSONEncoder().encode(docs) { return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data) }
+                return HTTPResponse(status: 200)
+            }
+            #endif
+            return HTTPResponse(status: 404)
+        case ("GET", let seg) where seg.count == 5 && seg[0] == "v1" && seg[1] == "admin" && seg[2] == "snapshots" && seg[4] == "network":
+            let sid = String(segs[3])
+            if let items = await service.loadNetwork(snapshotId: sid), let data = try? JSONEncoder().encode(items) {
+                return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+            }
+            return HTTPResponse(status: 404)
+        case ("GET", ["v1", "pages"]):
+            let params = qp(req.path)
+            let limit = min(max(Int(params["limit"] ?? "20") ?? 20, 1), 200)
+            let offset = max(Int(params["offset"] ?? "0") ?? 0, 0)
+            let (total, items) = await service.queryPages(q: params["q"], host: params["host"], lang: params["lang"], limit: limit, offset: offset)
+            let obj: [String: Any] = ["total": total, "items": try items.map { try JSONSerialization.jsonObject(with: JSONEncoder().encode($0)) }]
+            let data = try JSONSerialization.data(withJSONObject: obj)
+            return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+        case ("GET", ["v1", "segments"]):
+            let params = qp(req.path)
+            let limit = min(max(Int(params["limit"] ?? "20") ?? 20, 1), 200)
+            let offset = max(Int(params["offset"] ?? "0") ?? 0, 0)
+            let (total, items) = await service.querySegments(q: params["q"], kind: params["kind"], entity: params["entity"], limit: limit, offset: offset)
+            let obj: [String: Any] = ["total": total, "items": try items.map { try JSONSerialization.jsonObject(with: JSONEncoder().encode($0)) }]
+            let data = try JSONSerialization.data(withJSONObject: obj)
+            return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+        case ("GET", ["v1", "entities"]):
+            let params = qp(req.path)
+            let limit = min(max(Int(params["limit"] ?? "20") ?? 20, 1), 200)
+            let offset = max(Int(params["offset"] ?? "0") ?? 0, 0)
+            let (total, items) = await service.queryEntities(q: params["q"], type: params["type"], limit: limit, offset: offset)
+            let obj: [String: Any] = ["total": total, "items": try items.map { try JSONSerialization.jsonObject(with: JSONEncoder().encode($0)) }]
+            let data = try JSONSerialization.data(withJSONObject: obj)
+            return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+        case ("POST", ["v1", "index"]):
+            let t0 = Date()
+            if let apiReq = try? JSONDecoder().decode(APIModels.IndexRequest.self, from: req.body) {
+                // Map API Analysis to internal FullAnalysis
+                let a = apiReq.analysis
+                let blocks: [SemanticMemoryService.FullAnalysis.Block] = a.blocks.map { .init(id: $0.id, kind: $0.kind, text: $0.text, table: $0.table.map { .init(caption: $0.caption, columns: $0.columns, rows: $0.rows) }) }
+                let ents: [SemanticMemoryService.FullAnalysis.Semantics.Entity] = (a.semantics?.entities ?? []).map { .init(id: $0.id, name: $0.name, type: $0.type) }
+                let full = SemanticMemoryService.FullAnalysis(
+                    envelope: .init(id: a.envelope.id, source: .init(uri: a.envelope.source?.uri), contentType: a.envelope.contentType, language: a.envelope.language),
+                    blocks: blocks,
+                    semantics: .init(entities: ents)
+                )
+                let result = await service.ingest(full: full)
+                if let data = try? JSONEncoder().encode(APIModels.IndexResult(pagesUpserted: result.pagesUpserted, segmentsUpserted: result.segmentsUpserted, entitiesUpserted: result.entitiesUpserted, tablesUpserted: result.tablesUpserted)) {
+                    if let m = metrics { await m.inc("index_requests_total"); await m.observe("index_latency", ms: Int(Date().timeIntervalSince(t0)*1000)) }
+                    return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+                }
+                return HTTPResponse(status: 200)
+            } else if let reqObj = try? JSONDecoder().decode(SemanticMemoryService.IndexRequest.self, from: req.body) {
+                let result = await service.ingest(reqObj)
+                if let data = try? JSONEncoder().encode(result) { if let m = metrics { await m.inc("index_requests_total"); await m.observe("index_latency", ms: Int(Date().timeIntervalSince(t0)*1000)) }; return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data) }
+                return HTTPResponse(status: 200)
+            } else if let full = try? JSONDecoder().decode(SemanticMemoryService.FullAnalysis.self, from: req.body) {
+                let result = await service.ingest(full: full)
+                if let data = try? JSONEncoder().encode(result) { if let m = metrics { await m.inc("index_requests_total"); await m.observe("index_latency", ms: Int(Date().timeIntervalSince(t0)*1000)) }; return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data) }
+                return HTTPResponse(status: 200)
+            } else {
+                if let m = metrics { await m.inc("index_requests_error_total") }
+                return HTTPResponse(status: 400)
+            }
+        case ("POST", ["v1", "snapshot"]):
+            let t0 = Date()
+            if let sreq = try? JSONDecoder().decode(APIModels.SnapshotRequest.self, from: req.body) {
+                // SSRF guard
+                guard urlAllowed(sreq.url) else {
+                    let reason = ["code": "invalid_url", "message": "URL not allowed"]
+                    let data = try? JSONSerialization.data(withJSONObject: reason)
+                    return HTTPResponse(status: 400, headers: ["Content-Type": "application/json", "X-URL-Block-Reason": "policy"], body: data ?? Data())
+                }
+                let sid = UUID().uuidString
+                // Per-request capture overrides via headers
+                func parseSet(_ s: String?) -> Set<String>? { guard let s, !s.isEmpty else { return nil }; return Set(s.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }) }
+                let cap = CaptureOptions(
+                    allowedMIMEs: parseSet(req.headers["X-Capture-Mimes"]),
+                    maxBodies: Int(req.headers["X-Capture-Body-Max-Count"] ?? ""),
+                    maxBodyBytes: Int(req.headers["X-Capture-Body-Max-Bytes"] ?? ""),
+                    maxTotalBytes: Int(req.headers["X-Capture-Body-Total-Bytes"] ?? "")
+                )
+                // Concurrency gate
+                if let g = gate, await !g.tryAcquire() { return HTTPResponse(status: 429, headers: ["Retry-After": "1"], body: Data("too many requests".utf8)) }
+                defer { Task { if let g = gate { await g.release() } } }
+                // Host gate
+                let host = URL(string: sreq.url)?.host ?? ""
+                if let hg = hostGate, !host.isEmpty, await !hg.tryAcquire(host: host) { return HTTPResponse(status: 429, headers: ["Retry-After": "1"], body: Data("too many requests".utf8)) }
+                defer { Task { if let hg = hostGate, !host.isEmpty { await hg.release(host: host) } } }
+                let snapRes: SnapshotResult
+                if let engine {
+                    switch await withTimeout(ms: reqTimeoutMs, { try await engine.snapshot(for: sreq.url, wait: sreq.wait, capture: cap) }) {
+                    case .success(let r): snapRes = r
+                    case .failure: return HTTPResponse(status: 504, headers: ["Content-Type": "application/json"], body: Data("{\"code\":\"timeout\"}".utf8))
+                    }
+                } else {
+                    snapRes = SnapshotResult(html: "<html><body><h1>\(sreq.url)</h1></body></html>", text: sreq.url, finalURL: sreq.url, loadMs: nil, network: nil, pageStatus: nil, pageContentType: nil)
+                }
+                // Redirect pinning: final URL must also be allowed
+                if !urlAllowed(snapRes.finalURL) {
+                    let reason = ["code": "redirect_blocked", "message": "Final URL not allowed"]
+                    let data = try? JSONSerialization.data(withJSONObject: reason)
+                    return HTTPResponse(status: 400, headers: ["Content-Type": "application/json", "X-URL-Block-Reason": "redirect"], body: data ?? Data())
+                }
+                // Recompute text + blocks via parser for stable spans
+                let parsed = HTMLParser().parseTextAndBlocks(from: snapRes.html)
+                let now = Date()
+                let page = APIModels.Snapshot.Page(
+                    uri: sreq.url,
+                    finalUrl: snapRes.finalURL,
+                    fetchedAt: now.iso8601String,
+                    status: snapRes.pageStatus ?? 200,
+                    contentType: (snapRes.pageContentType ?? "text/html"),
+                    navigation: .init(ttfbMs: nil, loadMs: snapRes.loadMs)
+                )
+                await service.storeNetwork(snapshotId: sid, requests: snapRes.adminNetwork)
+                let apiSnap = APIModels.Snapshot(
+                    snapshotId: sid,
+                    page: page,
+                    rendered: .init(html: snapRes.html, text: parsed.text, meta: nil),
+                    network: (snapRes.network.map { APIModels.Snapshot.Network(requests: $0) }) ?? nil,
+                    diagnostics: []
+                )
+                // Store artifact for export compatibility
+                let store = sreq.storeArtifacts ?? true
+                if store { await service.store(snapshot: .init(id: sid, url: sreq.url, renderedHTML: snapRes.html, renderedText: parsed.text)) }
+                let resp = APIModels.SnapshotResponse(snapshot: apiSnap)
+                if let data = try? JSONEncoder().encode(resp) {
+                    // Build capture headers
+                    var headers = ["Content-Type": "application/json"]
+                    // effective capture values mirror CDP logic
+                    var allowedEff: Set<String> = [
+                        "text/html", "text/plain", "text/css",
+                        "application/json", "application/javascript", "text/javascript"
+                    ]
+                    if let raw = env["SB_NET_BODY_MIME_ALLOW"], !raw.isEmpty {
+                        for m in raw.split(separator: ",") { allowedEff.insert(String(m).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()) }
+                    }
+                    if let m = cap.allowedMIMEs { allowedEff.formUnion(m.map { $0.lowercased() }) }
+                    let maxBodiesEff = max(cap.maxBodies ?? (Int(env["SB_NET_BODY_MAX_COUNT"] ?? "20") ?? 20), 0)
+                    let maxBytesEff = max(cap.maxBodyBytes ?? (Int(env["SB_NET_BODY_MAX_BYTES"] ?? "16384") ?? 16384), 512)
+                    let maxTotalEff = max(cap.maxTotalBytes ?? (Int(env["SB_NET_BODY_TOTAL_MAX_BYTES"] ?? "131072") ?? 131072), maxBytesEff)
+                    headers["X-Capture-Allowed-MIMEs"] = Array(allowedEff).sorted().joined(separator: ",")
+                    headers["X-Capture-Body-Max-Count"] = String(maxBodiesEff)
+                    headers["X-Capture-Body-Max-Bytes"] = String(maxBytesEff)
+                    headers["X-Capture-Body-Total-Bytes"] = String(maxTotalEff)
+                    if let m = metrics { await m.inc("snapshot_requests_total"); await m.observe("snapshot_latency", ms: Int(Date().timeIntervalSince(t0)*1000)) }
+                    return HTTPResponse(status: 200, headers: headers, body: data)
+                }
+                return HTTPResponse(status: 200)
+            }
+            if let m = metrics { await m.inc("snapshot_requests_error_total") }
+            return HTTPResponse(status: 400)
+        case ("POST", ["v1", "analyze"]):
+            let t0 = Date()
+            if let areq = try? JSONDecoder().decode(APIModels.AnalyzeRequest.self, from: req.body) {
+                let snap: SemanticMemoryService.Snapshot?
+                if let s = areq.snapshot { snap = .init(id: s.snapshotId, url: s.page.uri, renderedHTML: s.rendered.html, renderedText: s.rendered.text) }
+                else if let sid = areq.snapshotRef?.snapshotId { snap = await service.loadSnapshot(id: sid) }
+                else { snap = nil }
+                guard let snap else { return HTTPResponse(status: 400) }
+                let fid = UUID().uuidString
+                let parsed = HTMLParser().parseTextAndBlocks(from: snap.renderedHTML)
+                let apiBlocks: [APIModels.Analysis.Block] = parsed.blocks.map { .init(id: $0.id, kind: $0.kind, level: $0.level, text: $0.text, span: [$0.start, $0.end], table: $0.table.map { .init(caption: $0.caption, columns: $0.columns, rows: $0.rows) }) }
+                var entities: [String: (id: String, mentions: [[String: Any]])] = [:]
+                let wordRe = try? NSRegularExpression(pattern: "\\b[A-Z][a-zA-Z]{2,}\\b")
+                for b in parsed.blocks {
+                    if let re = wordRe {
+                        let r = NSRange(location: 0, length: b.text.utf16.count)
+                        for m in re.matches(in: b.text, range: r) {
+                            if let rr = Range(m.range, in: b.text) {
+                                let token = String(b.text[rr])
+                                let start = b.start + b.text.distance(from: b.text.startIndex, to: rr.lowerBound)
+                                let end = start + token.count
+                                var ent = entities[token] ?? (UUID().uuidString, [])
+                                ent.mentions.append(["block": b.id, "span": [start, end]])
+                                entities[token] = ent
+                            }
+                        }
+                    }
+                }
+                let analysis = APIModels.Analysis(
+                    envelope: .init(id: fid, source: .init(uri: snap.url, fetchedAt: Date().iso8601String), contentType: "text/html", language: "en", bytes: snap.renderedHTML.utf8.count, diagnostics: []),
+                    blocks: apiBlocks,
+                    semantics: .init(outline: nil, entities: entities.map { APIModels.Analysis.Entity(id: $0.value.id, name: $0.key, type: "OTHER", mentions: $0.value.mentions.map { APIModels.Analysis.Entity.Mention(block: $0["block"] as? String, span: $0["span"] as? [Int]) }) }, claims: [], relations: []),
+                    summaries: .init(abstract: nil, keyPoints: nil, tl__dr: nil),
+                    provenance: .init(pipeline: "semantic-browser@0.2", model: nil)
+                )
+                // Store a FullAnalysis for internal indexing/export
+                let fullBlocks = parsed.blocks.map { SemanticMemoryService.FullAnalysis.Block(id: $0.id, kind: $0.kind, text: $0.text, table: $0.table) }
+                let full = SemanticMemoryService.FullAnalysis(
+                    envelope: .init(id: fid, source: .init(uri: snap.url), contentType: "text/html", language: "en"),
+                    blocks: fullBlocks,
+                    semantics: .init(entities: [])
+                )
+                await service.store(analysis: full, forSnapshotId: snap.id)
+                if let data = try? JSONEncoder().encode(analysis) { if let m = metrics { await m.inc("analyze_requests_total"); await m.observe("analyze_latency", ms: Int(Date().timeIntervalSince(t0)*1000)) }; return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data) }
+                return HTTPResponse(status: 200)
+            }
+            if let m = metrics { await m.inc("analyze_requests_error_total") }
+            return HTTPResponse(status: 400)
+        case ("POST", ["v1", "browse"]):
+            let t0 = Date()
+            if let breq = try? JSONDecoder().decode(APIModels.BrowseRequest.self, from: req.body) {
+                guard urlAllowed(breq.url) else { return HTTPResponse(status: 400, headers: ["Content-Type": "application/json"], body: Data("{\"code\":\"invalid_url\",\"message\":\"URL not allowed\"}".utf8)) }
+                let sid = UUID().uuidString
+                // Per-request capture overrides via headers
+                func parseSet(_ s: String?) -> Set<String>? { guard let s, !s.isEmpty else { return nil }; return Set(s.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }) }
+                let cap = CaptureOptions(
+                    allowedMIMEs: parseSet(req.headers["X-Capture-Mimes"]),
+                    maxBodies: Int(req.headers["X-Capture-Body-Max-Count"] ?? ""),
+                    maxBodyBytes: Int(req.headers["X-Capture-Body-Max-Bytes"] ?? ""),
+                    maxTotalBytes: Int(req.headers["X-Capture-Body-Total-Bytes"] ?? "")
+                )
+                if let g = gate, await !g.tryAcquire() { return HTTPResponse(status: 429, headers: ["Retry-After": "1"], body: Data("too many requests".utf8)) }
+                defer { Task { if let g = gate { await g.release() } } }
+                let host = URL(string: breq.url)?.host ?? ""
+                if let hg = hostGate, !host.isEmpty, await !hg.tryAcquire(host: host) { return HTTPResponse(status: 429, headers: ["Retry-After": "1"], body: Data("too many requests".utf8)) }
+                defer { Task { if let hg = hostGate, !host.isEmpty { await hg.release(host: host) } } }
+                let snapRes: SnapshotResult
+                if let engine {
+                    switch await withTimeout(ms: reqTimeoutMs, { try await engine.snapshot(for: breq.url, wait: breq.wait, capture: cap) }) {
+                    case .success(let r): snapRes = r
+                    case .failure: return HTTPResponse(status: 504, headers: ["Content-Type": "application/json"], body: Data("{\"code\":\"timeout\"}".utf8))
+                    }
+                } else {
+                    snapRes = SnapshotResult(html: "<html><body><h1>\(breq.url)</h1></body></html>", text: breq.url, finalURL: breq.url, loadMs: nil, network: nil, pageStatus: nil, pageContentType: nil)
+                }
+                if !urlAllowed(snapRes.finalURL) { return HTTPResponse(status: 400, headers: ["Content-Type": "application/json"], body: Data("{\"code\":\"redirect_blocked\",\"message\":\"Final URL not allowed\"}".utf8)) }
+                let parsed = HTMLParser().parseTextAndBlocks(from: snapRes.html)
+                await service.store(snapshot: .init(id: sid, url: breq.url, renderedHTML: snapRes.html, renderedText: parsed.text))
+                let now = Date()
+                await service.storeNetwork(snapshotId: sid, requests: snapRes.adminNetwork)
+                let snap = APIModels.Snapshot(
+                    snapshotId: sid,
+                    page: .init(uri: breq.url, finalUrl: snapRes.finalURL, fetchedAt: now.iso8601String, status: snapRes.pageStatus ?? 200, contentType: (snapRes.pageContentType ?? "text/html"), navigation: .init(ttfbMs: nil, loadMs: snapRes.loadMs)),
+                    rendered: .init(html: snapRes.html, text: parsed.text, meta: nil),
+                    network: (snapRes.network.map { APIModels.Snapshot.Network(requests: $0) }) ?? nil,
+                    diagnostics: []
+                )
+                // Persist artifacts (FS store)
+                if let st = artifactStore {
+                    if let ref = try? st.put(kind: "snapshot.html", ext: "html", mime: "text/html", data: Data(snapRes.html.utf8), ttlDays: Int(env["ARTIFACT_TTL_DAYS"] ?? "7") ?? 7) { await service.storeArtifactRef(ownerId: sid, kind: "snapshot.html", refPath: ref.refPath); if let m=metrics { await m.inc("artifact_writes_total"); await m.addGauge("artifact_bytes_total", by: Int64(ref.size)) } }
+                    if let ref = try? st.put(kind: "snapshot.text", ext: "txt", mime: "text/plain", data: Data(parsed.text.utf8), ttlDays: Int(env["ARTIFACT_TTL_DAYS"] ?? "7") ?? 7) { await service.storeArtifactRef(ownerId: sid, kind: "snapshot.text", refPath: ref.refPath); if let m=metrics { await m.inc("artifact_writes_total"); await m.addGauge("artifact_bytes_total", by: Int64(ref.size)) } }
+                }
+                // Analyze
+                let fid = UUID().uuidString
+                let parsedBlocks = parsed.blocks
+                var apiBlocks: [APIModels.Analysis.Block] = parsedBlocks.map { APIModels.Analysis.Block(id: $0.id, kind: $0.kind, level: $0.level, text: $0.text, span: [$0.start, $0.end], table: $0.table.map { .init(caption: $0.caption, columns: $0.columns, rows: $0.rows) }) }
+                // Baseline entities: capitalized tokens with spans
+                var entities: [String: (id: String, mentions: [[String: Any]])] = [:]
+                let wordRe = try? NSRegularExpression(pattern: "\\b[A-Z][a-zA-Z]{2,}\\b")
+                for b in parsedBlocks {
+                    if let re = wordRe {
+                        let r = NSRange(location: 0, length: b.text.utf16.count)
+                        let matches = re.matches(in: b.text, range: r)
+                        for m in matches {
+                            if let rr = Range(m.range, in: b.text) {
+                                let token = String(b.text[rr])
+                                let start = b.start + b.text.distance(from: b.text.startIndex, to: rr.lowerBound)
+                                let end = start + token.count
+                                var ent = entities[token] ?? (UUID().uuidString, [])
+                                ent.mentions.append(["block": b.id, "span": [start, end]])
+                                entities[token] = ent
+                            }
+                        }
+                    }
+                }
+                let analysis = APIModels.Analysis(
+                    envelope: .init(id: fid, source: .init(uri: breq.url, fetchedAt: now.iso8601String), contentType: "text/html", language: "en", bytes: snapRes.html.utf8.count, diagnostics: []),
+                    blocks: apiBlocks,
+                    semantics: .init(outline: nil, entities: entities.map { APIModels.Analysis.Entity(id: $0.value.id, name: $0.key, type: "OTHER", mentions: $0.value.mentions.map { APIModels.Analysis.Entity.Mention(block: $0["block"] as? String, span: $0["span"] as? [Int]) }) }, claims: [], relations: []),
+                    summaries: .init(abstract: nil, keyPoints: nil, tl__dr: nil),
+                    provenance: .init(pipeline: "semantic-browser@0.2", model: nil)
+                )
+                if let st = artifactStore, let data = try? JSONEncoder().encode(analysis) {
+                    if let ref = try? st.put(kind: "analysis.json", ext: "json", mime: "application/json", data: data, ttlDays: Int(env["ARTIFACT_TTL_DAYS"] ?? "7") ?? 7) { await service.storeArtifactRef(ownerId: fid, kind: "analysis.json", refPath: ref.refPath); if let m=metrics { await m.inc("artifact_writes_total"); await m.addGauge("artifact_bytes_total", by: Int64(ref.size)) } }
+                }
+                // Store internal analysis
+                let full = SemanticMemoryService.FullAnalysis(
+                    envelope: .init(id: fid, source: .init(uri: breq.url), contentType: "text/html", language: "en"),
+                    blocks: blocks,
+                    semantics: .init(entities: [])
+                )
+                await service.store(analysis: full, forSnapshotId: sid)
+                // Optionally index
+                var indexRes: APIModels.IndexResult? = nil
+                if breq.index?.enabled ?? true {
+                    let res = await service.ingest(full: full)
+                    indexRes = .init(pagesUpserted: res.pagesUpserted, segmentsUpserted: res.segmentsUpserted, entitiesUpserted: res.entitiesUpserted, tablesUpserted: res.tablesUpserted)
+                }
+                let resp = APIModels.BrowseResponse(snapshot: snap, analysis: analysis, index: indexRes)
+                if let data = try? JSONEncoder().encode(resp) {
+                    // Build capture headers
+                    var headers = ["Content-Type": "application/json"]
+                    var allowedEff: Set<String> = [
+                        "text/html", "text/plain", "text/css",
+                        "application/json", "application/javascript", "text/javascript"
+                    ]
+                    if let raw = env["SB_NET_BODY_MIME_ALLOW"], !raw.isEmpty {
+                        for m in raw.split(separator: ",") { allowedEff.insert(String(m).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()) }
+                    }
+                    if let m = cap.allowedMIMEs { allowedEff.formUnion(m.map { $0.lowercased() }) }
+                    let maxBodiesEff = max(cap.maxBodies ?? (Int(env["SB_NET_BODY_MAX_COUNT"] ?? "20") ?? 20), 0)
+                    let maxBytesEff = max(cap.maxBodyBytes ?? (Int(env["SB_NET_BODY_MAX_BYTES"] ?? "16384") ?? 16384), 512)
+                    let maxTotalEff = max(cap.maxTotalBytes ?? (Int(env["SB_NET_BODY_TOTAL_MAX_BYTES"] ?? "131072") ?? 131072), maxBytesEff)
+                    headers["X-Capture-Allowed-MIMEs"] = Array(allowedEff).sorted().joined(separator: ",")
+                    headers["X-Capture-Body-Max-Count"] = String(maxBodiesEff)
+                    headers["X-Capture-Body-Max-Bytes"] = String(maxBytesEff)
+                    headers["X-Capture-Body-Total-Bytes"] = String(maxTotalEff)
+                    if let m = metrics { await m.inc("browse_requests_total"); await m.observe("browse_latency", ms: Int(Date().timeIntervalSince(t0)*1000)) }
+                    return HTTPResponse(status: 200, headers: headers, body: data)
+                }
+                return HTTPResponse(status: 200)
+            }
+            if let m = metrics { await m.inc("browse_requests_error_total") }
+            return HTTPResponse(status: 400)
+        case ("GET", let seg) where seg.count == 3 && seg[0] == "v1" && seg[1] == "pages":
+            let id = String(seg[2])
+            if let p = await service.getPage(id: id), let data = try? JSONEncoder().encode(p) {
+                return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+            }
+            return HTTPResponse(status: 404)
+        case ("GET", ["v1", "export"]):
+            let params = qp(req.path)
+            guard let pageId = params["pageId"], let format = params["format"] else { return HTTPResponse(status: 400) }
+            if format == "snapshot.html" {
+                if let st = artifactStore, let ref = await service.loadArtifactRef(ownerId: pageId, kind: "snapshot.html"), let (data, _) = try? st.get(refPath: ref) {
+                    if let m = metrics { await m.inc("artifact_reads_total") }
+                    return HTTPResponse(status: 200, headers: ["Content-Type": "text/html"], body: data)
+                }
+                if let snap = await service.resolveSnapshot(byPageId: pageId) { return HTTPResponse(status: 200, headers: ["Content-Type": "text/html"], body: Data(snap.renderedHTML.utf8)) }
+            }
+            if format == "snapshot.text" {
+                if let st = artifactStore, let ref = await service.loadArtifactRef(ownerId: pageId, kind: "snapshot.text"), let (data, _) = try? st.get(refPath: ref) {
+                    if let m = metrics { await m.inc("artifact_reads_total") }
+                    return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: data)
+                }
+                if let snap = await service.resolveSnapshot(byPageId: pageId) { return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data(snap.renderedText.utf8)) }
+            }
+            if format == "analysis.json" {
+                if let st = artifactStore, let ref = await service.loadArtifactRef(ownerId: pageId, kind: "analysis.json"), let (data, _) = try? st.get(refPath: ref) {
+                    if let m = metrics { await m.inc("artifact_reads_total") }
+                    return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+                }
+                if let a = await service.resolveAnalysis(byPageId: pageId), let data = try? JSONEncoder().encode(a) { return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data) }
+            }
+            if format == "tables.csv", let a = await service.resolveAnalysis(byPageId: pageId) {
+                let tables = a.blocks.compactMap { $0.table }
+                if tables.isEmpty { return HTTPResponse(status: 404) }
+                var csv = ""
+                for (i, table) in tables.enumerated() {
+                    if i > 0 { csv += "
+" }
+                    if let cols = table.columns, !cols.isEmpty { csv += cols.joined(separator: ",") + "
+" }
+                    for row in table.rows { csv += row.joined(separator: ",") + "
+" }
+                }
+                return HTTPResponse(status: 200, headers: ["Content-Type": "text/csv"], body: Data(csv.utf8))
+            }
+            if format == "summary.md", let a = await service.resolveAnalysis(byPageId: pageId) {
+                var md = "# Summary
+
+"
+                if let title = a.blocks.first(where: { $0.kind == "heading" })?.text { md += "**Title:** \(title)
+
+" }
+                if let ents = a.semantics?.entities, !ents.isEmpty {
+                    md += "**Entities:**
+" + ents.map{ "- \($0.name) (\($0.type))" }.joined(separator: "
+") + "
+
+"
+                }
+        case ("GET", ["metrics"]):
+            if let m = metrics { let body = Data(await m.renderPrometheus().utf8); return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain; version=0.0.4"], body: body) }
+            return HTTPResponse(status: 404)
+                md += "**Blocks:** \(a.blocks.count)
+
+"
+                return HTTPResponse(status: 200, headers: ["Content-Type": "text/markdown"], body: Data(md.utf8))
+            }
+            return HTTPResponse(status: 404)
+        default:
+            return HTTPResponse(status: 404)
+        }
+    }
+}

--- a/semantic-browser/Sources/SemanticBrowser/Service.swift
+++ b/semantic-browser/Sources/SemanticBrowser/Service.swift
@@ -1,0 +1,203 @@
+import Foundation
+
+public actor SemanticMemoryService {
+    public protocol Backend: Sendable {
+        func upsert(page: PageDoc)
+        func upsert(segment: SegmentDoc)
+        func upsert(entity: EntityDoc)
+        func searchPages(q: String?, host: String?, lang: String?, limit: Int, offset: Int) -> (Int, [PageDoc])
+        func searchSegments(q: String?, kind: String?, entity: String?, limit: Int, offset: Int) -> (Int, [SegmentDoc])
+        func searchEntities(q: String?, type: String?, limit: Int, offset: Int) -> (Int, [EntityDoc])
+    }
+
+    private var pages: [PageDoc] = []
+    private var segments: [SegmentDoc] = []
+    private var entities: [EntityDoc] = []
+    private let backend: Backend?
+    // Stored artifacts for snapshot/analyze/export
+    public struct Snapshot: Codable, Sendable {
+        public let id: String
+        public let url: String
+        public let renderedHTML: String
+        public let renderedText: String
+        public init(id: String, url: String, renderedHTML: String, renderedText: String) { self.id = id; self.url = url; self.renderedHTML = renderedHTML; self.renderedText = renderedText }
+    }
+    private var snapshots: [String: Snapshot] = [:] // key: snapshotId
+    private var analyses: [String: FullAnalysis] = [:] // key: envelope.id
+    private var analysisToSnapshot: [String: String] = [:]
+    private var snapshotToAnalysis: [String: String] = [:]
+    private var networks: [String: [AdminNetworkRequest]] = [:]
+    private var artifactRefs: [String: [String: String]] = [:] // key: id (snapshotId or analysisId) -> kind -> refPath
+
+    public init(backend: Backend? = nil) { self.backend = backend }
+
+    public init() {}
+
+    // Seeding for tests or importers
+    public func seed(pages: [PageDoc] = [], segments: [SegmentDoc] = [], entities: [EntityDoc] = []) {
+        self.pages.append(contentsOf: pages)
+        self.segments.append(contentsOf: segments)
+        self.entities.append(contentsOf: entities)
+    }
+
+    public func queryPages(q: String?, host: String?, lang: String?, limit: Int, offset: Int) -> (total: Int, items: [PageDoc]) {
+        if let backend { let (t, items) = backend.searchPages(q: q, host: host, lang: lang, limit: limit, offset: offset); return (t, items) }
+        var list = pages
+        if let host, !host.isEmpty { list = list.filter { $0.host == host } }
+        if let lang, !lang.isEmpty { list = list.filter { $0.lang?.lowercased() == lang.lowercased() } }
+        if let q, !q.isEmpty {
+            let n = q.lowercased()
+            list = list.filter { ($0.title ?? "").lowercased().contains(n) || ($0.url).lowercased().contains(n) }
+        }
+        let total = list.count
+        let slice = Array(list.dropFirst(min(offset, total)).prefix(limit))
+        return (total, slice)
+    }
+
+    public func querySegments(q: String?, kind: String?, entity: String?, limit: Int, offset: Int) -> (total: Int, items: [SegmentDoc]) {
+        if let backend { let (t, items) = backend.searchSegments(q: q, kind: kind, entity: entity, limit: limit, offset: offset); return (t, items) }
+        var list = segments
+        if let kind, !kind.isEmpty { list = list.filter { $0.kind == kind } }
+        if let entity, !entity.isEmpty { list = list.filter { ($0.entities ?? []).contains(entity) } }
+        if let q, !q.isEmpty { let n = q.lowercased(); list = list.filter { $0.text.lowercased().contains(n) } }
+        let total = list.count
+        let slice = Array(list.dropFirst(min(offset, total)).prefix(limit))
+        return (total, slice)
+    }
+
+    public func queryEntities(q: String?, type: String?, limit: Int, offset: Int) -> (total: Int, items: [EntityDoc]) {
+        if let backend { let (t, items) = backend.searchEntities(q: q, type: type, limit: limit, offset: offset); return (t, items) }
+        var list = entities
+        if let type, !type.isEmpty { list = list.filter { $0.type == type } }
+        if let q, !q.isEmpty { let n = q.lowercased(); list = list.filter { $0.name.lowercased().contains(n) } }
+        let total = list.count
+        let slice = Array(list.dropFirst(min(offset, total)).prefix(limit))
+        return (total, slice)
+    }
+
+    // MARK: - Ingest (Index)
+    public struct IndexRequest: Codable, Sendable {
+        public let analysis: IngestAnalysis
+        public init(analysis: IngestAnalysis) { self.analysis = analysis }
+    }
+    public struct IngestAnalysis: Codable, Sendable {
+        public let page: PageDoc
+        public let segments: [SegmentDoc]?
+        public let entities: [EntityDoc]?
+        public init(page: PageDoc, segments: [SegmentDoc]? = nil, entities: [EntityDoc]? = nil) {
+            self.page = page; self.segments = segments; self.entities = entities
+        }
+    }
+    public struct IndexResult: Codable, Sendable {
+        public let pagesUpserted: Int
+        public let segmentsUpserted: Int
+        public let entitiesUpserted: Int
+        public let tablesUpserted: Int
+    }
+
+    public func ingest(_ req: IndexRequest) -> IndexResult {
+        var pUp = 0, sUp = 0, eUp = 0
+        // Upsert page by id
+        if let backend {
+            backend.upsert(page: req.analysis.page)
+        } else {
+            if let idx = pages.firstIndex(where: { $0.id == req.analysis.page.id }) { pages[idx] = req.analysis.page } else { pages.append(req.analysis.page) }
+        }
+        pUp = 1
+        if let segs = req.analysis.segments {
+            for s in segs {
+                if let backend { backend.upsert(segment: s) } else { if let i = segments.firstIndex(where: { $0.id == s.id }) { segments[i] = s } else { segments.append(s) } }
+                sUp += 1
+            }
+        }
+        if let ents = req.analysis.entities {
+            for e in ents {
+                if let backend { backend.upsert(entity: e) } else { if let i = entities.firstIndex(where: { $0.id == e.id }) { entities[i] = e } else { entities.append(e) } }
+                eUp += 1
+            }
+        }
+        return IndexResult(pagesUpserted: pUp, segmentsUpserted: sUp, entitiesUpserted: eUp, tablesUpserted: 0)
+    }
+
+    // MARK: - Full Analysis mapping (subset of OpenAPI)
+    public struct FullAnalysis: Codable, Sendable {
+        public struct Envelope: Codable, Sendable {
+            public struct Source: Codable, Sendable { public let uri: String? }
+            public let id: String
+            public let source: Source?
+            public let contentType: String?
+            public let language: String?
+        }
+        public struct Table: Codable, Sendable { public let caption: String?; public let columns: [String]?; public let rows: [[String]] }
+        public struct Block: Codable, Sendable {
+            public let id: String
+            public let kind: String
+            public let text: String
+            public let table: Table?
+        }
+        public struct Semantics: Codable, Sendable {
+            public struct Entity: Codable, Sendable { public let id: String; public let name: String; public let type: String }
+            public let entities: [Entity]?
+        }
+        public let envelope: Envelope
+        public let blocks: [Block]
+        public let semantics: Semantics?
+    }
+
+    public func ingest(full: FullAnalysis) -> IndexResult {
+        let url = full.envelope.source?.uri ?? ""
+        let host = URL(string: url)?.host ?? ""
+        let title = full.blocks.first(where: { $0.kind == "heading" })?.text
+        let textSize = full.blocks.reduce(0) { $0 + $1.text.count }
+        let pageId = full.envelope.id
+        let page = PageDoc(id: pageId, url: url, host: host, status: nil, contentType: full.envelope.contentType, lang: full.envelope.language, title: title, textSize: textSize, fetchedAt: nil, labels: nil)
+        var segs: [SegmentDoc] = []
+        for b in full.blocks { segs.append(SegmentDoc(id: b.id, pageId: pageId, kind: b.kind, text: b.text)) }
+        var ents: [EntityDoc] = []
+        if let es = full.semantics?.entities { ents = es.map { EntityDoc(id: $0.id, name: $0.name, type: $0.type) } }
+        return ingest(IndexRequest(analysis: IngestAnalysis(page: page, segments: segs, entities: ents)))
+    }
+
+    // MARK: - Snapshot / Analyze artifact storage
+    public func store(snapshot: Snapshot) { snapshots[snapshot.id] = snapshot }
+    public func loadSnapshot(id: String) -> Snapshot? { snapshots[id] }
+    public func store(analysis: FullAnalysis, forSnapshotId snapshotId: String? = nil) {
+        analyses[analysis.envelope.id] = analysis
+        if let sid = snapshotId {
+            analysisToSnapshot[analysis.envelope.id] = sid
+            snapshotToAnalysis[sid] = analysis.envelope.id
+        }
+    }
+    public func loadAnalysis(id: String) -> FullAnalysis? { analyses[id] }
+    public func resolveSnapshot(byPageId id: String) -> Snapshot? {
+        if let s = snapshots[id] { return s }
+        if let sid = analysisToSnapshot[id], let s = snapshots[sid] { return s }
+        return nil
+    }
+    public func resolveAnalysis(byPageId id: String) -> FullAnalysis? {
+        if let a = analyses[id] { return a }
+        if let aid = snapshotToAnalysis[id], let a = analyses[aid] { return a }
+        return nil
+    }
+
+    public func storeNetwork(snapshotId: String, requests: [AdminNetworkRequest]?) { if let r = requests { networks[snapshotId] = r } }
+    public func loadNetwork(snapshotId: String) -> [AdminNetworkRequest]? { networks[snapshotId] }
+
+    public func storeArtifactRef(ownerId: String, kind: String, refPath: String) {
+        var m = artifactRefs[ownerId] ?? [:]
+        m[kind] = refPath
+        artifactRefs[ownerId] = m
+    }
+    public func loadArtifactRef(ownerId: String, kind: String) -> String? { artifactRefs[ownerId]?[kind] }
+    public func getPage(id: String) -> PageDoc? {
+        if let p = pages.first(where: { $0.id == id }) { return p }
+        // Backend fallback: naive search and filter by id
+        if let backend {
+            let (total, list) = backend.searchPages(q: "*", host: nil, lang: nil, limit: 200, offset: 0)
+            if total > 0 { return list.first(where: { $0.id == id }) }
+        }
+        return nil
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/semantic-browser/Sources/SemanticBrowser/StringHTML.swift
+++ b/semantic-browser/Sources/SemanticBrowser/StringHTML.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension String {
+    func removingHTMLTags() -> String {
+        return self.replacingOccurrences(of: "<[^>]+>", with: " ", options: .regularExpression)
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+

--- a/semantic-browser/Sources/SemanticBrowser/TypesenseBackend.swift
+++ b/semantic-browser/Sources/SemanticBrowser/TypesenseBackend.swift
@@ -1,0 +1,77 @@
+#if canImport(Typesense)
+import Foundation
+import Typesense
+
+public final class TypesenseSemanticBackend: SemanticMemoryService.Backend, @unchecked Sendable {
+    private let client: Client
+
+    public init(nodes: [String], apiKey: String, debug: Bool = false) {
+        let tsNodes = nodes.map { Node(url: $0) }
+        let config = Configuration(nodes: tsNodes, apiKey: apiKey, logger: Logger(debugMode: debug))
+        self.client = Client(config: config)
+        Task { try? await self.ensureCollections() }
+    }
+
+    private func ensureCollections() async throws {
+        let pageFields = [Field(name: "id", type: "string"), Field(name: "url", type: "string"), Field(name: "host", type: "string"), Field(name: "title", type: "string"), Field(name: "lang", type: "string")]
+        _ = try? await client.collections.create(schema: CollectionSchema(name: "pages", fields: pageFields, defaultSortingField: nil))
+        let segFields = [Field(name: "id", type: "string"), Field(name: "pageId", type: "string"), Field(name: "kind", type: "string"), Field(name: "text", type: "string"), Field(name: "entities", type: "string[]")]
+        _ = try? await client.collections.create(schema: CollectionSchema(name: "segments", fields: segFields, defaultSortingField: nil))
+        let entFields = [Field(name: "id", type: "string"), Field(name: "name", type: "string"), Field(name: "type", type: "string")]
+        _ = try? await client.collections.create(schema: CollectionSchema(name: "entities", fields: entFields, defaultSortingField: nil))
+    }
+
+    public func upsert(page: PageDoc) {
+        if let data = try? JSONEncoder().encode(page) {
+            Task { _ = try? await client.collection(name: "pages").documents().upsert(document: data) }
+        }
+    }
+    public func upsert(segment: SegmentDoc) {
+        if let data = try? JSONEncoder().encode(segment) {
+            Task { _ = try? await client.collection(name: "segments").documents().upsert(document: data) }
+        }
+    }
+    public func upsert(entity: EntityDoc) {
+        if let data = try? JSONEncoder().encode(entity) {
+            Task { _ = try? await client.collection(name: "entities").documents().upsert(document: data) }
+        }
+    }
+
+    private func totalAndDocs<T: Decodable>(_ res: SearchResult<T>?) -> (Int, [T]) {
+        guard let res else { return (0, []) }
+        let docs = res.hits?.compactMap { $0.document } ?? []
+        var total = docs.count
+        if let f = Mirror(reflecting: res as Any).children.first(where: { $0.label == "found" })?.value as? Int { total = f }
+        else if let f32 = Mirror(reflecting: res as Any).children.first(where: { $0.label == "found" })?.value as? Int32 { total = Int(f32) }
+        return (total, docs)
+    }
+
+    public func searchPages(q: String?, host: String?, lang: String?, limit: Int, offset: Int) -> (Int, [PageDoc]) {
+        let page = max(offset / max(limit, 1) + 1, 1)
+        var filter: [String] = []
+        if let host, !host.isEmpty { filter.append("host:=\(host)") }
+        if let lang, !lang.isEmpty { filter.append("lang:=\(lang)") }
+        let params = SearchParameters(q: (q?.isEmpty == false ? q! : "*"), queryBy: "title,url,host,lang", filterBy: filter.isEmpty ? nil : filter.joined(separator: " && "), page: page, perPage: max(limit, 1))
+        let res = try? await client.collection(name: "pages").documents().search(params, for: PageDoc.self)
+        return totalAndDocs(res?.0)
+    }
+
+    public func searchSegments(q: String?, kind: String?, entity: String?, limit: Int, offset: Int) -> (Int, [SegmentDoc]) {
+        let page = max(offset / max(limit, 1) + 1, 1)
+        var filter: [String] = []
+        if let kind, !kind.isEmpty { filter.append("kind:=\(kind)") }
+        if let entity, !entity.isEmpty { filter.append("entities:=[\(entity)]") }
+        let params = SearchParameters(q: (q?.isEmpty == false ? q! : "*"), queryBy: "text,kind,entities", filterBy: filter.isEmpty ? nil : filter.joined(separator: " && "), page: page, perPage: max(limit, 1))
+        let res = try? await client.collection(name: "segments").documents().search(params, for: SegmentDoc.self)
+        return totalAndDocs(res?.0)
+    }
+
+    public func searchEntities(q: String?, type: String?, limit: Int, offset: Int) -> (Int, [EntityDoc]) {
+        let page = max(offset / max(limit, 1) + 1, 1)
+        let filter = (type?.isEmpty == false) ? "type:=\(type!)" : nil
+        let params = SearchParameters(q: (q?.isEmpty == false ? q! : "*"), queryBy: "name,type", filterBy: filter, page: page, perPage: max(limit, 1))
+        let res = try? await client.collection(name: "entities").documents().search(params, for: EntityDoc.self)
+        return totalAndDocs(res?.0)
+    }
+}
+#endif

--- a/semantic-browser/Tests/SemanticBrowserTests/CDPSmokeTests.swift
+++ b/semantic-browser/Tests/SemanticBrowserTests/CDPSmokeTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import SemanticBrowser
+
+final class CDPSmokeTests: XCTestCase {
+    func testCDPSnapshotSkipsWhenNoEnv() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let ws = env["SB_CDP_URL"], let url = URL(string: ws) else { throw XCTSkip("SB_CDP_URL not set") }
+        let engine = CDPBrowserEngine(wsURL: url)
+        do {
+            let (html, text) = try await engine.snapshotHTML(for: "https://example.com")
+            XCTAssertFalse(html.isEmpty || text.isEmpty)
+        } catch {
+            throw XCTSkip("CDP engine unavailable: \(error)")
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/semantic-browser/Tests/SemanticBrowserTests/SemanticBrowserIndexTests.swift
+++ b/semantic-browser/Tests/SemanticBrowserTests/SemanticBrowserIndexTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import SemanticBrowser
+@testable import FountainCodex
+
+final class SemanticBrowserIndexTests: XCTestCase {
+    func testIndexThenQuery() async throws {
+        let svc = SemanticMemoryService()
+        let kernel = makeSemanticKernel(service: svc)
+        let server = NIOHTTPServer(kernel: kernel)
+        let port = try await server.start(port: 0)
+
+        // Ingest one page with segments and entities
+        let payload: [String: Any] = [
+            "analysis": [
+                "page": ["id": "pZ", "url": "https://ex.com/z", "host": "ex.com", "title": "Zeta"],
+                "segments": [
+                    ["id": "sz1", "pageId": "pZ", "kind": "heading", "text": "Z title"],
+                    ["id": "sz2", "pageId": "pZ", "kind": "paragraph", "text": "content z"]
+                ],
+                "entities": [
+                    ["id": "ez1", "name": "Zed", "type": "PERSON"]
+                ]
+            ]
+        ]
+        var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/index")!)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        let (_, resp) = try await URLSession.shared.data(for: req)
+        XCTAssertEqual((resp as? HTTPURLResponse)?.statusCode, 200)
+
+        // Query pages to see Zeta
+        let (data, r) = try await URLSession.shared.data(from: URL(string: "http://127.0.0.1:\(port)/v1/pages?q=Zeta")!)
+        XCTAssertEqual((r as? HTTPURLResponse)?.statusCode, 200)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(obj?["total"] as? Int, 1)
+
+        try await server.stop()
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/semantic-browser/Tests/SemanticBrowserTests/SemanticBrowserQueryTests.swift
+++ b/semantic-browser/Tests/SemanticBrowserTests/SemanticBrowserQueryTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import SemanticBrowser
+@testable import FountainCodex
+
+final class SemanticBrowserQueryTests: XCTestCase {
+    func testQueryPagesSegmentsEntities() async throws {
+        let svc = SemanticMemoryService()
+        await svc.seed(
+            pages: [PageDoc(id: "p1", url: "https://ex.com/a", host: "ex.com", title: "Alpha"), PageDoc(id: "p2", url: "https://ex.com/b", host: "ex.com", title: "Beta")],
+            segments: [SegmentDoc(id: "s1", pageId: "p1", kind: "paragraph", text: "hello alpha"), SegmentDoc(id:"s2", pageId: "p2", kind: "heading", text: "beta title")],
+            entities: [EntityDoc(id: "e1", name: "Alice", type: "PERSON"), EntityDoc(id: "e2", name: "Bob", type: "PERSON")]
+        )
+        let kernel = makeSemanticKernel(service: svc)
+        let server = NIOHTTPServer(kernel: kernel)
+        let port = try await server.start(port: 0)
+
+        do {
+            let (data, resp) = try await URLSession.shared.data(from: URL(string: "http://127.0.0.1:\(port)/v1/pages?q=Alpha")!)
+            XCTAssertEqual((resp as? HTTPURLResponse)?.statusCode, 200)
+            let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            XCTAssertEqual(obj?["total"] as? Int, 1)
+
+            let (sdata, sresp) = try await URLSession.shared.data(from: URL(string: "http://127.0.0.1:\(port)/v1/segments?kind=heading")!)
+            XCTAssertEqual((sresp as? HTTPURLResponse)?.statusCode, 200)
+            let sobj = try JSONSerialization.jsonObject(with: sdata) as? [String: Any]
+            XCTAssertEqual(sobj?["total"] as? Int, 1)
+
+            let (edata, eresp) = try await URLSession.shared.data(from: URL(string: "http://127.0.0.1:\(port)/v1/entities?q=Alice&type=PERSON")!)
+            XCTAssertEqual((eresp as? HTTPURLResponse)?.statusCode, 200)
+            let eobj = try JSONSerialization.jsonObject(with: edata) as? [String: Any]
+            XCTAssertEqual(eobj?["total"] as? Int, 1)
+        }
+        try await server.stop()
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/semantic-browser/Tests/SemanticBrowserTests/SpecConformanceTests.swift
+++ b/semantic-browser/Tests/SemanticBrowserTests/SpecConformanceTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import SemanticBrowser
+@testable import FountainCodex
+
+final class SpecConformanceTests: XCTestCase {
+    func testSnapshotRequiresWaitAndReturnsSpecFields() async throws {
+        let svc = SemanticMemoryService()
+        let kernel = makeSemanticKernel(service: svc, requireAPIKey: false)
+        let server = NIOHTTPServer(kernel: kernel)
+        let port = try await server.start(port: 0)
+        defer { try? await server.stop() }
+
+        // Missing wait -> 400
+        do {
+            var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/snapshot")!)
+            req.httpMethod = "POST"
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            req.httpBody = try JSONSerialization.data(withJSONObject: ["url": "https://example.com"]) 
+            let (_, resp) = try await URLSession.shared.data(for: req)
+            XCTAssertEqual((resp as? HTTPURLResponse)?.statusCode, 400)
+        }
+
+        // With wait -> 200 and expected shape
+        do {
+            var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/snapshot")!)
+            req.httpMethod = "POST"
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            req.httpBody = try JSONSerialization.data(withJSONObject: [
+                "url": "https://example.com",
+                "wait": ["strategy": "domContentLoaded", "maxWaitMs": 1000]
+            ])
+            let (data, resp) = try await URLSession.shared.data(for: req)
+            XCTAssertEqual((resp as? HTTPURLResponse)?.statusCode, 200)
+            let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            let snap = obj?["snapshot"] as? [String: Any]
+            XCTAssertNotNil(snap? ["snapshotId"]) 
+            let page = snap?["page"] as? [String: Any]
+            XCTAssertEqual(page?["status"] as? Int, 200)
+            XCTAssertEqual((page?["contentType"] as? String)?.lowercased(), "text/html")
+            let rendered = snap?["rendered"] as? [String: Any]
+            XCTAssertNotNil(rendered?["html"]) 
+            XCTAssertNotNil(rendered?["text"]) 
+        }
+    }
+
+    func testBrowseIncludesSpans() async throws {
+        let svc = SemanticMemoryService()
+        let kernel = makeSemanticKernel(service: svc, requireAPIKey: false)
+        let server = NIOHTTPServer(kernel: kernel)
+        let port = try await server.start(port: 0)
+        defer { try? await server.stop() }
+
+        var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/browse")!)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONSerialization.data(withJSONObject: [
+            "url": "https://example.com",
+            "wait": ["strategy": "domContentLoaded", "maxWaitMs": 1000],
+            "mode": "standard",
+            "index": ["enabled": false]
+        ])
+        let (data, resp) = try await URLSession.shared.data(for: req)
+        XCTAssertEqual((resp as? HTTPURLResponse)?.statusCode, 200)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let analysis = obj?["analysis"] as? [String: Any]
+        let blocks = analysis?["blocks"] as? [[String: Any]]
+        XCTAssertNotNil(blocks)
+        XCTAssertTrue(blocks!.contains { ($0["span"] as? [Int]) != nil })
+    }
+
+    func testHealthIsSpecOnly() async throws {
+        let svc = SemanticMemoryService()
+        let kernel = makeSemanticKernel(service: svc, requireAPIKey: false)
+        let server = NIOHTTPServer(kernel: kernel)
+        let port = try await server.start(port: 0)
+        defer { try? await server.stop() }
+
+        let (data, resp) = try await URLSession.shared.data(from: URL(string: "http://127.0.0.1:\(port)/v1/health")!)
+        XCTAssertEqual((resp as? HTTPURLResponse)?.statusCode, 200)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        XCTAssertEqual(obj?["status"] as? String, "ok")
+        XCTAssertNotNil(obj?["version"]) 
+        XCTAssertNotNil((obj?["browserPool"] as? [String: Any])? ["capacity"]) 
+        XCTAssertNil(obj?["capture"]) 
+        XCTAssertNil(obj?["ssrf"]) 
+    }
+}
+


### PR DESCRIPTION
## Summary
- Add new `semantic-browser` directory with Swift Package Manager setup.
- Include SemanticBrowser sources and tests.
- Configure Package.swift with dependencies on FountainCodex and Typesense.

## Testing
- `swift test` *(fails: could not clone FountainCodex dependency - authentication required)*

------
https://chatgpt.com/codex/tasks/task_b_68ae9cf3c5bc83339bb11c043cb5e90d