### PR TITLE
Deprecate FountainCodex in favor of FountainRuntime

### DIFF
--- a/Tests/ClientGeneratorTests/ClientGeneratorTests.swift
+++ b/Tests/ClientGeneratorTests/ClientGeneratorTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class ClientGeneratorTests: XCTestCase {
     func testClientFilesGenerated() throws {

--- a/Tests/ClientGeneratorTests/OpenAPIParameterTests.swift
+++ b/Tests/ClientGeneratorTests/OpenAPIParameterTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class OpenAPIParameterTests: XCTestCase {
     /// Ensures hyphens are converted to underscores for Swift identifiers.

--- a/Tests/ClientGeneratorTests/OpenAPISwiftTypeTests.swift
+++ b/Tests/ClientGeneratorTests/OpenAPISwiftTypeTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class OpenAPISwiftTypeTests: XCTestCase {
     /// Verifies the `swiftType` helper produces the correct Swift type name.

--- a/Tests/ClientGeneratorTests/SecurityRequirementTests.swift
+++ b/Tests/ClientGeneratorTests/SecurityRequirementTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import FountainCodex
+@testable import FountainRuntime
 
 /// Tests encoding and decoding of ``OpenAPISpec.SecurityRequirement``.
 final class SecurityRequirementTests: XCTestCase {

--- a/Tests/ClientGeneratorTests/SpecLoaderTests.swift
+++ b/Tests/ClientGeneratorTests/SpecLoaderTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class SpecLoaderTests: XCTestCase {
     func testLoadsJSONRemovingCopyright() throws {

--- a/Tests/ClientGeneratorTests/SpecValidatorTests.swift
+++ b/Tests/ClientGeneratorTests/SpecValidatorTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class SpecValidatorTests: XCTestCase {
     func testDuplicateOperationIdThrows() throws {

--- a/Tests/ClientGeneratorTests/StringExtensionTests.swift
+++ b/Tests/ClientGeneratorTests/StringExtensionTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class StringExtensionTests: XCTestCase {
     /// Ensures the `camelCased` computed property transforms snake case names.

--- a/Tests/DNSPerfTests/DNSPerformanceTests.swift
+++ b/Tests/DNSPerfTests/DNSPerformanceTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import NIOCore
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class DNSPerformanceTests: XCTestCase {
     static func makeQuery(name: String) -> ByteBuffer {

--- a/Tests/DNSTests/DNSEngineTests.swift
+++ b/Tests/DNSTests/DNSEngineTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import NIOCore
 import NIOEmbedded
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class DNSEngineTests: XCTestCase {
     func makeQuery(name: String, type: UInt16) -> ByteBuffer {

--- a/Tests/DNSTests/DNSSECSignerTests.swift
+++ b/Tests/DNSTests/DNSSECSignerTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import Crypto
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class DNSSECSignerTests: XCTestCase {
     func testSignAndVerifyZone() throws {

--- a/Tests/DNSTests/DNSServerTests.swift
+++ b/Tests/DNSTests/DNSServerTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import Foundation
 import NIOCore
 import NIOPosix
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class DNSServerTests: XCTestCase {
     static func makeQuery(name: String) -> ByteBuffer {

--- a/Tests/DNSTests/ZoneManagerDNSSECTests.swift
+++ b/Tests/DNSTests/ZoneManagerDNSSECTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import Crypto
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class ZoneManagerDNSSECTests: XCTestCase {
     func temporaryFile() -> URL {

--- a/Tests/DNSTests/ZoneManagerTests.swift
+++ b/Tests/DNSTests/ZoneManagerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import FountainCodex
+@testable import FountainRuntime
 import Yams
 import Foundation
 

--- a/Tests/GatewayAppTests/GatewayPersistProxyTests.swift
+++ b/Tests/GatewayAppTests/GatewayPersistProxyTests.swift
@@ -4,7 +4,7 @@ import Foundation
 import FoundationNetworking
 #endif
 @testable import gateway_server
-@testable import FountainCodex
+@testable import FountainRuntime
 @testable import persist_server
 @testable import TypesensePersistence
 

--- a/Tests/IntegrationRuntimeTests/CoTLoggerTests.swift
+++ b/Tests/IntegrationRuntimeTests/CoTLoggerTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import gateway_server
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class CoTLoggerTests: XCTestCase {
     /// Ensures reasoning steps are logged when include_cot is true.

--- a/Tests/IntegrationRuntimeTests/DNSIntegrationTests.swift
+++ b/Tests/IntegrationRuntimeTests/DNSIntegrationTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import NIOCore
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class DNSIntegrationTests: XCTestCase {
     static func makeQuery(name: String) -> ByteBuffer {

--- a/Tests/IntegrationRuntimeTests/GatewayServerTests.swift
+++ b/Tests/IntegrationRuntimeTests/GatewayServerTests.swift
@@ -4,7 +4,7 @@ import Foundation
 import FoundationNetworking
 #endif
 @testable import gateway_server
-@testable import FountainCodex
+@testable import FountainRuntime
 import RateLimiterGatewayPlugin
 
 final class GatewayServerTests: XCTestCase {

--- a/Tests/IntegrationRuntimeTests/HTTPRequestTests.swift
+++ b/Tests/IntegrationRuntimeTests/HTTPRequestTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class HTTPRequestTests: XCTestCase {
     /// Verifies default initializer values for ``HTTPRequest``.

--- a/Tests/IntegrationRuntimeTests/HTTPResponseDefaultsTests.swift
+++ b/Tests/IntegrationRuntimeTests/HTTPResponseDefaultsTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class HTTPResponseDefaultsTests: XCTestCase {
     /// Verifies default initializer values for ``HTTPResponse``.

--- a/Tests/IntegrationRuntimeTests/LoggingPluginTests.swift
+++ b/Tests/IntegrationRuntimeTests/LoggingPluginTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import gateway_server
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class LoggingPluginTests: XCTestCase {
     /// Verifies requests and responses pass through the ``LoggingPlugin``.

--- a/Tests/IntegrationRuntimeTests/PublishingFrontendPluginTests.swift
+++ b/Tests/IntegrationRuntimeTests/PublishingFrontendPluginTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 @testable import gateway_server
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class PublishingFrontendPluginTests: XCTestCase {
     func testPluginServesFile() async throws {

--- a/Tests/IntegrationRuntimeTests/URLSessionHTTPClientTests.swift
+++ b/Tests/IntegrationRuntimeTests/URLSessionHTTPClientTests.swift
@@ -5,7 +5,7 @@ import FoundationNetworking
 #endif
 import NIOCore
 import NIOHTTP1
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class URLSessionHTTPClientTests: XCTestCase {
     private class MockURLProtocol: URLProtocol {

--- a/Tests/OpenAPIConformanceTests/RuntimeSchemaValidationTests.swift
+++ b/Tests/OpenAPIConformanceTests/RuntimeSchemaValidationTests.swift
@@ -7,7 +7,7 @@ import Yams
 @testable import AwarenessService
 @testable import BootstrapService
 @testable import TypesensePersistence
-@testable import FountainCodex
+@testable import FountainRuntime
 
 final class RuntimeSchemaValidationTests: XCTestCase {
     @MainActor

--- a/Tests/PersistServerTests/PersistServerTests.swift
+++ b/Tests/PersistServerTests/PersistServerTests.swift
@@ -3,7 +3,7 @@ import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
-@testable import FountainCodex
+@testable import FountainRuntime
 @testable import persist_server
 @testable import TypesensePersistence
 

--- a/libs/FountainCodex/Deprecation.swift
+++ b/libs/FountainCodex/Deprecation.swift
@@ -1,0 +1,3 @@
+/// FountainCodex is deprecated. Use FountainRuntime instead.
+@available(*, deprecated, message: "Use FountainRuntime")
+public enum _FountainCodexDeprecated {}


### PR DESCRIPTION
## Summary
- add `_FountainCodexDeprecated` marker to signal FountainCodex deprecation
- update tests to import FountainRuntime instead of FountainCodex

## Testing
- `swift build` *(fails: cannot use mutating member on immutable value 'products' is a 'let' constant)*

------
https://chatgpt.com/codex/tasks/task_b_68b06aba25448333b5c0971bd66b48f4