### PR TITLE
Add Planner service handlers and metrics test

### DIFF
--- a/Tests/PlannerServiceTests/PlannerServiceTests.swift
+++ b/Tests/PlannerServiceTests/PlannerServiceTests.swift
@@ -69,6 +69,15 @@ final class PlannerServiceTests: XCTestCase {
         let obj = try JSONSerialization.jsonObject(with: resp.body) as? [String: Any]
         XCTAssertEqual(obj?["total"] as? Int, 1)
     }
+
+    func testMetricsEndpoint() async throws {
+        let svc = TypesensePersistenceService(client: MockTypesenseClient())
+        let router = PlannerRouter(persistence: svc)
+        let resp = try await router.route(.init(method: "GET", path: "/metrics"))
+        XCTAssertEqual(resp.status, 200)
+        let text = String(data: resp.body, encoding: .utf8) ?? ""
+        XCTAssertTrue(text.contains("planner_requests_total"))
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- refactor PlannerService to expose handler functions for planner_reason, planner_execute, planner_list_corpora, get_reflection_history, get_semantic_arc, post_reflection, and metrics_metrics_get
- register routes to call these handlers
- extend PlannerService tests with metrics endpoint coverage

## Testing
- ⚠️ `swift test --filter PlannerServiceTests` *(build exceeded execution constraints; tests did not complete)*

------
https://chatgpt.com/codex/tasks/task_b_68b16f551a9c8333a936cccd7181e3fc