### PR TITLE
Add ToolsFactory service module and migrate server runtime

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,8 @@ let fullProducts: [Product] = [
     .library(name: "PlannerService", targets: ["PlannerService"]),
     .executable(name: "planner-server", targets: ["planner-server"]),
     .library(name: "FunctionCallerService", targets: ["FunctionCallerService"]),
-    .executable(name: "function-caller-server", targets: ["function-caller-server"])
+    .executable(name: "function-caller-server", targets: ["function-caller-server"]),
+    .library(name: "ToolsFactoryService", targets: ["ToolsFactoryService"])
 ]
 
 let leanProducts: [Product] = [
@@ -197,9 +198,14 @@ let fullTargets: [Target] = [
         exclude: ["Service", "Dockerfile"],
         resources: [.process("openapi.yaml")]
     ),
+    .target(
+        name: "ToolsFactoryService",
+        dependencies: ["FountainRuntime", "ToolServer", "TypesensePersistence"],
+        path: "libs/ToolsFactoryService"
+    ),
     .executableTarget(
         name: "tools-factory-server",
-        dependencies: ["ToolServer", "TypesensePersistence"],
+        dependencies: ["FountainRuntime", "ToolsFactoryService", "TypesensePersistence"],
         path: "apps/ToolsFactoryServer"
     ),
     .executableTarget(
@@ -243,7 +249,7 @@ let fullTargets: [Target] = [
     .testTarget(name: "FlexctlTests", dependencies: ["flexctl", "ResourceLoader"], path: "Tests/FlexctlTests"),
     .testTarget(name: "GatewayAppTests", dependencies: ["gateway-server", "LLMGatewayPlugin", "AuthGatewayPlugin", "DestructiveGuardianGatewayPlugin", "SecuritySentinelGatewayPlugin", "PayloadInspectionGatewayPlugin", "BudgetBreakerGatewayPlugin", "RateLimiterGatewayPlugin", "persist-server"], path: "Tests/GatewayAppTests"),
     .testTarget(name: "FountainOpsTests", dependencies: ["LLMGatewayPlugin"], path: "Tests/FountainOpsTests"),
-    .testTarget(name: "ToolServerTests", dependencies: ["ToolServer"], path: "Tests/ToolServerTests"),
+    .testTarget(name: "ToolsFactoryServiceTests", dependencies: ["ToolsFactoryService", "TypesensePersistence"], path: "Tests/ToolsFactoryServiceTests"),
     .testTarget(
         name: "ToolsmithPackageTests",
         dependencies: [

--- a/Tests/ToolsFactoryServiceTests/ManifestEndpointTests.swift
+++ b/Tests/ToolsFactoryServiceTests/ManifestEndpointTests.swift
@@ -1,10 +1,10 @@
 import XCTest
-@testable import ToolServer
+@testable import ToolsFactoryService
 
 final class ManifestEndpointTests: XCTestCase {
     func testManifestEndpoint() async throws {
         let manifest = ToolManifest(image: .init(name: "img", tarball: "t.tar", sha256: "a", qcow2: "q.qcow2", qcow2_sha256: "b"), tools: ["swift": "1"], operations: ["swiftc"])
-        let router = Router(adapters: [:], manifest: manifest)
+        let router = ToolsFactoryRouter(service: nil, adapters: [:], manifest: manifest)
         let resp = try await router.route(HTTPRequest(method: "GET", path: "/manifest"))
         XCTAssertEqual(resp.status, 200)
         let decoded = try JSONDecoder().decode(ToolManifest.self, from: resp.body)

--- a/Tests/ToolsFactoryServiceTests/PublishFunctionsTests.swift
+++ b/Tests/ToolsFactoryServiceTests/PublishFunctionsTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import ToolServer
+@testable import ToolsFactoryService
 @testable import TypesensePersistence
 
 final class PublishFunctionsTests: XCTestCase {

--- a/Tests/ToolsFactoryServiceTests/ToolsFactoryEndpointsTests.swift
+++ b/Tests/ToolsFactoryServiceTests/ToolsFactoryEndpointsTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import ToolServer
+@testable import ToolsFactoryService
 @testable import TypesensePersistence
 
 final class ToolsFactoryEndpointsTests: XCTestCase {
@@ -11,7 +11,7 @@ final class ToolsFactoryEndpointsTests: XCTestCase {
         )
         let svc = TypesensePersistenceService(client: MockTypesenseClient())
         await svc.ensureCollections()
-        let router = Router(adapters: [:], manifest: manifest, persistence: svc, defaultCorpusId: "tf")
+        let router = ToolsFactoryRouter(service: svc, adapters: [:], manifest: manifest, defaultCorpusId: "tf")
 
         // Register from an OpenAPI doc
         let openapi: [String: Any] = [

--- a/libs/ToolsFactoryService/ToolsFactoryService.swift
+++ b/libs/ToolsFactoryService/ToolsFactoryService.swift
@@ -1,0 +1,56 @@
+@_exported import ToolServer
+import Foundation
+import FountainRuntime
+import TypesensePersistence
+
+public struct HTTPRequest: Sendable {
+    public let method: String
+    public let path: String
+    public let headers: [String: String]
+    public let body: Data
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+}
+
+public struct HTTPResponse: Sendable {
+    public let status: Int
+    public let headers: [String: String]
+    public let body: Data
+    public init(status: Int, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}
+
+public final class ToolsFactoryRouter: @unchecked Sendable {
+    private let router: ToolServer.Router
+    public init(service: TypesensePersistenceService?, adapters: [String: ToolAdapter], manifest: ToolManifest, defaultCorpusId: String = ProcessInfo.processInfo.environment["TOOLS_FACTORY_CORPUS_ID"] ?? "tools-factory") {
+        self.router = ToolServer.Router(adapters: adapters, manifest: manifest, persistence: service, defaultCorpusId: defaultCorpusId)
+    }
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse {
+        if request.method == "GET" && request.path == "/openapi.yaml" {
+            let url = URL(fileURLWithPath: "openapi/v1/tools-factory.yml")
+            let data = try Data(contentsOf: url)
+            return HTTPResponse(status: 200, headers: ["Content-Type": "application/yaml"], body: data)
+        }
+        let ar = ToolServer.HTTPRequest(method: request.method, path: request.path, headers: request.headers, body: request.body)
+        let resp = try await router.route(ar)
+        return HTTPResponse(status: resp.status, headers: resp.headers, body: resp.body)
+    }
+}
+
+public func makeToolsFactoryKernel(service svc: TypesensePersistenceService?, adapters: [String: ToolAdapter], manifest: ToolManifest) -> HTTPKernel {
+    let router = ToolsFactoryRouter(service: svc, adapters: adapters, manifest: manifest)
+    return HTTPKernel { req in
+        let ar = HTTPRequest(method: req.method, path: req.path, headers: req.headers, body: req.body)
+        let resp = try await router.route(ar)
+        return FountainRuntime.HTTPResponse(status: resp.status, headers: resp.headers, body: resp.body)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- Wrap ToolServer with new ToolsFactoryService and expose `makeToolsFactoryKernel`
- Replace custom runtime with NIOHTTPServer in tools-factory-server app
- Move ToolServer tests to ToolsFactoryService and expose new OpenAPI spec route

## Testing
- `swift scripts/generate-service-registry.swift` (fails: services.json path missing)
- `FULL_TESTS=1 swift build --product tools-factory-server`
- `FULL_TESTS=1 swift test -v` *(terminated due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_b_68b138ad47408333853174293c6d90a3