### PR TITLE
Add Planner service and server

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,9 @@ let fullProducts: [Product] = [
     .executable(name: "publishing-frontend", targets: ["publishing-frontend"]),
     .executable(name: "flexctl", targets: ["flexctl"]),
     .executable(name: "tools-factory-server", targets: ["tools-factory-server"]),
-    .executable(name: "sse-client", targets: ["sse-client"])
+    .executable(name: "sse-client", targets: ["sse-client"]),
+    .library(name: "PlannerService", targets: ["PlannerService"]),
+    .executable(name: "planner-server", targets: ["planner-server"])
 ]
 
 let leanProducts: [Product] = [
@@ -141,6 +143,11 @@ let fullTargets: [Target] = [
         dependencies: ["TypesensePersistence", .product(name: "Numerics", package: "swift-numerics"), .product(name: "Atomics", package: "swift-atomics")],
         path: "libs/BootstrapService"
     ),
+    .target(
+        name: "PlannerService",
+        dependencies: ["FountainRuntime", "TypesensePersistence"],
+        path: "libs/PlannerService"
+    ),
     .executableTarget(
         name: "publishing-frontend",
         dependencies: ["PublishingFrontend"],
@@ -187,6 +194,11 @@ let fullTargets: [Target] = [
         name: "tools-factory-server",
         dependencies: ["ToolServer", "TypesensePersistence"],
         path: "apps/ToolsFactoryServer"
+    ),
+    .executableTarget(
+        name: "planner-server",
+        dependencies: ["FountainRuntime", "TypesensePersistence", "PlannerService", "Yams"],
+        path: "apps/PlannerServer"
     ),
     .executableTarget(
         name: "persist-server",
@@ -249,6 +261,11 @@ let fullTargets: [Target] = [
         name: "BootstrapServiceTests",
         dependencies: ["BootstrapService", "TypesensePersistence"],
         path: "Tests/BootstrapServiceTests"
+    ),
+    .testTarget(
+        name: "PlannerServiceTests",
+        dependencies: ["PlannerService", "TypesensePersistence", "Yams"],
+        path: "Tests/PlannerServiceTests"
     ),
     .testTarget(
         name: "E2ETests",

--- a/Tests/PlannerServiceTests/PlannerOpenAPIConformanceTests.swift
+++ b/Tests/PlannerServiceTests/PlannerOpenAPIConformanceTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+import Yams
+
+final class PlannerOpenAPIConformanceTests: XCTestCase {
+    func testLoadPlannerSpec() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let url = root.appendingPathComponent("openapi/v1/planner.yml")
+        let text = try String(contentsOf: url)
+        let obj = try Yams.load(yaml: text)
+        XCTAssertNotNil(obj)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/PlannerServiceTests/PlannerServiceTests.swift
+++ b/Tests/PlannerServiceTests/PlannerServiceTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+@testable import PlannerService
+@testable import TypesensePersistence
+
+final class PlannerServiceTests: XCTestCase {
+    func testReasonEndpoint() async throws {
+        let svc = TypesensePersistenceService(client: MockTypesenseClient())
+        let router = PlannerRouter(persistence: svc)
+        let reqObj = UserObjectiveRequest(objective: "test goal")
+        let data = try JSONEncoder().encode(reqObj)
+        let req = HTTPRequest(method: "POST", path: "/planner/reason", body: data)
+        let resp = try await router.route(req)
+        XCTAssertEqual(resp.status, 200)
+        let plan = try JSONDecoder().decode(PlanResponse.self, from: resp.body)
+        XCTAssertEqual(plan.objective, "test goal")
+    }
+
+    func testExecuteEndpoint() async throws {
+        let svc = TypesensePersistenceService(client: MockTypesenseClient())
+        let router = PlannerRouter(persistence: svc)
+        let step = FunctionCall(name: "step1", arguments: ["a": "1"])
+        let execReq = PlanExecutionRequest(objective: "obj", steps: [step])
+        let data = try JSONEncoder().encode(execReq)
+        let req = HTTPRequest(method: "POST", path: "/planner/execute", body: data)
+        let resp = try await router.route(req)
+        XCTAssertEqual(resp.status, 200)
+        let result = try JSONDecoder().decode(ExecutionResult.self, from: resp.body)
+        XCTAssertEqual(result.results.count, 1)
+        XCTAssertEqual(result.results.first?.step, "step1")
+    }
+
+    func testListCorpora() async throws {
+        let svc = TypesensePersistenceService(client: MockTypesenseClient())
+        _ = try await svc.createCorpus(.init(corpusId: "c1"))
+        let router = PlannerRouter(persistence: svc)
+        let resp = try await router.route(.init(method: "GET", path: "/planner/corpora"))
+        XCTAssertEqual(resp.status, 200)
+        let corpora = try JSONDecoder().decode([String].self, from: resp.body)
+        XCTAssertEqual(corpora, ["c1"])
+    }
+
+    func testPostReflection() async throws {
+        let svc = TypesensePersistenceService(client: MockTypesenseClient())
+        let router = PlannerRouter(persistence: svc)
+        let reqObj = ChatReflectionRequest(corpusId: "c1", message: "hello")
+        let data = try JSONEncoder().encode(reqObj)
+        let resp = try await router.route(.init(method: "POST", path: "/planner/reflections", body: data))
+        XCTAssertEqual(resp.status, 200)
+        let item = try JSONDecoder().decode(ReflectionItem.self, from: resp.body)
+        XCTAssertEqual(item.content, "hello")
+    }
+
+    func testGetReflections() async throws {
+        let svc = TypesensePersistenceService(client: MockTypesenseClient())
+        _ = try await svc.addReflection(.init(corpusId: "c1", reflectionId: "r1", question: "q", content: "a"))
+        let router = PlannerRouter(persistence: svc)
+        let resp = try await router.route(.init(method: "GET", path: "/planner/reflections/c1"))
+        XCTAssertEqual(resp.status, 200)
+        let history = try JSONDecoder().decode(HistoryListResponse.self, from: resp.body)
+        XCTAssertEqual(history.reflections.count, 1)
+    }
+
+    func testGetSemanticArc() async throws {
+        let svc = TypesensePersistenceService(client: MockTypesenseClient())
+        _ = try await svc.addReflection(.init(corpusId: "c1", reflectionId: "r1", question: "q", content: "a"))
+        let router = PlannerRouter(persistence: svc)
+        let resp = try await router.route(.init(method: "GET", path: "/planner/reflections/c1/semantic-arc"))
+        XCTAssertEqual(resp.status, 200)
+        let obj = try JSONSerialization.jsonObject(with: resp.body) as? [String: Any]
+        XCTAssertEqual(obj?["total"] as? Int, 1)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/apps/PlannerServer/main.swift
+++ b/apps/PlannerServer/main.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Dispatch
+import FountainRuntime
+import Yams
+import TypesensePersistence
+import PlannerService
+
+struct PlannerConfig: Codable {
+    var typesenseURLs: [String]
+    var apiKey: String
+    var debug: Bool
+}
+
+func loadPlannerConfig() -> PlannerConfig? {
+    let fileURL = URL(fileURLWithPath: "Configuration/planner.yml")
+    if FileManager.default.fileExists(atPath: fileURL.path) {
+        if let contents = try? String(contentsOf: fileURL, encoding: .utf8) {
+            let sanitized = contents
+                .split(separator: "\n", omittingEmptySubsequences: false)
+                .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("©") }
+                .joined(separator: "\n")
+            if let yaml = try? Yams.load(yaml: sanitized) as? [String: Any] {
+                let urls = (yaml["typesenseURLs"] as? [String]) ?? []
+                let apiKey = (yaml["apiKey"] as? String) ?? ""
+                let debug = (yaml["debug"] as? Bool) ?? false
+                return PlannerConfig(typesenseURLs: urls, apiKey: apiKey, debug: debug)
+            }
+        }
+    }
+    let env = ProcessInfo.processInfo.environment
+    let urls = env["TYPESENSE_URLS"].map { $0.split(separator: ",").map { String($0) } }
+        ?? env["TYPESENSE_URL"].map { [ $0 ] }
+        ?? []
+    let apiKey = env["TYPESENSE_API_KEY"] ?? ""
+    let debug = (env["PLANNER_DEBUG"] ?? "").lowercased() == "true"
+    if urls.isEmpty || apiKey.isEmpty { return nil }
+    return PlannerConfig(typesenseURLs: urls, apiKey: apiKey, debug: debug)
+}
+
+func buildService() -> TypesensePersistenceService {
+    if let cfg = loadPlannerConfig() {
+        #if canImport(Typesense)
+        let client = RealTypesenseClient(nodes: cfg.typesenseURLs, apiKey: cfg.apiKey, debug: cfg.debug)
+        return TypesensePersistenceService(client: client)
+        #else
+        return TypesensePersistenceService(client: MockTypesenseClient())
+        #endif
+    } else {
+        FileHandle.standardError.write(Data("[planner] Warning: TYPESENSE_URL(S) or TYPESENSE_API_KEY not set; using in-memory mock.\n".utf8))
+        return TypesensePersistenceService(client: MockTypesenseClient())
+    }
+}
+
+let svc = buildService()
+Task {
+    await svc.ensureCollections()
+    let kernel = makePlannerKernel(service: svc)
+    let server = NIOHTTPServer(kernel: kernel)
+    do {
+        _ = try await server.start(port: 8083)
+        print("planner server listening on port 8083")
+    } catch {
+        FileHandle.standardError.write(Data("[planner] Failed to start: \(error)\n".utf8))
+    }
+}
+dispatchMain()
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/PlannerService/PlannerService.swift
+++ b/libs/PlannerService/PlannerService.swift
@@ -1,0 +1,141 @@
+import Foundation
+import TypesensePersistence
+import FountainRuntime
+
+public struct UserObjectiveRequest: Codable, Sendable {
+    public let objective: String
+    public init(objective: String) { self.objective = objective }
+}
+
+public struct FunctionCall: Codable, Sendable {
+    public let name: String
+    public let arguments: [String: String]
+    public init(name: String, arguments: [String: String]) { self.name = name; self.arguments = arguments }
+}
+
+public struct PlanResponse: Codable, Sendable {
+    public let objective: String
+    public let steps: [FunctionCall]
+    public init(objective: String, steps: [FunctionCall]) { self.objective = objective; self.steps = steps }
+}
+
+public struct PlanExecutionRequest: Codable, Sendable {
+    public let objective: String
+    public let steps: [FunctionCall]
+    public init(objective: String, steps: [FunctionCall]) { self.objective = objective; self.steps = steps }
+}
+
+public struct FunctionCallResult: Codable, Sendable {
+    public let step: String
+    public let arguments: [String: String]
+    public let output: String
+    public init(step: String, arguments: [String: String], output: String) {
+        self.step = step; self.arguments = arguments; self.output = output
+    }
+}
+
+public struct ExecutionResult: Codable, Sendable {
+    public let results: [FunctionCallResult]
+    public init(results: [FunctionCallResult]) { self.results = results }
+}
+
+public struct ChatReflectionRequest: Codable, Sendable {
+    public let corpusId: String
+    public let message: String
+    public init(corpusId: String, message: String) { self.corpusId = corpusId; self.message = message }
+    enum CodingKeys: String, CodingKey { case corpusId = "corpus_id"; case message }
+}
+
+public struct ReflectionItem: Codable, Sendable {
+    public let timestamp: String
+    public let content: String
+    public init(timestamp: String, content: String) { self.timestamp = timestamp; self.content = content }
+}
+
+public struct HistoryListResponse: Codable, Sendable {
+    public let reflections: [ReflectionItem]
+    public init(reflections: [ReflectionItem]) { self.reflections = reflections }
+}
+
+public struct HTTPRequest: Sendable {
+    public let method: String
+    public let path: String
+    public let body: Data
+    public init(method: String, path: String, body: Data = Data()) {
+        self.method = method; self.path = path; self.body = body
+    }
+}
+
+public struct HTTPResponse: Sendable {
+    public let status: Int
+    public let headers: [String: String]
+    public let body: Data
+    public init(status: Int, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status; self.headers = headers; self.body = body
+    }
+}
+
+public final class PlannerRouter: @unchecked Sendable {
+    let persistence: TypesensePersistenceService
+    public init(persistence: TypesensePersistenceService) { self.persistence = persistence }
+
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let pathOnly = request.path.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false).first.map(String.init) ?? request.path
+        let segments = pathOnly.split(separator: "/", omittingEmptySubsequences: true)
+        switch (request.method, segments) {
+        case ("POST", ["planner", "reason"]):
+            if let obj = try? JSONDecoder().decode(UserObjectiveRequest.self, from: request.body) {
+                let plan = PlanResponse(objective: obj.objective, steps: [])
+                let data = try JSONEncoder().encode(plan)
+                return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+            }
+            return HTTPResponse(status: 422)
+        case ("POST", ["planner", "execute"]):
+            if let obj = try? JSONDecoder().decode(PlanExecutionRequest.self, from: request.body) {
+                let results = obj.steps.map { FunctionCallResult(step: $0.name, arguments: $0.arguments, output: "ok") }
+                let data = try JSONEncoder().encode(ExecutionResult(results: results))
+                return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+            }
+            return HTTPResponse(status: 422)
+        case ("GET", ["planner", "corpora"]):
+            let (_, corpora) = try await persistence.listCorpora()
+            let data = try JSONEncoder().encode(corpora)
+            return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+        case ("GET", ["planner", "reflections", let corpusId]):
+            let (_, refs) = try await persistence.listReflections(corpusId: String(corpusId))
+            let items = refs.map { ReflectionItem(timestamp: String($0.ts), content: $0.content) }
+            let data = try JSONEncoder().encode(HistoryListResponse(reflections: items))
+            return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+        case ("GET", ["planner", "reflections", let corpusId, "semantic-arc"]):
+            let (_, refs) = try await persistence.listReflections(corpusId: String(corpusId))
+            let obj: [String: Any] = ["corpus_id": String(corpusId), "total": refs.count]
+            let data = try JSONSerialization.data(withJSONObject: obj)
+            return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+        case ("POST", ["planner", "reflections"]):
+            if let incoming = try? JSONDecoder().decode(ChatReflectionRequest.self, from: request.body) {
+                let reflection = Reflection(corpusId: incoming.corpusId, reflectionId: UUID().uuidString, question: incoming.message, content: incoming.message)
+                _ = try await persistence.addReflection(reflection)
+                let item = ReflectionItem(timestamp: String(reflection.ts), content: reflection.content)
+                let data = try JSONEncoder().encode(item)
+                return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+            }
+            return HTTPResponse(status: 422)
+        case ("GET", ["metrics"]):
+            let body = Data("planner_requests_total 0\n".utf8)
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: body)
+        default:
+            return HTTPResponse(status: 404)
+        }
+    }
+}
+
+public func makePlannerKernel(service svc: TypesensePersistenceService) -> HTTPKernel {
+    let router = PlannerRouter(persistence: svc)
+    return HTTPKernel { req in
+        let ar = HTTPRequest(method: req.method, path: req.path, body: req.body)
+        let resp = try await router.route(ar)
+        return FountainRuntime.HTTPResponse(status: resp.status, headers: resp.headers, body: resp.body)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/platform/FountainAILauncher/Sources/FountainAiLauncher/services.json
+++ b/platform/FountainAILauncher/Sources/FountainAiLauncher/services.json
@@ -1,12 +1,72 @@
 [
-  {"name":"Baseline Awareness","binaryPath":"/usr/local/bin/baseline-awareness","port":8001,"healthPath":"/metrics","shouldRestart":true},
-  {"name":"Bootstrap","binaryPath":"/usr/local/bin/bootstrap","port":8002,"healthPath":"/metrics","shouldRestart":true},
-  {"name":"Planner","binaryPath":"/usr/local/bin/planner","port":8003,"healthPath":"/metrics","shouldRestart":true},
-  {"name":"Function Caller","binaryPath":"/usr/local/bin/function-caller","port":8004,"healthPath":"/metrics","shouldRestart":true},
-  {"name":"Persist","binaryPath":"/usr/local/bin/persist","port":8005,"healthPath":"/metrics","shouldRestart":true},
-  {"name":"LLM Gateway","binaryPath":"/usr/local/bin/llm-gateway","port":8006,"healthPath":"/metrics","shouldRestart":true},
-  {"name":"Semantic Browser","binaryPath":"/usr/local/bin/semantic-browser","port":8007,"healthPath":"/metrics","shouldRestart":true},
-  {"name":"Gateway","binaryPath":"/usr/local/bin/fountain-gateway","port":8010,"healthPath":"/metrics","shouldRestart":true},
-  {"name":"Tools Factory","binaryPath":"/usr/local/bin/tools-factory","port":8011,"healthPath":"/metrics","shouldRestart":true},
-  {"name":"Typesense","binaryPath":"/usr/local/bin/typesense","port":8100,"healthPath":"/metrics","shouldRestart":true}
+  {
+    "port" : 8001,
+    "shouldRestart" : true,
+    "healthPath" : "\/metrics",
+    "name" : "Baseline Awareness",
+    "binaryPath" : "\/usr\/local\/bin\/baseline-awareness"
+  },
+  {
+    "port" : 8002,
+    "shouldRestart" : true,
+    "healthPath" : "\/metrics",
+    "name" : "Bootstrap",
+    "binaryPath" : "\/usr\/local\/bin\/bootstrap"
+  },
+  {
+    "port" : 8003,
+    "shouldRestart" : true,
+    "healthPath" : "\/metrics",
+    "name" : "Planner",
+    "binaryPath" : "\/usr\/local\/bin\/planner"
+  },
+  {
+    "port" : 8004,
+    "shouldRestart" : true,
+    "healthPath" : "\/metrics",
+    "name" : "Function Caller",
+    "binaryPath" : "\/usr\/local\/bin\/function-caller"
+  },
+  {
+    "port" : 8005,
+    "shouldRestart" : true,
+    "healthPath" : "\/metrics",
+    "name" : "Persist",
+    "binaryPath" : "\/usr\/local\/bin\/persist"
+  },
+  {
+    "port" : 8006,
+    "shouldRestart" : true,
+    "healthPath" : "\/metrics",
+    "name" : "LLM Gateway",
+    "binaryPath" : "\/usr\/local\/bin\/llm-gateway"
+  },
+  {
+    "port" : 8007,
+    "shouldRestart" : true,
+    "healthPath" : "\/metrics",
+    "name" : "Semantic Browser",
+    "binaryPath" : "\/usr\/local\/bin\/semantic-browser"
+  },
+  {
+    "binaryPath" : "\/usr\/local\/bin\/fountain-gateway",
+    "port" : 8010,
+    "name" : "Gateway",
+    "healthPath" : "\/metrics",
+    "shouldRestart" : true
+  },
+  {
+    "binaryPath" : "\/usr\/local\/bin\/tools-factory",
+    "port" : 8011,
+    "name" : "Tools Factory",
+    "healthPath" : "\/metrics",
+    "shouldRestart" : true
+  },
+  {
+    "binaryPath" : "\/usr\/local\/bin\/typesense",
+    "port" : 8100,
+    "name" : "Typesense",
+    "healthPath" : "\/metrics",
+    "shouldRestart" : true
+  }
 ]


### PR DESCRIPTION
## Summary
- introduce PlannerService with request/response models and router endpoints
- add PlannerServer executable using Typesense persistence and NIOHTTPServer
- wire PlannerService and server into Package manifest and regenerate launcher services.json

## Testing
- `swift build`
- `swift test -v` *(fails to complete: build in progress)*

------
https://chatgpt.com/codex/tasks/task_b_68b12f08944c83339bacd8a8634de853