### PR TITLE
feat: expand llm gateway handlers

### DIFF
--- a/libs/GatewayPlugins/LLMGatewayPlugin/LLMGatewayPlugin/Models.swift
+++ b/libs/GatewayPlugins/LLMGatewayPlugin/LLMGatewayPlugin/Models.swift
@@ -1,5 +1,73 @@
 import Foundation
 
+/// Chat message used in ``ChatRequest``.
+public struct MessageObject: Codable {
+    public let role: String
+    public let content: String
+    public init(role: String, content: String) {
+        self.role = role
+        self.content = content
+    }
+}
+
+/// Function description for ``ChatRequest``.
+public struct FunctionObject: Codable {
+    public let name: String
+    public let description: String?
+    public init(name: String, description: String? = nil) {
+        self.name = name
+        self.description = description
+    }
+}
+
+/// Explicit function call request.
+public struct FunctionCallObject: Codable {
+    public let name: String
+    public init(name: String) { self.name = name }
+}
+
+/// Function call option for ``ChatRequest``.
+public enum FunctionCall: Codable {
+    case auto
+    case named(FunctionCallObject)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(String.self), value == "auto" {
+            self = .auto
+        } else {
+            let obj = try container.decode(FunctionCallObject.self)
+            self = .named(obj)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .auto:
+            try container.encode("auto")
+        case .named(let obj):
+            try container.encode(obj)
+        }
+    }
+}
+
+/// Request body for the chat endpoint.
+public struct ChatRequest: Codable {
+    public let model: String
+    public let messages: [MessageObject]
+    public let functions: [FunctionObject]?
+    public let function_call: FunctionCall?
+    public let include_cot: Bool?
+    public init(model: String, messages: [MessageObject], functions: [FunctionObject]? = nil, function_call: FunctionCall? = nil, include_cot: Bool? = nil) {
+        self.model = model
+        self.messages = messages
+        self.functions = functions
+        self.function_call = function_call
+        self.include_cot = include_cot
+    }
+}
+
 /// Request sent to the sentinel consult endpoint.
 public struct SecurityCheckRequest: Codable {
     public let summary: String


### PR DESCRIPTION
## Summary
- implement chat, CoT fetch, and metrics handlers for LLM Gateway
- route new endpoints through gateway router
- add basic model structs and tests

## Testing
- `swift build -v` *(fails: output exceeded buffer, build attempted)*
- `swift test -v --filter LLMGatewayPluginTests` *(fails: output exceeded buffer)*

------
https://chatgpt.com/codex/tasks/task_b_68b17d59ccac83339ebe213eaeb2519b