### PR TITLE
Add OpenAPICurator package and basic curation pipeline

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -324,7 +324,12 @@ let fullTargets: [Target] = [
         name: "ToolServerTests",
         dependencies: ["ToolServerService", "Yams"],
         path: "Tests/ToolServerTests"
-    )
+    ),
+    .testTarget(
+        name: "OpenAPICuratorTests",
+        dependencies: [.product(name: "OpenAPICurator", package: "OpenAPICurator")],
+        path: "Tests/OpenAPICuratorTests"
+    ),
 ]
 
 let leanTargets: [Target] = [
@@ -458,7 +463,12 @@ let leanTargets: [Target] = [
         name: "ToolServerTests",
         dependencies: ["ToolServerService", "Yams"],
         path: "Tests/ToolServerTests"
-    )
+    ),
+    .testTarget(
+        name: "OpenAPICuratorTests",
+        dependencies: [.product(name: "OpenAPICurator", package: "OpenAPICurator")],
+        path: "Tests/OpenAPICuratorTests"
+    ),
 ]
 
 var targets: [Target] = LEAN ? leanTargets : fullTargets
@@ -486,6 +496,7 @@ let package = Package(
         .package(url: "https://github.com/Fountain-Coach/midi2.git", from: "0.3.1"),
         .package(url: "https://github.com/apple/swift-numerics.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.3.0"),
+        .package(path: "libs/OpenAPICurator"),
     ],
     targets: targets
 )

--- a/Tests/OpenAPICuratorTests/OpenAPICuratorTests.swift
+++ b/Tests/OpenAPICuratorTests/OpenAPICuratorTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import OpenAPICurator
+
+final class OpenAPICuratorTests: XCTestCase {
+    func testRuleApplicationRenamesOperations() {
+        let spec = Spec(operations: ["getUser"])
+        let rules = Rules(renames: ["getUser": "fetchUser"])
+        let result = curate(specs: [spec], rules: rules)
+        XCTAssertTrue(result.report.appliedRules.contains("getUser->fetchUser"))
+        XCTAssertEqual(result.spec.operations, ["fetchUser"])
+    }
+
+    func testCollisionResolverAddsSuffix() {
+        let spec1 = Spec(operations: ["op"])
+        let spec2 = Spec(operations: ["op"])
+        let result = curate(specs: [spec1, spec2], rules: Rules())
+        XCTAssertEqual(result.report.collisions, ["op"])
+        XCTAssertEqual(result.spec.operations, ["op", "op_1"])
+    }
+}

--- a/libs/OpenAPICurator/Package.swift
+++ b/libs/OpenAPICurator/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "OpenAPICurator",
+    products: [
+        .library(name: "OpenAPICurator", targets: ["OpenAPICurator"])
+    ],
+    targets: [
+        .target(name: "OpenAPICurator"),
+        .testTarget(name: "OpenAPICuratorTests", dependencies: ["OpenAPICurator"])
+    ]
+)

--- a/libs/OpenAPICurator/Sources/OpenAPICurator/CollisionResolver.swift
+++ b/libs/OpenAPICurator/Sources/OpenAPICurator/CollisionResolver.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum CollisionResolver {
+    static func resolve(_ api: OpenAPI) -> (OpenAPI, [String]) {
+        var seen: Set<String> = []
+        var collisions: [String] = []
+        var result: [String] = []
+        for name in api.operations {
+            var candidate = name
+            var counter = 1
+            while seen.contains(candidate) {
+                collisions.append(name)
+                candidate = "\(name)_\(counter)"
+                counter += 1
+            }
+            seen.insert(candidate)
+            result.append(candidate)
+        }
+        return (OpenAPI(operations: result), collisions)
+    }
+}

--- a/libs/OpenAPICurator/Sources/OpenAPICurator/Curator.swift
+++ b/libs/OpenAPICurator/Sources/OpenAPICurator/Curator.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+public struct Spec {
+    public let operations: [String]
+    public init(operations: [String]) {
+        self.operations = operations
+    }
+}
+
+public struct OpenAPI {
+    public var operations: [String]
+    public init(operations: [String]) {
+        self.operations = operations
+    }
+}
+
+public struct Rules {
+    public let renames: [String: String]
+    public init(renames: [String: String] = [:]) {
+        self.renames = renames
+    }
+}
+
+public struct CuratorReport {
+    public let appliedRules: [String]
+    public let collisions: [String]
+    public init(appliedRules: [String], collisions: [String]) {
+        self.appliedRules = appliedRules
+        self.collisions = collisions
+    }
+}
+
+public func curate(specs: [Spec], rules: Rules) -> (spec: OpenAPI, report: CuratorReport) {
+    let parsed = Parser.parse(specs)
+    let normalized = Resolver.normalize(parsed)
+    let (ruled, applied) = RulesEngine.apply(rules, to: normalized)
+    let (deduped, collisions) = CollisionResolver.resolve(ruled)
+    let report = ReportBuilder.build(appliedRules: applied, collisions: collisions)
+    return (deduped, report)
+}

--- a/libs/OpenAPICurator/Sources/OpenAPICurator/Parser.swift
+++ b/libs/OpenAPICurator/Sources/OpenAPICurator/Parser.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum Parser {
+    static func parse(_ specs: [Spec]) -> OpenAPI {
+        let ops = specs.flatMap { $0.operations }
+        return OpenAPI(operations: ops)
+    }
+}

--- a/libs/OpenAPICurator/Sources/OpenAPICurator/ReportBuilder.swift
+++ b/libs/OpenAPICurator/Sources/OpenAPICurator/ReportBuilder.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum ReportBuilder {
+    static func build(appliedRules: [String], collisions: [String]) -> CuratorReport {
+        CuratorReport(appliedRules: appliedRules, collisions: collisions)
+    }
+}

--- a/libs/OpenAPICurator/Sources/OpenAPICurator/Resolver.swift
+++ b/libs/OpenAPICurator/Sources/OpenAPICurator/Resolver.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+enum Resolver {
+    static func normalize(_ api: OpenAPI) -> OpenAPI {
+        let normalized = api.operations.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        return OpenAPI(operations: normalized)
+    }
+}

--- a/libs/OpenAPICurator/Sources/OpenAPICurator/RulesEngine.swift
+++ b/libs/OpenAPICurator/Sources/OpenAPICurator/RulesEngine.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum RulesEngine {
+    static func apply(_ rules: Rules, to api: OpenAPI) -> (OpenAPI, [String]) {
+        var operations = api.operations
+        var applied: [String] = []
+        for (index, op) in operations.enumerated() {
+            if let newName = rules.renames[op] {
+                operations[index] = newName
+                applied.append("\(op)->\(newName)")
+            }
+        }
+        return (OpenAPI(operations: operations), applied)
+    }
+}


### PR DESCRIPTION
## Summary
- add OpenAPICurator Swift package for spec parsing, rule application, collision resolution and reporting
- expose `curate` API that returns curated spec and report
- include tests for rule matching and collision handling

## Testing
- `swift test` *(fails: value of type 'Handlers' has no member 'chatCoT')*

------
https://chatgpt.com/codex/tasks/task_b_68b1b526206c8333849df6dc97740b8e