### PR TITLE
Add FountainCodex import check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         if: runner.os == 'macOS'
         working-directory: sps
         run: ./install-deps.sh
+      - name: Check FountainCodex imports
+        run: Scripts/check_no_codex.sh
       - name: Build
         run: swift build
       - name: Test
@@ -88,6 +90,8 @@ jobs:
       - uses: swift-actions/setup-swift@v1
         with:
           swift-version: '6.1.2'
+      - name: Check FountainCodex imports
+        run: Scripts/check_no_codex.sh
       - name: Build
         run: swift build
       - name: Run Typesense integration tests
@@ -113,6 +117,8 @@ jobs:
       - uses: swift-actions/setup-swift@v1
         with:
           swift-version: '6.1.2'
+      - name: Check FountainCodex imports
+        run: Scripts/check_no_codex.sh
       - name: Build
         run: swift build
       - name: Semantic Browser smoke tests

--- a/Scripts/check_no_codex.sh
+++ b/Scripts/check_no_codex.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "[check_no_codex] verifying FountainCodex imports"
+
+if rg 'import\s+FountainCodex' --type swift --glob '!libs/FountainRuntime/Reexport.swift' >/dev/null; then
+  echo "[check_no_codex] unexpected FountainCodex import(s) detected:"
+  rg 'import\s+FountainCodex' --type swift --glob '!libs/FountainRuntime/Reexport.swift'
+  exit 1
+fi
+
+echo "[check_no_codex] OK"


### PR DESCRIPTION
## Summary
- add check_no_codex script to ensure FountainCodex is only imported from FountainRuntime
- run FountainCodex import check in all CI jobs before building

## Testing
- `Scripts/check_no_codex.sh`
- `swift build` *(fails: invalid Package.swift manifest)*
- `swift test` *(fails: invalid Package.swift manifest)*

------
https://chatgpt.com/codex/tasks/task_b_68b06bb437e083338d37d8bfbec0ce50