### PR TITLE
Add Gateway edge-case and failure tests

### DIFF
--- a/Tests/GatewayAppTests/CircuitBreakerStateTests.swift
+++ b/Tests/GatewayAppTests/CircuitBreakerStateTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import gateway_server
+
+final class CircuitBreakerStateTests: XCTestCase {
+    @MainActor
+    func testCircuitBreakerOpensAndRejects() async throws {
+        setenv("GATEWAY_CB_FAILURES", "1", 1)
+        setenv("GATEWAY_CB_RESET_SECS", "100", 1)
+
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("routes.json")
+        struct Route: Codable { var id: String; var path: String; var target: String; var methods: [String]; var rateLimit: Int?; var proxyEnabled: Bool? }
+        let routes = [Route(id: "bad", path: "/bad", target: "http://127.0.0.1:1", methods: ["GET"], rateLimit: nil, proxyEnabled: true)]
+        try JSONEncoder().encode(routes).write(to: file)
+
+        let server = GatewayServer(plugins: [], zoneManager: nil, routeStoreURL: file)
+        let port = 9153
+        Task { try await server.start(port: port) }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        func metrics() async throws -> [String: Int] {
+            let url = URL(string: "http://127.0.0.1:\(port)/metrics")!
+            let (data, _) = try await URLSession.shared.data(from: url)
+            return (try JSONSerialization.jsonObject(with: data) as? [String: Int]) ?? [:]
+        }
+
+        let m0 = try await metrics()
+        let base502 = m0["gateway_responses_status_502_total"] ?? 0
+        let base503 = m0["gateway_responses_status_503_total"] ?? 0
+        let baseOpens = m0["gateway_cb_opens_total"] ?? 0
+        let baseRejects = m0["gateway_cb_rejects_total"] ?? 0
+
+        let url = URL(string: "http://127.0.0.1:\(port)/bad")!
+
+        // First call triggers failure -> 502 and open
+        let (_, r1) = try await URLSession.shared.data(from: url)
+        XCTAssertEqual((r1 as? HTTPURLResponse)?.statusCode, 502)
+        var m1 = try await metrics()
+        XCTAssertEqual(m1["gateway_responses_status_502_total"] ?? 0, base502 + 1)
+        XCTAssertEqual(m1["gateway_cb_opens_total"] ?? 0, baseOpens + 1)
+
+        // Second call rejected -> 503
+        let (_, r2) = try await URLSession.shared.data(from: url)
+        XCTAssertEqual((r2 as? HTTPURLResponse)?.statusCode, 503)
+        m1 = try await metrics()
+        XCTAssertEqual(m1["gateway_responses_status_503_total"] ?? 0, base503 + 1)
+        XCTAssertEqual(m1["gateway_cb_rejects_total"] ?? 0, baseRejects + 1)
+
+        try await server.stop()
+        unsetenv("GATEWAY_CB_FAILURES")
+        unsetenv("GATEWAY_CB_RESET_SECS")
+    }
+}
+

--- a/Tests/GatewayAppTests/HopByHopHeaderStripTests.swift
+++ b/Tests/GatewayAppTests/HopByHopHeaderStripTests.swift
@@ -1,0 +1,66 @@
+import XCTest
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import gateway_server
+import FountainRuntime
+
+final class HopByHopHeaderStripTests: XCTestCase {
+    @MainActor
+    func testHopByHopHeadersStripped() async throws {
+        actor HeaderBox {
+            private var storage: [String: String] = [:]
+            func update(_ h: [String: String]) { storage = h }
+            func snapshot() -> [String: String] { storage }
+        }
+        let box = HeaderBox()
+        let kernel = HTTPKernel { req in
+            await box.update(req.headers)
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: Data("ok".utf8))
+        }
+        let upstream = NIOHTTPServer(kernel: kernel)
+        let upstreamPort = try await upstream.start(port: 0)
+
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("routes.json")
+        struct Route: Codable { var id: String; var path: String; var target: String; var methods: [String]; var rateLimit: Int?; var proxyEnabled: Bool? }
+        let routes = [Route(id: "t", path: "/t", target: "http://127.0.0.1:\(upstreamPort)", methods: ["GET"], rateLimit: nil, proxyEnabled: true)]
+        try JSONEncoder().encode(routes).write(to: file)
+
+        let server = GatewayServer(plugins: [], zoneManager: nil, routeStoreURL: file)
+        let port = 9154
+        Task { try await server.start(port: port) }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        func metrics() async throws -> [String: Int] {
+            let url = URL(string: "http://127.0.0.1:\(port)/metrics")!
+            let (data, _) = try await URLSession.shared.data(from: url)
+            return (try JSONSerialization.jsonObject(with: data) as? [String: Int]) ?? [:]
+        }
+        let m0 = try await metrics()
+        let base200 = m0["gateway_responses_status_200_total"] ?? 0
+
+        var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/t")!)
+        req.setValue("keep-alive", forHTTPHeaderField: "Connection")
+        req.setValue("chunked", forHTTPHeaderField: "Transfer-Encoding")
+        req.setValue("100-continue", forHTTPHeaderField: "Expect")
+        req.setValue("1", forHTTPHeaderField: "X-Test")
+        let (_, resp) = try await URLSession.shared.data(for: req)
+        XCTAssertEqual((resp as? HTTPURLResponse)?.statusCode, 200)
+
+        let headers = await box.snapshot()
+        let lower = Dictionary(uniqueKeysWithValues: headers.map { ($0.key.lowercased(), $0.value) })
+        XCTAssertNil(lower["connection"])
+        XCTAssertNil(lower["transfer-encoding"])
+        XCTAssertNil(lower["expect"])
+        XCTAssertEqual(lower["x-test"], "1")
+
+        let m1 = try await metrics()
+        XCTAssertEqual(m1["gateway_responses_status_200_total"] ?? 0, base200 + 1)
+
+        try await server.stop(); try await upstream.stop()
+    }
+}
+

