### PR TITLE
Support x‑fountain spec extensions and policy packs

### DIFF
--- a/Configuration/policies/dev.yml
+++ b/Configuration/policies/dev.yml
@@ -1,0 +1,1 @@
+# Policy pack for development environment

--- a/Configuration/policies/prod.yml
+++ b/Configuration/policies/prod.yml
@@ -1,0 +1,1 @@
+# Policy pack for production environment

--- a/Configuration/policies/stage.yml
+++ b/Configuration/policies/stage.yml
@@ -1,0 +1,1 @@
+# Policy pack for staging environment

--- a/libs/OpenAPICurator/Sources/OpenAPICurator/CollisionResolver.swift
+++ b/libs/OpenAPICurator/Sources/OpenAPICurator/CollisionResolver.swift
@@ -5,6 +5,7 @@ enum CollisionResolver {
         var seen: Set<String> = []
         var collisions: [String] = []
         var result: [String] = []
+        var exts = api.extensions
         for name in api.operations {
             var candidate = name
             var counter = 1
@@ -15,7 +16,10 @@ enum CollisionResolver {
             }
             seen.insert(candidate)
             result.append(candidate)
+            if candidate != name, let ext = exts.removeValue(forKey: name) {
+                exts[candidate] = ext
+            }
         }
-        return (OpenAPI(operations: result), collisions)
+        return (OpenAPI(operations: result, extensions: exts), collisions)
     }
 }

--- a/libs/OpenAPICurator/Sources/OpenAPICurator/Curator.swift
+++ b/libs/OpenAPICurator/Sources/OpenAPICurator/Curator.swift
@@ -2,15 +2,19 @@ import Foundation
 
 public struct Spec {
     public let operations: [String]
-    public init(operations: [String]) {
+    public let extensions: [String: [String: String]]
+    public init(operations: [String], extensions: [String: [String: String]] = [:]) {
         self.operations = operations
+        self.extensions = extensions
     }
 }
 
 public struct OpenAPI {
     public var operations: [String]
-    public init(operations: [String]) {
+    public var extensions: [String: [String: String]]
+    public init(operations: [String], extensions: [String: [String: String]] = [:]) {
         self.operations = operations
+        self.extensions = extensions
     }
 }
 

--- a/libs/OpenAPICurator/Sources/OpenAPICurator/Kit.swift
+++ b/libs/OpenAPICurator/Sources/OpenAPICurator/Kit.swift
@@ -1,13 +1,15 @@
 import Foundation
 
 public enum OpenAPICuratorKit {
-    public static var defaultSubmitter: (OpenAPI) -> Void = { _ in }
+    public static let defaultSubmitter: @Sendable (OpenAPI) -> Void = { _ in }
 
     public static func run(specs: [Spec],
                            rules: Rules = Rules(),
                            submit: Bool = false,
+                           reviewer: ((OpenAPI, CuratorReport) -> Void)? = nil,
                            submitter: ((OpenAPI) -> Void)? = nil) -> (spec: OpenAPI, report: CuratorReport) {
         let result = curate(specs: specs, rules: rules)
+        reviewer?(result.spec, result.report)
         if submit {
             let handler = submitter ?? defaultSubmitter
             handler(result.spec)

--- a/libs/OpenAPICurator/Sources/OpenAPICurator/Parser.swift
+++ b/libs/OpenAPICurator/Sources/OpenAPICurator/Parser.swift
@@ -3,6 +3,11 @@ import Foundation
 enum Parser {
     static func parse(_ specs: [Spec]) -> OpenAPI {
         let ops = specs.flatMap { $0.operations }
-        return OpenAPI(operations: ops)
+        let exts = specs.reduce(into: [String: [String: String]]()) { result, spec in
+            for (op, ext) in spec.extensions {
+                result[op, default: [:]].merge(ext) { current, _ in current }
+            }
+        }
+        return OpenAPI(operations: ops, extensions: exts)
     }
 }

--- a/libs/OpenAPICurator/Sources/OpenAPICurator/Resolver.swift
+++ b/libs/OpenAPICurator/Sources/OpenAPICurator/Resolver.swift
@@ -3,6 +3,6 @@ import Foundation
 enum Resolver {
     static func normalize(_ api: OpenAPI) -> OpenAPI {
         let normalized = api.operations.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-        return OpenAPI(operations: normalized)
+        return OpenAPI(operations: normalized, extensions: api.extensions)
     }
 }

--- a/libs/OpenAPICurator/Sources/OpenAPICurator/RulesEngine.swift
+++ b/libs/OpenAPICurator/Sources/OpenAPICurator/RulesEngine.swift
@@ -3,11 +3,18 @@ import Foundation
 enum RulesEngine {
     static func apply(_ rules: Rules, to api: OpenAPI) -> (OpenAPI, [String]) {
         var operations = api.operations
+        var exts = api.extensions
         var applied: [String] = []
         for (index, op) in operations.enumerated() {
             if let newName = rules.renames[op] {
                 operations[index] = newName
+                if let ext = exts.removeValue(forKey: op) { exts[newName] = ext }
                 applied.append("\(op)->\(newName)")
+            }
+            if let opExts = exts[operations[index]] {
+                for (key, value) in opExts where key.hasPrefix("x-fountain.") {
+                    applied.append("\(key)=\(value)")
+                }
             }
         }
         if !rules.allowlist.isEmpty {
@@ -20,6 +27,6 @@ enum RulesEngine {
             applied.append(contentsOf: removed.map { "deny:\($0)" })
             operations = operations.filter { !denied.contains($0) }
         }
-        return (OpenAPI(operations: operations), applied)
+        return (OpenAPI(operations: operations, extensions: exts), applied)
     }
 }


### PR DESCRIPTION
## Summary
- Track vendor extensions and expose `x-fountain.*` hints during rule application
- Allow optional diff reviewer hook from `OpenAPICuratorKit`
- Scaffold environment policy packs for dev, stage and prod

## Testing
- `swift build`
- `swift test` *(fails: Handlers has no member `chatCoT`)*

------
https://chatgpt.com/codex/tasks/task_b_68b28520f2ec83339d049ce3e65235d9