### PR TITLE
Add ResourceLoader error handling tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -256,6 +256,11 @@ let fullTargets: [Target] = [
         path: "Tests/E2ETests"
     ),
     .testTarget(
+        name: "ResourceLoaderTests",
+        dependencies: ["ResourceLoader"],
+        path: "Tests/ResourceLoaderTests"
+    ),
+    .testTarget(
         name: "OpenAPIConformanceTests",
         dependencies: ["Yams", "AwarenessService", "BootstrapService", "TypesensePersistence", "FountainRuntime"],
         path: "Tests/OpenAPIConformanceTests"
@@ -343,11 +348,17 @@ let leanTargets: [Target] = [
         dependencies: ["FountainRuntime", "Yams"],
         path: "libs/PublishingFrontend"
     ),
+    .target(name: "ResourceLoader", path: "libs/ResourceLoader"),
     .testTarget(
         name: "IntegrationRuntimeTests",
         dependencies: ["gateway-server", "FountainRuntime", "LLMGatewayPlugin", "RateLimiterGatewayPlugin", .product(name: "NIO", package: "swift-nio")],
         path: "Tests/IntegrationRuntimeTests",
         resources: [.process("Fixtures")]
+    ),
+    .testTarget(
+        name: "ResourceLoaderTests",
+        dependencies: ["ResourceLoader"],
+        path: "Tests/ResourceLoaderTests"
     )
 ]
 

--- a/Tests/ResourceLoaderTests/ResourceLoaderTests.swift
+++ b/Tests/ResourceLoaderTests/ResourceLoaderTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+import ResourceLoader
+#if canImport(Glibc)
+import Glibc
+#else
+import Darwin
+#endif
+
+final class ResourceLoaderTests: XCTestCase {
+    func testMissingFile() throws {
+        XCTAssertThrowsError(try ResourceLoader.url("no-such-file", ext: "txt", subdir: nil, bundle: Bundle(for: Self.self))) { error in
+            guard case ResourceError.missing(let path) = error else {
+                return XCTFail("Expected ResourceError.missing, got \(error)")
+            }
+            XCTAssertEqual(path, "no-such-file.txt")
+            XCTAssertTrue(error.localizedDescription.contains("Resource missing"))
+        }
+    }
+
+    func testTraversalDoesNotEscapeRoot() throws {
+        XCTAssertThrowsError(try ResourceLoader.url("secret", ext: "txt", subdir: "..", bundle: Bundle(for: Self.self))) { error in
+            guard case ResourceError.missing(let path) = error else {
+                return XCTFail("Expected ResourceError.missing, got \(error)")
+            }
+            XCTAssertEqual(path, "../secret.txt")
+        }
+    }
+
+    func testPermissionDenied() throws {
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        let fileURL = tempDir.appendingPathComponent("unreadable.txt")
+        try "secret".write(to: fileURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: fileURL.path)
+        let original = geteuid()
+        guard seteuid(65534) == 0 else { throw XCTSkip("unable to drop privileges") }
+        defer { _ = seteuid(original) }
+        let bundle = Bundle(url: tempDir)!
+        XCTAssertThrowsError(try ResourceLoader.data("unreadable", ext: "txt", subdir: nil, bundle: bundle)) { error in
+            guard case ResourceError.unreadable(let desc, _) = error else {
+                return XCTFail("Expected ResourceError.unreadable, got \(error)")
+            }
+            XCTAssertEqual(desc, fileURL.path)
+            XCTAssertTrue(error.localizedDescription.contains("Failed to read resource"))
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add ResourceLoaderTests covering missing files, traversal attempts, and permission issues
- register ResourceLoaderTests for both full and lean builds

## Testing
- `swift test --filter ResourceLoaderTests`


------
https://chatgpt.com/codex/tasks/task_b_68b07dd382488333a7e9a50a2d30589e