--- a/Tests/GatewayAppTests/RoleGuardAuthVariationsTests.swift
+++ b/Tests/GatewayAppTests/RoleGuardAuthVariationsTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import gateway_server
+
+final class RoleGuardAuthVariationsTests: XCTestCase {
+    @MainActor
+    func testAuthResponsesAndMetrics() async throws {
+        let store = RoleGuardStore(initialRules: [:], configURL: nil)
+        let server = GatewayServer(plugins: [], roleGuardStore: store)
+        let port = 9151
+        Task { try await server.start(port: port) }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        func metrics() async throws -> [String: Int] {
+            let url = URL(string: "http://127.0.0.1:\(port)/metrics")!
+            let (data, _) = try await URLSession.shared.data(from: url)
+            return (try JSONSerialization.jsonObject(with: data) as? [String: Int]) ?? [:]
+        }
+
+        let m0 = try await metrics()
+        let base401 = m0["gateway_responses_status_401_total"] ?? 0
+        let base403 = m0["gateway_responses_status_403_total"] ?? 0
+        let base200 = m0["gateway_responses_status_200_total"] ?? 0
+        let baseUnauth = m0["roleguard_unauthorized_total"] ?? 0
+        let baseForbidden = m0["roleguard_forbidden_total"] ?? 0
+
+        let url = URL(string: "http://127.0.0.1:\(port)/roleguard")!
+
+        // No token
+        let (_, r1) = try await URLSession.shared.data(from: url)
+        XCTAssertEqual((r1 as? HTTPURLResponse)?.statusCode, 401)
+        var m1 = try await metrics()
+        XCTAssertEqual(m1["gateway_responses_status_401_total"] ?? 0, base401 + 1)
+        XCTAssertEqual(m1["roleguard_unauthorized_total"] ?? 0, baseUnauth + 1)
+
+        // User token -> 403
+        let credStore = CredentialStore()
+        var req = URLRequest(url: url)
+        let user = try credStore.signJWT(subject: "c", expiresAt: Date().addingTimeInterval(3600), role: "user")
+        req.setValue("Bearer \(user)", forHTTPHeaderField: "Authorization")
+        let (_, r2) = try await URLSession.shared.data(for: req)
+        XCTAssertEqual((r2 as? HTTPURLResponse)?.statusCode, 403)
+        m1 = try await metrics()
+        XCTAssertEqual(m1["gateway_responses_status_403_total"] ?? 0, base403 + 1)
+        XCTAssertEqual(m1["roleguard_forbidden_total"] ?? 0, baseForbidden + 1)
+
+        // Admin token -> 200
+        let admin = try credStore.signJWT(subject: "c", expiresAt: Date().addingTimeInterval(3600), role: "admin")
+        req.setValue("Bearer \(admin)", forHTTPHeaderField: "Authorization")
+        let (_, r3) = try await URLSession.shared.data(for: req)
+        XCTAssertEqual((r3 as? HTTPURLResponse)?.statusCode, 200)
+        let m2 = try await metrics()
+        XCTAssertEqual(m2["gateway_responses_status_200_total"] ?? 0, base200 + 1)
+
+        try await server.stop()
+    }
+}
+

