### PR TITLE
Document OpenAPI Curator and integrate into build pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ cp .env.example .env
 
 `scripts/boot.sh` and other utilities will automatically load variables from `.env`.
 
+The build pipeline relies on the [OpenAPI Curator](docs/openapi-curator.md) to produce curated service specs before registering tools with the Tools Factory.
+
 ### Required environment variables
 
 The OpenAPI Curator service uses the following variables:
@@ -60,19 +62,21 @@ Each endpoint replies to MIDI-CI **Process Inquiry** with `manufacturerId`, `fam
 ## 📁 Repository Structure
 
 - apps: Executable targets (CLIs and servers)
-  - GatewayServer: HTTP gateway runtime (target `gateway-server`).
-  - PublishingFrontendCLI: Publishing frontend CLI (target `publishing-frontend`).
-  - Flexctl: MIDI2 tooling CLI (target `flexctl`).
-  - ClientgenService: Client generator service (target `clientgen-service`).
-  - ToolsFactoryServer: Tool server runtime (target `tools-factory-server`).
+   - GatewayServer: HTTP gateway runtime (target `gateway-server`).
+   - PublishingFrontendCLI: Publishing frontend CLI (target `publishing-frontend`).
+   - Flexctl: MIDI2 tooling CLI (target `flexctl`).
+   - ClientgenService: Client generator service (target `clientgen-service`).
+   - ToolsFactoryServer: Tool server runtime (target `tools-factory-server`).
+   - OpenAPICuratorCLI: OpenAPI spec curation and promotion CLI.
+   - OpenAPICuratorService: Ephemeral service exposing the curation API.
 - libs: Reusable Swift libraries
-  - FountainCodex: Core code generation and utilities.
-  - PublishingFrontend: Publishing frontend library APIs.
-  - ResourceLoader: Shared resource loading utilities.
-  - MIDI2: MIDI2 components (MIDI2Models, MIDI2Core, MIDI2Transports, SSEOverMIDI, FlexBridge).
-  - ToolServer: Tool server library (adapters, router, resources).
+   - FountainCodex: Core code generation and utilities.
+   - PublishingFrontend: Publishing frontend library APIs.
+   - ResourceLoader: Shared resource loading utilities.
+- MIDI2: MIDI2 components (MIDI2Models, MIDI2Core, MIDI2Transports, SSEOverMIDI, FlexBridge).
+- ToolServer: Tool server library (adapters, router, resources).
 - internal: Generated code and internal modules (not user-edited)
-  - openapi: Service specs and API codegen.
+   - openapi: Service specs and API codegen.
 - docs: Documentation and design notes (gateway, SSE, security, proposals).
 - tests: SwiftPM test targets mirroring apps/libs components.
 

--- a/docs/openapi-curator.md
+++ b/docs/openapi-curator.md
@@ -1,0 +1,68 @@
+# OpenAPI Curator
+
+## Overview
+The OpenAPI Curator filters FountainAI service specifications into a conflict-free subset before the Tools Factory sees them. It runs as a CLI for build scripts or as an ephemeral review service, emitting curated specs and reports for each run.
+
+## API Examples
+The service exposes endpoints such as `/curate`:
+
+```http
+POST /curate
+Content-Type: application/json
+
+{
+  "corpusId": "tools-factory",
+  "specs": ["file://openapi/v1/baseline-awareness.yml"],
+  "submitToToolsFactory": false
+}
+```
+
+It returns a JSON object containing `curatedOpenAPI` and a `report` with removed or renamed operations.
+
+## CLI Usage
+Run the CLI locally or in CI:
+
+```bash
+swift run openapi-curator-cli --spec openapi/v1/tools-factory.yml --corpus tools-factory
+```
+
+Add `--submit` to register the curated spec with the Tools Factory.
+
+## Promotion Workflow
+1. Run curation in review mode to produce `curated.yaml` and `report.json`.
+2. Inspect the artifacts and diff against previous snapshots.
+3. Rerun with `submitToToolsFactory=true` or `--submit` to promote the curated spec.
+
+## Quickstart Examples
+### A) Minimal curation call (dry run)
+```json
+POST /curate
+{
+  "corpusId": "tools-factory",
+  "specs": [
+    "file://openapi/v1/baseline-awareness.yml",
+    "file://openapi/v1/persist.yml",
+    "file://openapi/v1/tools-factory.yml"
+  ],
+  "submitToToolsFactory": false
+}
+```
+**Outcome:** `curatedOpenAPI` without `/metrics`, without TF’s `register_openapi`/`list_tools`, and with collision-safe `operationId`s.
+
+### B) Promote curated spec to Tools Factory
+```json
+POST /curate
+{
+  "corpusId": "tools-factory",
+  "specs": ["file:///data/corpora/tools-factory/curator/20250829-1012/curated.yaml"],
+  "submitToToolsFactory": true
+}
+```
+
+## Acceptance Criteria
+* Given overlapping ecosystem specs, running `/curate`:
+  * **removes** denylisted/admin endpoints,
+  * **resolves** all `operationId` conflicts per configured strategy,
+  * **emits** a valid OpenAPI 3.1 document,
+  * optionally **submits** to Tools Factory,
+  * **persists** artifacts and **exposes** metrics.


### PR DESCRIPTION
## Summary
- add `docs/openapi-curator.md` with overview, API and CLI examples, quickstart, and acceptance criteria
- reference the curator in the build pipeline and repository structure in `README.md`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68b289eaa9848333aa9247952acbe1fa