### PR TITLE
chore: track per-target coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 env:
   CONTAINER_IMAGE: ghcr.io/${{ github.repository }}:latest
+  MIN_COVERAGE: 90
 
 jobs:
   lint:
@@ -42,7 +43,7 @@ jobs:
       - name: Build
         run: swift build
       - name: Coverage
-        run: Scripts/coverage.sh 50
+        run: Scripts/coverage.sh ${{ env.MIN_COVERAGE }}
       - name: Test SPS
         working-directory: sps
         run: swift test --enable-code-coverage
@@ -63,6 +64,7 @@ jobs:
           path: |
             coverage.lcov
             coverage-badge.svg
+            coverage-targets.txt
       - name: Install supply chain tools
         if: runner.os == 'Linux'
         run: |

--- a/Scripts/coverage.sh
+++ b/Scripts/coverage.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 THRESHOLD="${1:-0}"
-MODULE="FountainRuntime"
 SWIFT_BIN=$(command -v swift)
 LLVM_COV_BIN=$(command -v llvm-cov || echo "$(dirname "$SWIFT_BIN")/../usr/bin/llvm-cov")
 
@@ -19,17 +18,31 @@ TEST_BINARY=$(find .build -name '*.xctest' | head -n 1)
 echo "[coverage] generating per-file summaries"
 "$LLVM_COV_BIN" show "$TEST_BINARY" -instr-profile "$CODECOV_DIR/default.profdata" -summary-only > coverage-summary.txt
 
-MODULE_COV=$("$LLVM_COV_BIN" export -summary-only "$TEST_BINARY" -instr-profile "$CODECOV_DIR/default.profdata" |
-  jq '[.data[].files[] | select(.filename | contains("libs/FountainRuntime")) | .summary.lines] |
-      reduce .[] as $f ({covered:0,count:0}; {covered: (.covered + $f.covered), count: (.count + $f.count)}) |
-      if .count > 0 then (.covered / .count * 100) else 0 end')
+TARGETS=(
+  "FountainRuntime:libs/FountainRuntime"
+  "gateway-server:apps/GatewayServer"
+  "LLMGatewayPlugin:libs/GatewayPlugins/LLMGatewayPlugin"
+  "AuthGatewayPlugin:libs/GatewayPlugins/AuthGatewayPlugin"
+  "RateLimiterGatewayPlugin:libs/GatewayPlugins/RateLimiterGatewayPlugin"
+  "BudgetBreakerGatewayPlugin:libs/GatewayPlugins/BudgetBreakerGatewayPlugin"
+  "PayloadInspectionGatewayPlugin:libs/GatewayPlugins/PayloadInspectionGatewayPlugin"
+  "DestructiveGuardianGatewayPlugin:libs/GatewayPlugins/DestructiveGuardianGatewayPlugin"
+  "SecuritySentinelGatewayPlugin:libs/GatewayPlugins/SecuritySentinelGatewayPlugin"
+)
 
-printf "[coverage] FountainRuntime line coverage: %.2f%%\n" "$MODULE_COV"
-
-below=$(awk -v cov="$MODULE_COV" -v thr="$THRESHOLD" 'BEGIN {print (cov < thr)}')
-if [ "$below" -eq 1 ]; then
-  echo "[coverage] FountainRuntime coverage ${MODULE_COV}% below threshold ${THRESHOLD}%"
-  exit 1
-fi
+> coverage-targets.txt
+COVERAGE_JSON=$("$LLVM_COV_BIN" export -summary-only "$TEST_BINARY" -instr-profile "$CODECOV_DIR/default.profdata")
+for entry in "${TARGETS[@]}"; do
+  name=${entry%%:*}
+  path=${entry#*:}
+  cov=$(echo "$COVERAGE_JSON" | jq --arg path "$path" '[.data[].files[] | select(.filename | contains($path)) | .summary.lines] | reduce .[] as $f ({covered:0,count:0}; {covered: (.covered + $f.covered), count: (.count + $f.count)}) | if .count > 0 then (.covered / .count * 100) else 0 end')
+  printf "%s %.2f\n" "$name" "$cov" >> coverage-targets.txt
+  printf "[coverage] %s line coverage: %.2f%%\n" "$name" "$cov"
+  below=$(awk -v cov="$cov" -v thr="$THRESHOLD" 'BEGIN {print (cov < thr)}')
+  if [ "$below" -eq 1 ]; then
+    echo "[coverage] $name coverage ${cov}% below threshold ${THRESHOLD}%"
+    exit 1
+  fi
+done
 
 echo "[coverage] OK"


### PR DESCRIPTION
## Summary
- record coverage for gateway-server and each gateway plugin
- enforce minimum coverage in CI with configurable threshold

## Testing
- `Scripts/coverage.sh 0` *(fails: 'swift-crypto': Couldn’t check out revision 'd1c6b70f7c5f19fb0b8750cb8dcdf2ea6e2d8c34')*


------
https://chatgpt.com/codex/tasks/task_b_68b08aa9a4dc833381c849eb0f90cc54