--- a/Tests/GatewayAppTests/RoleGuardReload304Tests.swift
+++ b/Tests/GatewayAppTests/RoleGuardReload304Tests.swift
@@ -1,0 +1,45 @@
+import XCTest
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import gateway_server
+
+final class RoleGuardReload304Tests: XCTestCase {
+    @MainActor
+    func testReloadReturns304AndMetrics() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("roleguard.yml")
+        try Data().write(to: file)
+        let store = RoleGuardStore(initialRules: loadRoleGuardRules(from: file), configURL: file)
+        let server = GatewayServer(plugins: [], roleGuardStore: store)
+        let port = 9152
+        Task { try await server.start(port: port) }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        func metrics() async throws -> [String: Int] {
+            let url = URL(string: "http://127.0.0.1:\(port)/metrics")!
+            let (data, _) = try await URLSession.shared.data(from: url)
+            return (try JSONSerialization.jsonObject(with: data) as? [String: Int]) ?? [:]
+        }
+
+        let m0 = try await metrics()
+        let base304 = m0["gateway_responses_status_304_total"] ?? 0
+        let baseReload = m0["roleguard_reload_total"] ?? 0
+
+        let creds = CredentialStore()
+        let admin = try creds.signJWT(subject: "c", expiresAt: Date().addingTimeInterval(3600), role: "admin")
+        var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/roleguard/reload")!)
+        req.httpMethod = "POST"
+        req.setValue("Bearer \(admin)", forHTTPHeaderField: "Authorization")
+        let (_, resp) = try await URLSession.shared.data(for: req)
+        XCTAssertEqual((resp as? HTTPURLResponse)?.statusCode, 304)
+        let m1 = try await metrics()
+        XCTAssertEqual(m1["gateway_responses_status_304_total"] ?? 0, base304 + 1)
+        XCTAssertEqual(m1["roleguard_reload_total"] ?? 0, baseReload)
+
+        try await server.stop()
+    }
+}
+

--- a/Tests/GatewayAppTests/RouteCrudFailureTests.swift
+++ b/Tests/GatewayAppTests/RouteCrudFailureTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+@testable import gateway_server
+
+final class RouteCrudFailureTests: XCTestCase {
+    @MainActor
+    func testRouteCrudFailuresRecordMetrics() async throws {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let file = dir.appendingPathComponent("routes.json")
+        try Data("[]".utf8).write(to: file)
+
+        let server = GatewayServer(plugins: [], zoneManager: nil, routeStoreURL: file)
+        let port = 9150
+        Task { try await server.start(port: port) }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        func metrics() async throws -> [String: Int] {
+            let url = URL(string: "http://127.0.0.1:\(port)/metrics")!
+            let (data, _) = try await URLSession.shared.data(from: url)
+            return (try JSONSerialization.jsonObject(with: data) as? [String: Int]) ?? [:]
+        }
+
+        let m0 = try await metrics()
+        let base400 = m0["gateway_responses_status_400_total"] ?? 0
+        let base404 = m0["gateway_responses_status_404_total"] ?? 0
+
+        struct Route: Codable { var id: String; var path: String; var target: String; var methods: [String]; var rateLimit: Int?; var proxyEnabled: Bool? }
+        // Create with invalid method -> 400
+        let badRoute = Route(id: "r1", path: "/x", target: "http://example", methods: ["BAD"], rateLimit: nil, proxyEnabled: true)
+        var create = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/routes")!)
+        create.httpMethod = "POST"
+        create.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        create.httpBody = try JSONEncoder().encode(badRoute)
+        let (_, r1) = try await URLSession.shared.data(for: create)
+        XCTAssertEqual((r1 as? HTTPURLResponse)?.statusCode, 400)
+        var m1 = try await metrics()
+        XCTAssertEqual(m1["gateway_responses_status_400_total"] ?? 0, base400 + 1)
+
+        // Update nonexistent -> 404
+        let upd = Route(id: "nope", path: "/x", target: "http://example", methods: ["GET"], rateLimit: nil, proxyEnabled: true)
+        var update = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/routes/nope")!)
+        update.httpMethod = "PUT"
+        update.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        update.httpBody = try JSONEncoder().encode(upd)
+        let (_, r2) = try await URLSession.shared.data(for: update)
+        XCTAssertEqual((r2 as? HTTPURLResponse)?.statusCode, 404)
+        m1 = try await metrics()
+        XCTAssertEqual(m1["gateway_responses_status_404_total"] ?? 0, base404 + 1)
+
+        // Delete nonexistent -> 404
+        var del = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/routes/nope")!)
+        del.httpMethod = "DELETE"
+        let (_, r3) = try await URLSession.shared.data(for: del)
+        XCTAssertEqual((r3 as? HTTPURLResponse)?.statusCode, 404)
+        let m2 = try await metrics()
+        XCTAssertEqual(m2["gateway_responses_status_404_total"] ?? 0, base404 + 2)
+
+        try await server.stop()
+    }
+}
+


### PR DESCRIPTION
## Summary
- cover route CRUD error paths and metrics
- test RoleGuard auth scenarios and reload 304 metrics
- verify circuit breaker opens/rejects and hop-by-hop header stripping

## Testing
- `swift test -v`

------
https://chatgpt.com/codex/tasks/task_b_68b083a560c88333979e5e29244e7903