### PR TITLE
Add ControlPlane HTTP server for FountainAiLauncher

### DIFF
--- a/platform/FountainAILauncher/Package.swift
+++ b/platform/FountainAILauncher/Package.swift
@@ -10,13 +10,16 @@ let package = Package(
         .executable(name: "FountainAiLauncher", targets: ["FountainAiLauncher"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.0.0")
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0")
     ],
     targets: [
         .executableTarget(
             name: "FountainAiLauncher",
             dependencies: [
-                .product(name: "Crypto", package: "swift-crypto")
+                .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio")
             ],
             path: "Sources",
             resources: [

--- a/platform/FountainAILauncher/Sources/ControlPlane/ControlPlane.swift
+++ b/platform/FountainAILauncher/Sources/ControlPlane/ControlPlane.swift
@@ -1,0 +1,99 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Simple HTTP control plane exposing supervisor management endpoints.
+public final class ControlPlane: @unchecked Sendable {
+    private let supervisor: Supervisor
+    private let services: [String: Service]
+    private var server: NIOHTTPServer?
+    private var port: Int = 0
+
+    /// Creates a new control plane managing the given services.
+    /// - Parameters:
+    ///   - supervisor: Supervisor responsible for service processes.
+    ///   - services: Known services keyed by name.
+    public init(supervisor: Supervisor, services: [Service]) {
+        self.supervisor = supervisor
+        self.services = Dictionary(uniqueKeysWithValues: services.map { ($0.name, $0) })
+    }
+
+    /// Starts the HTTP server on the provided port.
+    /// - Parameter port: Desired listening port. Use 0 for an ephemeral port.
+    /// - Returns: The actual port the server bound to.
+    @discardableResult
+    public func start(port: Int) async throws -> Int {
+        let kernel = makeKernel()
+        let server = NIOHTTPServer(kernel: kernel)
+        let actual = try await server.start(port: port)
+        self.server = server
+        self.port = actual
+        return actual
+    }
+
+    /// Stops the HTTP server if running.
+    public func stop() async throws {
+        try await server?.stop()
+    }
+
+    /// Returns the port the server is listening on.
+    public var listenPort: Int { port }
+
+    private func makeKernel() -> HTTPKernel {
+        HTTPKernel { [weak self] req in
+            guard let self else { return HTTPResponse(status: 500) }
+            switch (req.method, req.path) {
+            case ("GET", "/status"):
+                return try await self.statusHandler()
+            case ("POST", "/shutdown"):
+                Task.detached { [supervisor] in
+                    supervisor.terminateAll()
+                    exit(0)
+                }
+                return HTTPResponse(status: 200)
+            case ("POST", let path) where path.hasPrefix("/restart/"):
+                let name = String(path.dropFirst("/restart/".count))
+                guard let service = self.services[name] else {
+                    return HTTPResponse(status: 404)
+                }
+                self.supervisor.restart(service: service)
+                return HTTPResponse(status: 200)
+            default:
+                return HTTPResponse(status: 404)
+            }
+        }
+    }
+
+    private func statusHandler() async throws -> HTTPResponse {
+        var statuses: [ServiceStatus] = []
+        for (name, service) in services {
+            let running = supervisor.isRunning(serviceName: name)
+            var healthy = running
+            if running, let port = service.port, let path = service.healthPath {
+                let url = URL(string: "http://127.0.0.1:\(port)\(path)")!
+                do {
+                    let (_, response) = try await URLSession.shared.data(from: url)
+                    healthy = (response as? HTTPURLResponse)?.statusCode == 200
+                } catch {
+                    healthy = false
+                }
+            }
+            statuses.append(ServiceStatus(name: name, running: running, healthy: healthy))
+        }
+        let data = try JSONEncoder().encode(statuses)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+    }
+}
+
+/// Status information returned by the control plane.
+public struct ServiceStatus: Codable, Sendable {
+    /// Service name.
+    public let name: String
+    /// Whether the process is running.
+    public let running: Bool
+    /// Whether the last health probe succeeded.
+    public let healthy: Bool
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/platform/FountainAILauncher/Sources/ControlPlane/HTTPKernel.swift
+++ b/platform/FountainAILauncher/Sources/ControlPlane/HTTPKernel.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Minimal async HTTP router used by lightweight servers.
+public struct HTTPKernel: @unchecked Sendable {
+    /// Closure that transforms a ``HTTPRequest`` into an ``HTTPResponse``.
+    let router: (HTTPRequest) async throws -> HTTPResponse
+
+    /// Creates a new kernel with the given routing closure.
+    /// - Parameter route: Handler responsible for processing requests.
+    public init(route: @escaping (HTTPRequest) async throws -> HTTPResponse) {
+        self.router = route
+    }
+
+    /// Passes a request through the router and returns the response.
+    /// - Parameter request: Incoming request object.
+    /// - Throws: Rethrows any error produced by the routing closure.
+    public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
+        try await router(request)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/platform/FountainAILauncher/Sources/ControlPlane/HTTPRequest.swift
+++ b/platform/FountainAILauncher/Sources/ControlPlane/HTTPRequest.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Placeholder type representing an empty request body.
+public struct NoBody: Codable {}
+
+/// Represents an HTTP request flowing through ``HTTPKernel`` powered servers.
+/// Stores the HTTP method, path, headers and optional body data.
+public struct HTTPRequest: Sendable {
+    /// HTTP verb such as `GET` or `POST`.
+    public let method: String
+    /// Requested path without scheme or host.
+    public let path: String
+    /// HTTP headers associated with the request.
+    public var headers: [String: String]
+    /// Optional message body data.
+    public var body: Data
+
+    /// Creates a new request instance.
+    /// - Parameters:
+    ///   - method: HTTP verb such as `GET` or `POST`.
+    ///   - path: Requested resource path.
+    ///   - headers: HTTP headers to include.
+    ///   - body: Optional payload data.
+    public init(method: String, path: String, headers: [String: String] = [:], body: Data = Data()) {
+        self.method = method
+        self.path = path
+        self.headers = headers
+        self.body = body
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/platform/FountainAILauncher/Sources/ControlPlane/HTTPResponse.swift
+++ b/platform/FountainAILauncher/Sources/ControlPlane/HTTPResponse.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Standard HTTP response returned by ``HTTPKernel`` handlers.
+/// Provides mutable status, headers and response body.
+public struct HTTPResponse: Sendable {
+    /// HTTP status code sent back to the client.
+    public var status: Int
+    /// Headers included with the response.
+    public var headers: [String: String]
+    /// Raw payload returned as the message body.
+    public var body: Data
+
+    /// Creates a new response value.
+    /// - Parameters:
+    ///   - status: HTTP status code to return.
+    ///   - headers: Headers for the response.
+    ///   - body: Response body bytes.
+    public init(status: Int = 200, headers: [String: String] = [:], body: Data = Data()) {
+        self.status = status
+        self.headers = headers
+        self.body = body
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/platform/FountainAILauncher/Sources/ControlPlane/NIOHTTPServer.swift
+++ b/platform/FountainAILauncher/Sources/ControlPlane/NIOHTTPServer.swift
@@ -1,0 +1,137 @@
+@preconcurrency import NIO
+@preconcurrency import NIOHTTP1
+import Foundation
+
+/// Lightweight SwiftNIO based HTTP server used by FountainAI services.
+public final class NIOHTTPServer: @unchecked Sendable {
+    /// Router transforming requests into responses.
+    let kernel: HTTPKernel
+    /// Event loop group powering the NIO server.
+    let group: EventLoopGroup
+    /// Active server channel once bound to a port.
+    var channel: Channel?
+
+    /// Creates a new server wrapping the given kernel and event loop group.
+    /// - Parameters:
+    ///   - kernel: Router handling incoming requests.
+    ///   - group: Event loop group providing NIO threads. Defaults to a single-threaded group.
+    public init(kernel: HTTPKernel, group: EventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)) {
+        self.kernel = kernel
+        self.group = group
+    }
+
+    /// Starts the HTTP server.
+    /// - Parameter port: Port to bind the server on.
+    /// - Returns: The actual bound port.
+    @discardableResult
+    public func start(port: Int) async throws -> Int {
+        let bootstrap = ServerBootstrap(group: group)
+            .serverChannelOption(ChannelOptions.backlog, value: 256)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { channel in
+                channel.pipeline.configureHTTPServerPipeline().flatMap {
+                    channel.pipeline.addHandler(HTTPHandler(kernel: self.kernel))
+                }
+            }
+        self.channel = try await bootstrap.bind(host: "127.0.0.1", port: port).get()
+        return self.channel?.localAddress?.port ?? port
+    }
+
+    /// Stops the server and releases allocated resources.
+    public func stop() async throws {
+        try await channel?.close().get()
+        try await group.shutdownGracefully()
+    }
+
+    /// Internal NIO channel handler translating NIO events into ``HTTPRequest``s.
+    final class HTTPHandler: ChannelInboundHandler {
+        typealias InboundIn = HTTPServerRequestPart
+        typealias OutboundOut = HTTPServerResponsePart
+
+        /// Kernel responsible for routing incoming requests.
+        let kernel: HTTPKernel
+        /// Stored request head while waiting for the body.
+        var head: HTTPRequestHead?
+        /// Accumulated body bytes for the current request.
+        var body: ByteBuffer?
+
+        /// Creates a new handler bound to the provided ``HTTPKernel``.
+        /// - Parameter kernel: Kernel responsible for routing requests.
+        init(kernel: HTTPKernel) {
+            self.kernel = kernel
+        }
+
+        /// Handles inbound HTTP request parts and dispatches them through the ``HTTPKernel``.
+        func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+            switch unwrapInboundIn(data) {
+            case .head(let h):
+                head = h
+                body = context.channel.allocator.buffer(capacity: 0)
+            case .body(var part):
+                body?.writeBuffer(&part)
+            case .end:
+                guard let head else { return }
+                let req = HTTPRequest(
+                    method: head.method.rawValue,
+                    path: head.uri,
+                    headers: Dictionary(uniqueKeysWithValues: head.headers.map { ($0.name, $0.value) }),
+                    body: Data(body?.readableBytesView ?? [])
+                )
+                Task {
+                    let resp = try await self.kernel.handle(req)
+                    context.eventLoop.execute {
+                        var headers = HTTPHeaders()
+                        for (k, v) in resp.headers { headers.add(name: k, value: v) }
+                        let isSSE = (resp.headers["Content-Type"]?.lowercased().contains("text/event-stream") == true)
+                        let chunkedSSE = isSSE && (resp.headers["X-Chunked-SSE"] == "1")
+
+                        var responseHead = HTTPResponseHead(version: head.version, status: .init(statusCode: resp.status))
+                        if chunkedSSE {
+                            // Ensure chunked transfer for streaming writes
+                            headers.remove(name: "Content-Length")
+                            headers.replaceOrAdd(name: "Transfer-Encoding", value: "chunked")
+                        }
+                        responseHead.headers = headers
+                        context.write(self.wrapOutboundOut(.head(responseHead)), promise: nil)
+
+                        if chunkedSSE {
+                            // Split body into SSE event chunks on blank line boundaries and flush with small delays
+                            let text = String(data: resp.body, encoding: .utf8) ?? ""
+                            let parts = text.components(separatedBy: "\n\n").map { $0 + "\n\n" }.filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+                            self.writeSSEChunks(parts, on: context, index: 0)
+                        } else {
+                            let buffer = context.channel.allocator.buffer(bytes: resp.body)
+                            context.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+                            context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+                        }
+                    }
+                }
+                self.head = nil
+                self.body = nil
+            }
+        }
+
+        /// Writes SSE chunks progressively using the channel context.
+        private func writeSSEChunks(_ chunks: [String], on context: ChannelHandlerContext, index: Int) {
+            if index >= chunks.count {
+                context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+                return
+            }
+            let data = Data(chunks[index].utf8)
+            let buf = context.channel.allocator.buffer(bytes: data)
+            context.write(self.wrapOutboundOut(.body(.byteBuffer(buf))), promise: nil)
+            context.flush()
+            // Spread chunks slightly to emulate streaming and avoid coalescing
+            context.eventLoop.scheduleTask(in: .milliseconds(50)) { [weak self] in
+                guard let self else { return }
+                self.writeSSEChunks(chunks, on: context, index: index + 1)
+            }
+        }
+    }
+}
+
+extension NIOHTTPServer.HTTPHandler: @unchecked Sendable {}
+
+extension ChannelHandlerContext: @unchecked @retroactive Sendable {}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/platform/FountainAILauncher/Sources/Supervisor/Supervisor.swift
+++ b/platform/FountainAILauncher/Sources/Supervisor/Supervisor.swift
@@ -73,6 +73,13 @@ public final class Supervisor: @unchecked Sendable {
             terminate(serviceName: name)
         }
     }
+
+    /// Indicates whether the named service process is currently running.
+    /// - Parameter serviceName: Name of the service to inspect.
+    /// - Returns: `true` if the process is alive.
+    public func isRunning(serviceName: String) -> Bool {
+        processes[serviceName]?.isRunning == true
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/platform/FountainAILauncher/Sources/main.swift
+++ b/platform/FountainAILauncher/Sources/main.swift
@@ -18,6 +18,7 @@ if let url = Bundle.module.url(forResource: "services", withExtension: "json") {
 
 let supervisor = Supervisor()
 let monitor = HealthMonitor(supervisor: supervisor)
+let controlPlane = ControlPlane(supervisor: supervisor, services: services)
 
 do {
     try Diagnostics.run()
@@ -28,6 +29,9 @@ do {
     try supervisor.verify(services: services, manifestURL: manifestURL)
     try supervisor.start(services: services)
     monitor.startMonitoring(services: services)
+    Task {
+        try await controlPlane.start(port: 9090)
+    }
     dispatchMain()
 } catch {
     let message = "Failed to launch services: \(error)\n"

--- a/platform/FountainAILauncher/Tests/FountainAiLauncherTests/FountainAiLauncherTests.swift
+++ b/platform/FountainAILauncher/Tests/FountainAiLauncherTests/FountainAiLauncherTests.swift
@@ -1,4 +1,8 @@
 import XCTest
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 @testable import FountainAiLauncher
 
 final class FountainAiLauncherTests: XCTestCase {
@@ -69,6 +73,41 @@ final class FountainAiLauncherTests: XCTestCase {
         try JSONEncoder().encode(entries).write(to: url)
         let supervisor = Supervisor()
         XCTAssertThrowsError(try supervisor.verify(services: [service], manifestURL: url))
+    }
+
+    /// Control plane status endpoint lists running services.
+    func testControlPlaneStatus() async throws {
+        let supervisor = Supervisor()
+        let service = Service(name: "Sleep", binaryPath: "/bin/sleep", arguments: ["10"])
+        _ = try supervisor.start(service: service)
+        let cp = ControlPlane(supervisor: supervisor, services: [service])
+        let port = try await cp.start(port: 0)
+        defer {
+            supervisor.terminateAll()
+            Task { try? await cp.stop() }
+        }
+        let url = URL(string: "http://127.0.0.1:\(port)/status")!
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let statuses = try JSONDecoder().decode([ServiceStatus].self, from: data)
+        XCTAssertEqual(statuses.first?.name, service.name)
+        XCTAssertEqual(statuses.first?.running, true)
+    }
+
+    /// Restart endpoint returns 200 for known service.
+    func testControlPlaneRestart() async throws {
+        let supervisor = Supervisor()
+        let service = Service(name: "Sleep", binaryPath: "/bin/sleep", arguments: ["10"])
+        _ = try supervisor.start(service: service)
+        let cp = ControlPlane(supervisor: supervisor, services: [service])
+        let port = try await cp.start(port: 0)
+        defer {
+            supervisor.terminateAll()
+            Task { try? await cp.stop() }
+        }
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/restart/\(service.name)")!)
+        request.httpMethod = "POST"
+        let (_, response) = try await URLSession.shared.data(for: request)
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
     }
 }
 


### PR DESCRIPTION
## Summary
- Add lightweight NIO-based ControlPlane for runtime service management
- Expose `/status`, `/restart/{service}`, and `/shutdown` endpoints
- Boot ControlPlane alongside health monitor and cover endpoints with tests

## Testing
- `swift build -c debug`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68b3c2f2e440833394b8b98e36ca7bfa