### PR TITLE
Add AsyncHTTPClientDriver double shutdown test

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -208,7 +208,7 @@ let fullTargets: [Target] = [
     .testTarget(name: "DNSTests", dependencies: ["PublishingFrontend", "FountainRuntime", .product(name: "Crypto", package: "swift-crypto"), .product(name: "NIOEmbedded", package: "swift-nio"), .product(name: "NIO", package: "swift-nio")], path: "Tests/DNSTests"),
     .testTarget(
         name: "IntegrationRuntimeTests",
-        dependencies: ["gateway-server", "FountainRuntime", "LLMGatewayPlugin", "RateLimiterGatewayPlugin", .product(name: "NIO", package: "swift-nio")],
+        dependencies: ["gateway-server", "FountainRuntime", "LLMGatewayPlugin", "RateLimiterGatewayPlugin", .product(name: "NIO", package: "swift-nio"), .product(name: "AsyncHTTPClient", package: "async-http-client")],
         path: "Tests/IntegrationRuntimeTests",
         resources: [.process("Fixtures")]
     ),
@@ -351,7 +351,7 @@ let leanTargets: [Target] = [
     .target(name: "ResourceLoader", path: "libs/ResourceLoader"),
     .testTarget(
         name: "IntegrationRuntimeTests",
-        dependencies: ["gateway-server", "FountainRuntime", "LLMGatewayPlugin", "RateLimiterGatewayPlugin", .product(name: "NIO", package: "swift-nio")],
+        dependencies: ["gateway-server", "FountainRuntime", "LLMGatewayPlugin", "RateLimiterGatewayPlugin", .product(name: "NIO", package: "swift-nio"), .product(name: "AsyncHTTPClient", package: "async-http-client")],
         path: "Tests/IntegrationRuntimeTests",
         resources: [.process("Fixtures")]
     ),

--- a/Tests/IntegrationRuntimeTests/AsyncHTTPClientDriverTests.swift
+++ b/Tests/IntegrationRuntimeTests/AsyncHTTPClientDriverTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import NIOCore
 import NIOHTTP1
+import AsyncHTTPClient
 @testable import FountainRuntime
 
 final class AsyncHTTPClientDriverTests: XCTestCase {
@@ -52,6 +53,21 @@ final class AsyncHTTPClientDriverTests: XCTestCase {
             XCTAssertNotNil(error)
         }
         try await client.shutdown()
+    }
+
+    /// Ensures calling shutdown twice surfaces an already shutdown error.
+    func testShutdownTwiceThrows() async throws {
+        let client = AsyncHTTPClientDriver()
+        try await client.shutdown()
+        do {
+            try await client.shutdown()
+            XCTFail("Expected alreadyShutdown error")
+        } catch {
+            guard let httpError = error as? HTTPClientError else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(httpError, .alreadyShutdown)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure AsyncHTTPClientDriver shutdown emits alreadyShutdown on second call
- expose AsyncHTTPClient to IntegrationRuntimeTests

## Testing
- `swift test --filter AsyncHTTPClientDriverTests/testShutdownTwiceThrows`


------
https://chatgpt.com/codex/tasks/task_b_68b0a08d91f88333885e06b8658a7ec8