### PR TITLE
Add hot-reloadable curator rules configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,7 @@ OTEL_EXPORT_URL=
 QEMU_TEST_IMAGE=
 PORT=8080
 
+# OpenAPI Curator service
+CURATOR_RULES_PATH=Configuration/curator.yml
+CURATOR_STORAGE_PATH=/data/corpora/tools-factory/curator
+

--- a/Configuration/curator.yml
+++ b/Configuration/curator.yml
@@ -1,0 +1,37 @@
+# Sample rules for the OpenAPI Curator service
+# Adjust paths and IDs for your deployment.
+
+sources:
+  - id: baseline-awareness
+    allow_urls:
+      - file://openapi/v1/baseline-awareness.yml
+  - id: tools-factory
+    allow_urls:
+      - file://openapi/v1/tools-factory.yml
+
+global:
+  allow:
+    tags: [public, client]
+  deny:
+    tags: [admin, internal, experimental]
+    paths:
+      - ^/metrics$
+      - ^/debug
+    operationIds: [metrics_metrics_get]
+
+per_source:
+  baseline-awareness:
+    allow:
+      tags: [public]
+    deny:
+      paths: [^/awareness/internal]
+  tools-factory:
+    deny:
+      operationIds: [register_openapi]
+
+operationId:
+  strategy: namespace_if_conflict
+  namespace_format: "{sourceId}_{operationId}"
+
+renames:
+  getPetById: fetchPet

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ cp .env.example .env
 
 `scripts/boot.sh` and other utilities will automatically load variables from `.env`.
 
+### Required environment variables
+
+The OpenAPI Curator service uses the following variables:
+
+- `CURATOR_RULES_PATH` – path to the YAML rule file (default `Configuration/curator.yml`).
+- `CURATOR_STORAGE_PATH` – directory where curated outputs are stored.
+
 ---
 
 ## 🎹 Identity

--- a/apps/OpenAPICuratorService/CuratorRulesReloader.swift
+++ b/apps/OpenAPICuratorService/CuratorRulesReloader.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// Periodically checks the curator rules file and triggers reloads on change.
+final class CuratorRulesReloader: @unchecked Sendable {
+    private let store: CuratorRulesStore
+    private let url: URL
+    private var timer: DispatchSourceTimer?
+    private var lastMTime: Date?
+
+    init?(store: CuratorRulesStore, url: URL?) {
+        guard let url else { return nil }
+        self.store = store
+        self.url = url
+    }
+
+    func start(interval: TimeInterval = 2.0) {
+        let q = DispatchQueue(label: "curator.rules.reload.timer")
+        let t = DispatchSource.makeTimerSource(queue: q)
+        t.schedule(deadline: .now() + interval, repeating: interval)
+        t.setEventHandler { [weak self] in
+            guard let self else { return }
+            let attrs = try? FileManager.default.attributesOfItem(atPath: self.url.path)
+            let mtime = attrs?[.modificationDate] as? Date
+            if self.lastMTime == nil { self.lastMTime = mtime }
+            if let mtime, let last = self.lastMTime, mtime > last {
+                let store = self.store
+                Task.detached { _ = await store.reload() }
+                self.lastMTime = mtime
+            }
+        }
+        self.timer = t
+        t.resume()
+    }
+
+    func stop() {
+        timer?.cancel()
+        timer = nil
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/apps/OpenAPICuratorService/CuratorRulesStore.swift
+++ b/apps/OpenAPICuratorService/CuratorRulesStore.swift
@@ -1,0 +1,50 @@
+import Foundation
+import OpenAPICurator
+import Yams
+
+/// Actor-backed store for curator rules with optional config reloading.
+public actor CuratorRulesStore {
+    public private(set) var rules: Rules
+    private let configURL: URL?
+
+    public init(initialRules: Rules, configURL: URL?) {
+        self.rules = initialRules
+        self.configURL = configURL
+    }
+
+    public var configPath: URL? { configURL }
+
+    /// Reload rules from the configured URL if available.
+    /// Returns true when reload applied.
+    @discardableResult
+    public func reload() async -> Bool {
+        guard let url = configURL else { return false }
+        guard let contents = try? String(contentsOf: url) else { return false }
+        self.rules = parseRules(from: contents)
+        return true
+    }
+
+    /// Replace rules with a new YAML string and persist to disk.
+    @discardableResult
+    public func replace(with yaml: String) async -> Bool {
+        guard let url = configURL else { return false }
+        do {
+            try yaml.write(to: url, atomically: true, encoding: .utf8)
+            self.rules = parseRules(from: yaml)
+            return true
+        } catch {
+            return false
+        }
+    }
+}
+
+/// Parses curator rules from a YAML string.
+public func parseRules(from yaml: String) -> Rules {
+    if let obj = try? Yams.load(yaml: yaml) as? [String: Any] {
+        let renames = obj["renames"] as? [String: String] ?? [:]
+        return Rules(renames: renames)
+    }
+    return Rules()
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- sample `Configuration/curator.yml` with allow/deny rules and collision strategy
- hot-reload rules loader watching `CURATOR_RULES_PATH` and updating on `/rules` PUT
- document curator environment variables

## Testing
- `swift build --product openapi-curator-service` *(fails: no product named 'openapi-curator-service')*
- `swift build` *(partial build, interrupted)*


------
https://chatgpt.com/codex/tasks/task_b_68b276ba9a5c83338503d2ca3ec59ca9