### PR TITLE
Add DNSEngine tests for unsupported and invalid IPv6 records

### DIFF
--- a/Tests/DNSTests/DNSEngineTests.swift
+++ b/Tests/DNSTests/DNSEngineTests.swift
@@ -81,6 +81,26 @@ final class DNSEngineTests: XCTestCase {
         XCTAssertTrue(hasTarget)
     }
 
+    func testUnsupportedRecordTypeResponseNil() {
+        var query = makeQuery(name: "example.com", type: 16) // TXT
+        guard let parser = DNSParser(buffer: &query) else {
+            XCTFail("Expected parser")
+            return
+        }
+        let record = DNSEngine.Record(name: "example.com", type: "TXT", value: "hello")
+        XCTAssertNil(parser.makeResponse(record: record))
+    }
+
+    func testInvalidIPv6RecordReturnsNil() {
+        var query = makeQuery(name: "badipv6.com", type: 28) // AAAA
+        guard let parser = DNSParser(buffer: &query) else {
+            XCTFail("Expected parser")
+            return
+        }
+        let record = DNSEngine.Record(name: "badipv6.com", type: "AAAA", value: "not-a-valid-ip")
+        XCTAssertNil(parser.makeResponse(record: record))
+    }
+
     func testUnknownRecordReturnsNil() {
         var query = makeQuery(name: "unknown.com", type: 1)
         let engine = DNSEngine(records: [.init(name: "example.com", type: "A", value: "1.2.3.4")])


### PR DESCRIPTION
## Summary
- test TXT queries produce no response
- check AAAA record parsing fails for invalid IPv6

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68b095b92bb88333a04cccf080b41a30