### PR TITLE
feat: add curator yaml output, diff and tools factory submission

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -83,7 +83,7 @@ let fullTargets: [Target] = [
     ),
     .executableTarget(
         name: "openapi-curator-cli",
-        dependencies: ["OpenAPICurator"],
+        dependencies: ["OpenAPICurator", "Yams"],
         path: "apps/OpenAPICuratorCLI"
     ),
     .executableTarget(

--- a/apps/OpenAPICuratorCLI/main.swift
+++ b/apps/OpenAPICuratorCLI/main.swift
@@ -1,6 +1,7 @@
 import Foundation
 import FoundationNetworking
 import OpenAPICurator
+import Yams
 
 func loadDotEnv(path: String = ".env") {
     guard let data = try? String(contentsOfFile: path) else { return }
@@ -75,18 +76,60 @@ if specURL.isFileURL {
 let text = String(data: specData, encoding: .utf8) ?? ""
 let operations = extractOperationIds(from: text)
 let spec = Spec(operations: operations)
-let result = OpenAPICuratorKit.run(specs: [spec], submit: submit)
+let result = OpenAPICuratorKit.run(specs: [spec])
+let banned: Set<String> = ["metrics_metrics_get", "register_openapi", "list_tools"]
+let filteredOps = result.spec.operations.filter { !banned.contains($0) }
 
-let storageBase = ProcessInfo.processInfo.environment["CURATOR_STORAGE_PATH"] ?? "/data/corpora/\(corpusId)/curator"
+let storageRoot = ProcessInfo.processInfo.environment["CURATOR_STORAGE_PATH"] ?? "/data/corpora"
 let ts = ISO8601DateFormatter().string(from: Date())
-let outDir = URL(fileURLWithPath: storageBase).appendingPathComponent(ts)
+let corpusDir = URL(fileURLWithPath: storageRoot).appendingPathComponent(corpusId)
+let outDir = corpusDir.appendingPathComponent(ts)
 try? FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
-let specOut = outDir.appendingPathComponent("curated.json")
+let specOut = outDir.appendingPathComponent("curated.yaml")
 let reportOut = outDir.appendingPathComponent("report.json")
-if let specDataOut = try? JSONSerialization.data(withJSONObject: ["operations": result.spec.operations], options: [.prettyPrinted]) {
-    try? specDataOut.write(to: specOut)
+
+var diff: [String: [String]] = [:]
+let existing = (try? FileManager.default.contentsOfDirectory(atPath: corpusDir.path)) ?? []
+let previous = existing.filter { $0 < ts }.sorted().last
+if let prev = previous {
+    let prevFile = corpusDir.appendingPathComponent(prev).appendingPathComponent("curated.yaml")
+    if let prevText = try? String(contentsOf: prevFile),
+       let prevObj = try? Yams.load(yaml: prevText) as? [String: Any],
+       let prevOps = prevObj["operations"] as? [String] {
+        let prevSet = Set(prevOps)
+        let currSet = Set(filteredOps)
+        let added = Array(currSet.subtracting(prevSet)).sorted()
+        let removed = Array(prevSet.subtracting(currSet)).sorted()
+        if !added.isEmpty || !removed.isEmpty {
+            diff["added"] = added
+            diff["removed"] = removed
+        }
+    }
 }
-if let reportDataOut = try? JSONSerialization.data(withJSONObject: ["appliedRules": result.report.appliedRules, "collisions": result.report.collisions], options: [.prettyPrinted]) {
+
+if let yaml = try? Yams.dump(object: ["operations": filteredOps]) {
+    try? yaml.write(to: specOut, atomically: true, encoding: .utf8)
+    if submit,
+       let tfURL = ProcessInfo.processInfo.environment["TOOLS_FACTORY_URL"],
+       let token = ProcessInfo.processInfo.environment["TOOLS_FACTORY_TOKEN"],
+       let url = URL(string: "\(tfURL)/tools/register?corpusId=\(corpusId)") {
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.setValue("application/x-yaml", forHTTPHeaderField: "Content-Type")
+        req.httpBody = yaml.data(using: .utf8)
+        _ = try? URLSession.shared.data(for: req)
+    }
+}
+
+var reportObj: [String: Any] = [
+    "appliedRules": result.report.appliedRules,
+    "collisions": result.report.collisions
+]
+if !diff.isEmpty {
+    reportObj["diff"] = diff
+}
+if let reportDataOut = try? JSONSerialization.data(withJSONObject: reportObj, options: [.prettyPrinted]) {
     try? reportDataOut.write(to: reportOut)
 }
 


### PR DESCRIPTION
## Summary
- store curated specs as YAML with per-corpus timestamped directories
- compute diff against previous snapshot and include in report
- optionally submit curated YAML to Tools Factory with service token

## Testing
- `swift test` *(fails: type of expression is ambiguous without a type annotation)*

------
https://chatgpt.com/codex/tasks/task_b_68b27a24e01883339032733fa7e1554d