### PR TITLE
Add FunctionCaller handlers and OpenAPI tests

### DIFF
--- a/Tests/FunctionCallerServiceTests/FunctionCallerOpenAPIConformanceTests.swift
+++ b/Tests/FunctionCallerServiceTests/FunctionCallerOpenAPIConformanceTests.swift
@@ -1,13 +1,38 @@
 import XCTest
-import Yams
+@testable import FunctionCallerService
+@testable import TypesensePersistence
 
 final class FunctionCallerOpenAPIConformanceTests: XCTestCase {
-    func testLoadSpec() throws {
-        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-        let url = root.appendingPathComponent("openapi/v1/function-caller.yml")
-        let text = try String(contentsOf: url)
-        let obj = try Yams.load(yaml: text)
-        XCTAssertNotNil(obj)
+    func testListFunctionsResponseShapeMatchesOpenAPI() async throws {
+        let svc = TypesensePersistenceService(client: MockTypesenseClient())
+        await svc.ensureCollections()
+        // Seed a function
+        _ = try await svc.addFunction(.init(corpusId: "c1", functionId: "f1", name: "F1", description: "d1", httpMethod: "GET", httpPath: "/f1"))
+        let router = FunctionCallerRouter(persistence: svc)
+        let resp = try await router.route(.init(method: "GET", path: "/functions?page=1&page_size=1"))
+        XCTAssertEqual(resp.status, 200)
+        let obj = try JSONSerialization.jsonObject(with: resp.body) as? [String: Any]
+        XCTAssertNotNil(obj?["functions"]) ; XCTAssertNotNil(obj?["page"]) ; XCTAssertNotNil(obj?["page_size"]) ; XCTAssertNotNil(obj?["total"])
+        XCTAssertTrue(obj?["page"] is Int)
+        XCTAssertTrue(obj?["page_size"] is Int)
+        XCTAssertTrue(obj?["total"] is Int)
+        guard let arr = obj?["functions"] as? [[String: Any]], let first = arr.first else {
+            return XCTFail("functions array missing")
+        }
+        XCTAssertTrue(first["function_id"] is String)
+        XCTAssertTrue(first["name"] is String)
+        XCTAssertTrue(first["description"] is String)
+        XCTAssertTrue(first["http_method"] is String)
+        XCTAssertTrue(first["http_path"] is String)
+    }
+
+    func testMetricsEndpointReturnsPlainText() async throws {
+        let svc = TypesensePersistenceService(client: MockTypesenseClient())
+        let router = FunctionCallerRouter(persistence: svc)
+        let resp = try await router.route(.init(method: "GET", path: "/metrics"))
+        XCTAssertEqual(resp.status, 200)
+        let text = String(data: resp.body, encoding: .utf8) ?? ""
+        XCTAssertTrue(text.contains("function_caller_requests_total"))
     }
 }
 


### PR DESCRIPTION
## Summary
- add explicit handlers for Function Caller service operations (`list_functions`, `get_function_details`, `invoke_function`, `metrics_metrics_get`)
- route requests through these handlers
- add OpenAPI conformance tests for listing functions and metrics endpoint

## Testing
- `swift test --filter FunctionCallerServiceTests.FunctionCallerServiceTests` *(failed: build timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68b165efb00c83338757c2eb825359fc