### PR TITLE
feat: expose metrics endpoint

### DIFF
--- a/Tests/ToolsFactoryServiceTests/ToolsFactoryEndpointsTests.swift
+++ b/Tests/ToolsFactoryServiceTests/ToolsFactoryEndpointsTests.swift
@@ -48,6 +48,19 @@ final class ToolsFactoryEndpointsTests: XCTestCase {
         let arr2 = obj2?["functions"] as? [Any]
         XCTAssertEqual(arr2?.count, 1)
     }
+
+    func testMetricsEndpoint() async throws {
+        let manifest = ToolManifest(
+            image: .init(name: "img", tarball: "t", sha256: "s", qcow2: "q", qcow2_sha256: "qs"),
+            tools: [:],
+            operations: []
+        )
+        let router = ToolsFactoryRouter(service: nil, adapters: [:], manifest: manifest)
+        let resp = try await router.route(.init(method: "GET", path: "/metrics", body: Data()))
+        XCTAssertEqual(resp.status, 200)
+        let text = String(data: resp.body, encoding: .utf8) ?? ""
+        XCTAssertTrue(text.contains("tools_factory_uptime_seconds"))
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add Prometheus `/metrics` handler to ToolsFactoryService
- test metrics endpoint

## Testing
- `swift build --target ToolsFactoryService`
- `FULL_TESTS=1 swift test --filter ToolsFactoryEndpointsTests/testMetricsEndpoint` *(fails: 'let' binding pattern cannot appear in an expression)*

------
https://chatgpt.com/codex/tasks/task_b_68b178e63c3c83339d2439943b65260f