### PR TITLE
Add Function Caller service and server

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,9 @@ let fullProducts: [Product] = [
     .executable(name: "tools-factory-server", targets: ["tools-factory-server"]),
     .executable(name: "sse-client", targets: ["sse-client"]),
     .library(name: "PlannerService", targets: ["PlannerService"]),
-    .executable(name: "planner-server", targets: ["planner-server"])
+    .executable(name: "planner-server", targets: ["planner-server"]),
+    .library(name: "FunctionCallerService", targets: ["FunctionCallerService"]),
+    .executable(name: "function-caller-server", targets: ["function-caller-server"])
 ]
 
 let leanProducts: [Product] = [
@@ -148,6 +150,11 @@ let fullTargets: [Target] = [
         dependencies: ["FountainRuntime", "TypesensePersistence"],
         path: "libs/PlannerService"
     ),
+    .target(
+        name: "FunctionCallerService",
+        dependencies: ["FountainRuntime", "TypesensePersistence", .product(name: "AsyncHTTPClient", package: "async-http-client")],
+        path: "libs/FunctionCallerService"
+    ),
     .executableTarget(
         name: "publishing-frontend",
         dependencies: ["PublishingFrontend"],
@@ -199,6 +206,11 @@ let fullTargets: [Target] = [
         name: "planner-server",
         dependencies: ["FountainRuntime", "TypesensePersistence", "PlannerService", "Yams"],
         path: "apps/PlannerServer"
+    ),
+    .executableTarget(
+        name: "function-caller-server",
+        dependencies: ["FountainRuntime", "TypesensePersistence", "FunctionCallerService", "Yams"],
+        path: "apps/FunctionCallerServer"
     ),
     .executableTarget(
         name: "persist-server",
@@ -266,6 +278,11 @@ let fullTargets: [Target] = [
         name: "PlannerServiceTests",
         dependencies: ["PlannerService", "TypesensePersistence", "Yams"],
         path: "Tests/PlannerServiceTests"
+    ),
+    .testTarget(
+        name: "FunctionCallerServiceTests",
+        dependencies: ["FunctionCallerService", "TypesensePersistence", "FountainRuntime", "Yams"],
+        path: "Tests/FunctionCallerServiceTests"
     ),
     .testTarget(
         name: "E2ETests",

--- a/Tests/FunctionCallerServiceTests/FunctionCallerOpenAPIConformanceTests.swift
+++ b/Tests/FunctionCallerServiceTests/FunctionCallerOpenAPIConformanceTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+import Yams
+
+final class FunctionCallerOpenAPIConformanceTests: XCTestCase {
+    func testLoadSpec() throws {
+        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let url = root.appendingPathComponent("openapi/v1/function-caller.yml")
+        let text = try String(contentsOf: url)
+        let obj = try Yams.load(yaml: text)
+        XCTAssertNotNil(obj)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Tests/FunctionCallerServiceTests/FunctionCallerServiceTests.swift
+++ b/Tests/FunctionCallerServiceTests/FunctionCallerServiceTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import FunctionCallerService
+@testable import TypesensePersistence
+import FountainRuntime
+
+final class FunctionCallerServiceTests: XCTestCase {
+    func startStubServer() async throws -> (port: Int, shutdown: () async throws -> Void) {
+        let kernel = HTTPKernel { req in
+            return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: req.body)
+        }
+        let server = NIOHTTPServer(kernel: kernel)
+        let port = try await server.start(port: 0)
+        return (port, { try await server.stop() })
+    }
+
+    func testListDetailAndInvoke() async throws {
+        let stub = try await startStubServer()
+        defer { try? await stub.shutdown() }
+        let svc = TypesensePersistenceService(client: MockTypesenseClient())
+        let fn = FunctionModel(corpusId: "c1", functionId: "echo", name: "Echo", description: "desc", httpMethod: "POST", httpPath: "http://127.0.0.1:\(stub.port)/echo")
+        _ = try await svc.addFunction(fn)
+        let router = FunctionCallerRouter(persistence: svc)
+
+        let listResp = try await router.route(.init(method: "GET", path: "/functions"))
+        XCTAssertEqual(listResp.status, 200)
+        let list = try JSONDecoder().decode(FunctionsListResponse.self, from: listResp.body)
+        XCTAssertEqual(list.total, 1)
+        XCTAssertEqual(list.functions.first?.function_id, "echo")
+
+        let detailResp = try await router.route(.init(method: "GET", path: "/functions/echo"))
+        XCTAssertEqual(detailResp.status, 200)
+        let info = try JSONDecoder().decode(FunctionInfo.self, from: detailResp.body)
+        XCTAssertEqual(info.http_path, "http://127.0.0.1:\(stub.port)/echo")
+
+        let body = try JSONSerialization.data(withJSONObject: ["foo": "bar"])
+        let invokeResp = try await router.route(.init(method: "POST", path: "/functions/echo/invoke", body: body))
+        XCTAssertEqual(invokeResp.status, 200)
+        let obj = try JSONSerialization.jsonObject(with: invokeResp.body) as? [String: String]
+        XCTAssertEqual(obj?["foo"], "bar")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/apps/FunctionCallerServer/main.swift
+++ b/apps/FunctionCallerServer/main.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Dispatch
+import FountainRuntime
+import Yams
+import TypesensePersistence
+import FunctionCallerService
+
+struct FunctionCallerConfig: Codable {
+    var typesenseURLs: [String]
+    var apiKey: String
+    var debug: Bool
+}
+
+func loadFunctionCallerConfig() -> FunctionCallerConfig? {
+    let fileURL = URL(fileURLWithPath: "Configuration/function-caller.yml")
+    if FileManager.default.fileExists(atPath: fileURL.path) {
+        if let contents = try? String(contentsOf: fileURL, encoding: .utf8) {
+            let sanitized = contents
+                .split(separator: "\n", omittingEmptySubsequences: false)
+                .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("©") }
+                .joined(separator: "\n")
+            if let yaml = try? Yams.load(yaml: sanitized) as? [String: Any] {
+                let urls = (yaml["typesenseURLs"] as? [String]) ?? []
+                let apiKey = (yaml["apiKey"] as? String) ?? ""
+                let debug = (yaml["debug"] as? Bool) ?? false
+                return FunctionCallerConfig(typesenseURLs: urls, apiKey: apiKey, debug: debug)
+            }
+        }
+    }
+    let env = ProcessInfo.processInfo.environment
+    let urls = env["TYPESENSE_URLS"].map { $0.split(separator: ",").map { String($0) } }
+        ?? env["TYPESENSE_URL"].map { [ $0 ] }
+        ?? []
+    let apiKey = env["TYPESENSE_API_KEY"] ?? ""
+    let debug = (env["FUNCTION_CALLER_DEBUG"] ?? "").lowercased() == "true"
+    if urls.isEmpty || apiKey.isEmpty { return nil }
+    return FunctionCallerConfig(typesenseURLs: urls, apiKey: apiKey, debug: debug)
+}
+
+func buildService() -> TypesensePersistenceService {
+    if let cfg = loadFunctionCallerConfig() {
+        #if canImport(Typesense)
+        let client = RealTypesenseClient(nodes: cfg.typesenseURLs, apiKey: cfg.apiKey, debug: cfg.debug)
+        return TypesensePersistenceService(client: client)
+        #else
+        return TypesensePersistenceService(client: MockTypesenseClient())
+        #endif
+    } else {
+        FileHandle.standardError.write(Data("[function-caller] Warning: TYPESENSE_URL(S) or TYPESENSE_API_KEY not set; using in-memory mock.\n".utf8))
+        return TypesensePersistenceService(client: MockTypesenseClient())
+    }
+}
+
+let svc = buildService()
+Task {
+    await svc.ensureCollections()
+    let kernel = makeFunctionCallerKernel(service: svc)
+    let server = NIOHTTPServer(kernel: kernel)
+    do {
+        _ = try await server.start(port: 8084)
+        print("function-caller server listening on port 8084")
+    } catch {
+        FileHandle.standardError.write(Data("[function-caller] Failed to start: \(error)\n".utf8))
+    }
+}
+dispatchMain()
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/FunctionCallerService/FunctionCallerService.swift
+++ b/libs/FunctionCallerService/FunctionCallerService.swift
@@ -1,0 +1,161 @@
+import Foundation
+import AsyncHTTPClient
+import FountainRuntime
+import TypesensePersistence
+
+public struct FunctionInfo: Codable, Sendable {
+    public let function_id: String
+    public let name: String
+    public let description: String
+    public let http_method: String
+    public let http_path: String
+    public let parameters_schema: [String: String]?
+    public init(function_id: String, name: String, description: String, http_method: String, http_path: String, parameters_schema: [String: String]? = nil) {
+        self.function_id = function_id
+        self.name = name
+        self.description = description
+        self.http_method = http_method
+        self.http_path = http_path
+        self.parameters_schema = parameters_schema
+    }
+}
+
+public struct ErrorResponse: Codable, Sendable {
+    public let error_code: String
+    public let message: String
+    public init(error_code: String, message: String) {
+        self.error_code = error_code
+        self.message = message
+    }
+}
+
+public struct FunctionsListResponse: Codable, Sendable {
+    public let functions: [FunctionInfo]
+    public let page: Int
+    public let page_size: Int
+    public let total: Int
+    public init(functions: [FunctionInfo], page: Int, page_size: Int, total: Int) {
+        self.functions = functions
+        self.page = page
+        self.page_size = page_size
+        self.total = total
+    }
+}
+
+public struct HTTPRequest: Sendable {
+    public let method: String
+    public let path: String
+    public let headers: [String: String]
+    public let body: Data
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+}
+
+public struct HTTPResponse: Sendable {
+    public let status: Int
+    public let headers: [String: String]
+    public let body: Data
+    public init(status: Int, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}
+
+public final class FunctionCallerRouter: @unchecked Sendable {
+    let persistence: TypesensePersistenceService
+    let client: HTTPClient
+
+    public init(persistence: TypesensePersistenceService, client: HTTPClient = HTTPClient(eventLoopGroupProvider: .createNew)) {
+        self.persistence = persistence
+        self.client = client
+    }
+
+    deinit {
+        try? client.syncShutdown()
+    }
+
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
+        let parts = request.path.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false)
+        let pathOnly = parts.first.map(String.init) ?? request.path
+        let query = parts.dropFirst().first.map(String.init) ?? ""
+        let segments = pathOnly.split(separator: "/", omittingEmptySubsequences: true)
+        switch (request.method, segments) {
+        case ("GET", ["functions"]):
+            let params = Self.parseQuery(query)
+            let page = max(Int(params["page"] ?? "1") ?? 1, 1)
+            let pageSize = max(min(Int(params["page_size"] ?? "20") ?? 20, 100), 1)
+            let offset = (page - 1) * pageSize
+            let (total, funcs) = try await persistence.listFunctions(limit: pageSize, offset: offset)
+            let infos = funcs.map { FunctionInfo(function_id: $0.functionId, name: $0.name, description: $0.description, http_method: $0.httpMethod, http_path: $0.httpPath) }
+            let list = FunctionsListResponse(functions: infos, page: page, page_size: pageSize, total: total)
+            let data = try JSONEncoder().encode(list)
+            return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+        case ("GET", ["functions", let fid]):
+            if let fn = try await persistence.getFunctionDetails(functionId: String(fid)) {
+                let info = FunctionInfo(function_id: fn.functionId, name: fn.name, description: fn.description, http_method: fn.httpMethod, http_path: fn.httpPath)
+                let data = try JSONEncoder().encode(info)
+                return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+            }
+            let err = ErrorResponse(error_code: "not_found", message: "function not found")
+            let data = try JSONEncoder().encode(err)
+            return HTTPResponse(status: 404, headers: ["Content-Type": "application/json"], body: data)
+        case ("POST", ["functions", let fid, "invoke"]):
+            guard let fn = try await persistence.getFunctionDetails(functionId: String(fid)) else {
+                let err = ErrorResponse(error_code: "not_found", message: "function not found")
+                let data = try JSONEncoder().encode(err)
+                return HTTPResponse(status: 404, headers: ["Content-Type": "application/json"], body: data)
+            }
+            var req = HTTPClientRequest(url: fn.httpPath)
+            req.method = .RAW(value: fn.httpMethod)
+            if !request.body.isEmpty {
+                req.body = .bytes(request.body)
+            }
+            do {
+                let resp = try await client.execute(req, timeout: .seconds(30))
+                var headers: [String: String] = [:]
+                for (name, value) in resp.headers { headers[name] = value }
+                var body = Data()
+                if var buf = resp.body {
+                    body = Data(buffer: buf)
+                }
+                return HTTPResponse(status: Int(resp.status.code), headers: headers, body: body)
+            } catch {
+                let err = ErrorResponse(error_code: "invoke_error", message: error.localizedDescription)
+                let data = try JSONEncoder().encode(err)
+                return HTTPResponse(status: 500, headers: ["Content-Type": "application/json"], body: data)
+            }
+        case ("GET", ["metrics"]):
+            let body = Data("function_caller_requests_total 0\n".utf8)
+            return HTTPResponse(status: 200, headers: ["Content-Type": "text/plain"], body: body)
+        default:
+            return HTTPResponse(status: 404)
+        }
+    }
+
+    static func parseQuery(_ q: String) -> [String: String] {
+        var dict: [String: String] = [:]
+        for pair in q.split(separator: "&") {
+            let kv = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+            if kv.count == 2 {
+                dict[String(kv[0])] = String(kv[1])
+            }
+        }
+        return dict
+    }
+}
+
+public func makeFunctionCallerKernel(service svc: TypesensePersistenceService) -> HTTPKernel {
+    let router = FunctionCallerRouter(persistence: svc)
+    return HTTPKernel { req in
+        let ar = HTTPRequest(method: req.method, path: req.path, headers: req.headers, body: req.body)
+        let resp = try await router.route(ar)
+        return FountainRuntime.HTTPResponse(status: resp.status, headers: resp.headers, body: resp.body)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/platform/FountainAILauncher/Sources/FountainAiLauncher/services.json
+++ b/platform/FountainAILauncher/Sources/FountainAiLauncher/services.json
@@ -1,72 +1,72 @@
 [
   {
-    "port" : 8001,
-    "shouldRestart" : true,
     "healthPath" : "\/metrics",
     "name" : "Baseline Awareness",
-    "binaryPath" : "\/usr\/local\/bin\/baseline-awareness"
+    "binaryPath" : "\/usr\/local\/bin\/baseline-awareness",
+    "port" : 8001,
+    "shouldRestart" : true
   },
   {
-    "port" : 8002,
-    "shouldRestart" : true,
     "healthPath" : "\/metrics",
     "name" : "Bootstrap",
-    "binaryPath" : "\/usr\/local\/bin\/bootstrap"
+    "binaryPath" : "\/usr\/local\/bin\/bootstrap",
+    "port" : 8002,
+    "shouldRestart" : true
   },
   {
-    "port" : 8003,
-    "shouldRestart" : true,
     "healthPath" : "\/metrics",
     "name" : "Planner",
-    "binaryPath" : "\/usr\/local\/bin\/planner"
+    "binaryPath" : "\/usr\/local\/bin\/planner",
+    "port" : 8003,
+    "shouldRestart" : true
   },
   {
-    "port" : 8004,
-    "shouldRestart" : true,
     "healthPath" : "\/metrics",
     "name" : "Function Caller",
-    "binaryPath" : "\/usr\/local\/bin\/function-caller"
+    "binaryPath" : "\/usr\/local\/bin\/function-caller",
+    "port" : 8004,
+    "shouldRestart" : true
   },
   {
-    "port" : 8005,
-    "shouldRestart" : true,
     "healthPath" : "\/metrics",
     "name" : "Persist",
-    "binaryPath" : "\/usr\/local\/bin\/persist"
+    "binaryPath" : "\/usr\/local\/bin\/persist",
+    "port" : 8005,
+    "shouldRestart" : true
   },
   {
-    "port" : 8006,
-    "shouldRestart" : true,
     "healthPath" : "\/metrics",
     "name" : "LLM Gateway",
-    "binaryPath" : "\/usr\/local\/bin\/llm-gateway"
+    "binaryPath" : "\/usr\/local\/bin\/llm-gateway",
+    "port" : 8006,
+    "shouldRestart" : true
   },
   {
-    "port" : 8007,
-    "shouldRestart" : true,
     "healthPath" : "\/metrics",
     "name" : "Semantic Browser",
-    "binaryPath" : "\/usr\/local\/bin\/semantic-browser"
+    "binaryPath" : "\/usr\/local\/bin\/semantic-browser",
+    "port" : 8007,
+    "shouldRestart" : true
   },
   {
+    "healthPath" : "\/metrics",
+    "name" : "Gateway",
     "binaryPath" : "\/usr\/local\/bin\/fountain-gateway",
     "port" : 8010,
-    "name" : "Gateway",
-    "healthPath" : "\/metrics",
     "shouldRestart" : true
   },
   {
+    "healthPath" : "\/metrics",
+    "name" : "Tools Factory",
     "binaryPath" : "\/usr\/local\/bin\/tools-factory",
     "port" : 8011,
-    "name" : "Tools Factory",
-    "healthPath" : "\/metrics",
     "shouldRestart" : true
   },
   {
+    "healthPath" : "\/metrics",
+    "name" : "Typesense",
     "binaryPath" : "\/usr\/local\/bin\/typesense",
     "port" : 8100,
-    "name" : "Typesense",
-    "healthPath" : "\/metrics",
     "shouldRestart" : true
   }
 ]


### PR DESCRIPTION
## Summary
- implement FunctionCallerService with routing for listing, fetching and invoking registered functions
- add FunctionCallerServer app and integrate into package manifest and service registry
- cover service with unit and OpenAPI conformance tests

## Testing
- `swift build`
- `FULL_TESTS=1 swift test -v --filter FunctionCallerServiceTests.testListDetailAndInvoke` *(fails: value of type 'String' has no member 'camelCased')*


------
https://chatgpt.com/codex/tasks/task_b_68b1318964b4833389d95e995e91d2e8