### PR TITLE
Embed launcher signature and secure service startup

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -68,6 +68,10 @@ let fullTargets: [Target] = [
         exclude: ["DNS/README.md"]
     ),
     .target(
+        name: "LauncherSignature",
+        path: "libs/LauncherSignature"
+    ),
+    .target(
         name: "TypesensePersistence",
         dependencies: [
             .product(name: "Typesense", package: "typesense-swift"),
@@ -88,10 +92,10 @@ let fullTargets: [Target] = [
     ),
     .executableTarget(
         name: "openapi-curator-service",
-        dependencies: ["FountainRuntime", "OpenAPICurator", "Yams"],
+        dependencies: ["FountainRuntime", "OpenAPICurator", "Yams", "LauncherSignature"],
         path: "apps/OpenAPICuratorService"
     ),
-    .executableTarget(
+        .executableTarget(
         name: "gateway-server",
         dependencies: [
             "FountainRuntime",
@@ -104,8 +108,7 @@ let fullTargets: [Target] = [
             "DestructiveGuardianGatewayPlugin",
             "SecuritySentinelGatewayPlugin",
             "RoleHealthCheckGatewayPlugin",
-                        "RoleHealthCheckGatewayPlugin",
-            "RoleHealthCheckGatewayPlugin",
+            "LauncherSignature",
             .product(name: "Crypto", package: "swift-crypto"),
             .product(name: "X509", package: "swift-certificates"),
             "Yams"
@@ -232,32 +235,32 @@ let fullTargets: [Target] = [
     ),
     .executableTarget(
         name: "tools-factory-server",
-        dependencies: ["FountainRuntime", "ToolsFactoryService", "TypesensePersistence"],
+        dependencies: ["FountainRuntime", "ToolsFactoryService", "TypesensePersistence", "LauncherSignature"],
         path: "apps/ToolsFactoryServer"
     ),
     .executableTarget(
         name: "planner-server",
-        dependencies: ["FountainRuntime", "TypesensePersistence", "PlannerService", "Yams"],
+        dependencies: ["FountainRuntime", "TypesensePersistence", "PlannerService", "Yams", "LauncherSignature"],
         path: "apps/PlannerServer"
     ),
     .executableTarget(
         name: "function-caller-server",
-        dependencies: ["FountainRuntime", "TypesensePersistence", "FunctionCallerService", "Yams"],
+        dependencies: ["FountainRuntime", "TypesensePersistence", "FunctionCallerService", "Yams", "LauncherSignature"],
         path: "apps/FunctionCallerServer"
     ),
     .executableTarget(
         name: "persist-server",
-        dependencies: ["FountainRuntime", "TypesensePersistence", "Yams"],
+        dependencies: ["FountainRuntime", "TypesensePersistence", "Yams", "LauncherSignature"],
         path: "apps/PersistServer"
     ),
     .executableTarget(
         name: "baseline-awareness-server",
-        dependencies: ["TypesensePersistence", "AwarenessService"],
+        dependencies: ["TypesensePersistence", "AwarenessService", "LauncherSignature"],
         path: "apps/BaselineAwarenessServer"
     ),
     .executableTarget(
         name: "bootstrap-server",
-        dependencies: ["TypesensePersistence", "BootstrapService"],
+        dependencies: ["TypesensePersistence", "BootstrapService", "LauncherSignature"],
         path: "apps/BootstrapServer"
     ),
     .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainRuntime"], path: "Tests/ClientGeneratorTests"),
@@ -369,6 +372,10 @@ let leanTargets: [Target] = [
         exclude: ["DNS/README.md"]
     ),
     .target(
+        name: "LauncherSignature",
+        path: "libs/LauncherSignature"
+    ),
+    .target(
         name: "TypesensePersistence",
         dependencies: [
             .product(name: "Typesense", package: "typesense-swift"),
@@ -390,6 +397,7 @@ let leanTargets: [Target] = [
             "DestructiveGuardianGatewayPlugin",
             "SecuritySentinelGatewayPlugin",
             "RoleHealthCheckGatewayPlugin",
+            "LauncherSignature",
             .product(name: "Crypto", package: "swift-crypto"),
             .product(name: "X509", package: "swift-certificates"),
             "Yams"

--- a/apps/BaselineAwarenessServer/main.swift
+++ b/apps/BaselineAwarenessServer/main.swift
@@ -2,6 +2,9 @@ import Foundation
 import TypesensePersistence
 import AwarenessService
 import FountainRuntime
+import LauncherSignature
+
+verifyLauncherSignature()
 
 // Awareness server using the shared NIOHTTPServer for consistent HTTP handling
 do {

--- a/apps/BootstrapServer/main.swift
+++ b/apps/BootstrapServer/main.swift
@@ -2,6 +2,9 @@ import Foundation
 import TypesensePersistence
 import BootstrapService
 import FountainRuntime
+import LauncherSignature
+
+verifyLauncherSignature()
 
 // Bootstrap server using the shared NIOHTTPServer for consistent HTTP handling
 do {

--- a/apps/FunctionCallerServer/main.swift
+++ b/apps/FunctionCallerServer/main.swift
@@ -4,6 +4,9 @@ import FountainRuntime
 import Yams
 import TypesensePersistence
 import FunctionCallerService
+import LauncherSignature
+
+verifyLauncherSignature()
 
 struct FunctionCallerConfig: Codable {
     var typesenseURLs: [String]

--- a/apps/GatewayServer/GatewayApp/main.swift
+++ b/apps/GatewayServer/GatewayApp/main.swift
@@ -5,6 +5,9 @@ import FountainRuntime
 import LLMGatewayPlugin
 import AuthGatewayPlugin
 import RateLimiterGatewayPlugin
+import LauncherSignature
+
+verifyLauncherSignature()
 // Role guard plugin in this target
 // Loaded from config if present
 

--- a/apps/OpenAPICuratorService/main.swift
+++ b/apps/OpenAPICuratorService/main.swift
@@ -1,6 +1,9 @@
 import Foundation
 import Dispatch
 import FountainRuntime
+import LauncherSignature
+
+verifyLauncherSignature()
 
 let server = NIOHTTPServer(kernel: makeOpenAPICuratorKernel())
 Task {

--- a/apps/PersistServer/main.swift
+++ b/apps/PersistServer/main.swift
@@ -3,6 +3,9 @@ import Dispatch
 import FountainRuntime
 import Yams
 import TypesensePersistence
+import LauncherSignature
+
+verifyLauncherSignature()
 
 struct PersistConfig: Codable {
     var typesenseURLs: [String]

--- a/apps/PlannerServer/main.swift
+++ b/apps/PlannerServer/main.swift
@@ -4,6 +4,9 @@ import FountainRuntime
 import Yams
 import TypesensePersistence
 import PlannerService
+import LauncherSignature
+
+verifyLauncherSignature()
 
 struct PlannerConfig: Codable {
     var typesenseURLs: [String]

--- a/apps/SemanticBrowserServer/main.swift
+++ b/apps/SemanticBrowserServer/main.swift
@@ -1,5 +1,8 @@
 import Foundation
 import SemanticBrowser
+import LauncherSignature
+
+verifyLauncherSignature()
 
 func buildService() -> SemanticMemoryService {
     let env = ProcessInfo.processInfo.environment

--- a/apps/ToolsFactoryServer/main.swift
+++ b/apps/ToolsFactoryServer/main.swift
@@ -2,6 +2,9 @@ import Foundation
 import TypesensePersistence
 import ToolsFactoryService
 import FountainRuntime
+import LauncherSignature
+
+verifyLauncherSignature()
 
 let adapters: [String: ToolAdapter] = [
     "imagemagick": ImageMagickAdapter(),

--- a/libs/LauncherSignature/Signature.swift
+++ b/libs/LauncherSignature/Signature.swift
@@ -1,0 +1,1 @@
+public let embeddedLauncherSignature = "development"

--- a/libs/LauncherSignature/Verifier.swift
+++ b/libs/LauncherSignature/Verifier.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public func verifyLauncherSignature() {
+    let env = ProcessInfo.processInfo.environment
+    guard let runtimeSig = env["LAUNCHER_SIGNATURE"], runtimeSig == embeddedLauncherSignature else {
+        FileHandle.standardError.write(Data("Missing or invalid launcher signature\n".utf8))
+        exit(1)
+    }
+}

--- a/platform/FountainAILauncher/Sources/Builder/Builder.swift
+++ b/platform/FountainAILauncher/Sources/Builder/Builder.swift
@@ -12,7 +12,13 @@ enum BuilderError: Error, CustomStringConvertible {
 }
 
 struct Builder {
-    static func build(services: [Service]) throws {
+    static func build(services: [Service], signature: String) throws {
+        // Embed launcher signature into shared library so each service
+        // binary includes a compile-time token.
+        let sigURL = URL(fileURLWithPath: "libs/LauncherSignature/Signature.swift")
+        let sigContent = "public let embeddedLauncherSignature = \"\(signature)\"\n"
+        try sigContent.write(to: sigURL, atomically: true, encoding: .utf8)
+
         for service in services {
             let product = service.productName
             let process = Process()

--- a/platform/FountainAILauncher/Sources/Supervisor/Supervisor.swift
+++ b/platform/FountainAILauncher/Sources/Supervisor/Supervisor.swift
@@ -8,11 +8,21 @@ public final class Supervisor: @unchecked Sendable {
     private var serviceConfigs: [String: Service] = [:]
     /// Directory where logs will be written.
     private let logDirectory: URL
+    /// Environment variables propagated to child processes.
+    private let environment: [String: String]
+    /// Compile-time launcher signature each service must validate.
+    private let launcherSignature: String
 
     /// Creates a new supervisor writing logs to the given directory.
     /// - Parameter logDirectory: Directory where service logs are stored.
-    public init(logDirectory: URL = URL(fileURLWithPath: "logs", isDirectory: true)) {
+    public init(
+        logDirectory: URL = URL(fileURLWithPath: "logs", isDirectory: true),
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        launcherSignature: String
+    ) {
         self.logDirectory = logDirectory
+        self.environment = environment
+        self.launcherSignature = launcherSignature
         try? FileManager.default.createDirectory(at: logDirectory, withIntermediateDirectories: true)
     }
 
@@ -24,6 +34,9 @@ public final class Supervisor: @unchecked Sendable {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: service.binaryPath)
         process.arguments = service.arguments
+        var env = environment
+        env["LAUNCHER_SIGNATURE"] = launcherSignature
+        process.environment = env
 
         let sanitizedName = service.name.replacingOccurrences(of: " ", with: "_")
         let logURL = logDirectory.appendingPathComponent("\(sanitizedName).log")

--- a/platform/FountainAILauncher/Sources/main.swift
+++ b/platform/FountainAILauncher/Sources/main.swift
@@ -16,13 +16,14 @@ if let url = Bundle.module.url(forResource: "services", withExtension: "json") {
     exit(1)
 }
 
-let supervisor = Supervisor()
+let launcherSignature = UUID().uuidString
+let supervisor = Supervisor(launcherSignature: launcherSignature)
 let monitor = HealthMonitor(supervisor: supervisor)
 let controlPlane = ControlPlane(supervisor: supervisor, services: services)
 
 do {
     try Diagnostics.run()
-    try Builder.build(services: services)
+    try Builder.build(services: services, signature: launcherSignature)
     try Installer.install(services: services)
     let manifestURL = URL(fileURLWithPath: "service-manifest.json")
     try ManifestGenerator.generate(services: services, url: manifestURL)

--- a/platform/FountainAILauncher/Tests/FountainAiLauncherTests/FountainAiLauncherTests.swift
+++ b/platform/FountainAILauncher/Tests/FountainAiLauncherTests/FountainAiLauncherTests.swift
@@ -7,7 +7,7 @@ import FoundationNetworking
 
 final class FountainAiLauncherTests: XCTestCase {
     func testServiceLaunch() throws {
-        let supervisor = Supervisor()
+        let supervisor = Supervisor(launcherSignature: "test")
         let service = Service(name: "Echo", binaryPath: "/usr/bin/env", arguments: ["true"])
         let process = try supervisor.start(service: service)
         process.waitUntilExit()
@@ -15,7 +15,7 @@ final class FountainAiLauncherTests: XCTestCase {
     }
 
     func testTerminateAllStopsProcesses() throws {
-        let supervisor = Supervisor()
+        let supervisor = Supervisor(launcherSignature: "test")
         let service = Service(name: "Sleep", binaryPath: "/bin/sleep", arguments: ["5"])
         let process = try supervisor.start(service: service)
         XCTAssertTrue(process.isRunning)
@@ -59,7 +59,7 @@ final class FountainAiLauncherTests: XCTestCase {
         let service = Service(name: "Echo", binaryPath: "/bin/echo")
         let url = FileManager.default.temporaryDirectory.appendingPathComponent("manifest.json")
         try ManifestGenerator.generate(services: [service], url: url)
-        let supervisor = Supervisor()
+        let supervisor = Supervisor(launcherSignature: "test")
         XCTAssertNoThrow(try supervisor.verify(services: [service], manifestURL: url))
     }
 
@@ -71,13 +71,13 @@ final class FountainAiLauncherTests: XCTestCase {
         var entries = try JSONDecoder().decode([ServiceManifestEntry].self, from: Data(contentsOf: url))
         entries[0] = ServiceManifestEntry(name: entries[0].name, binaryPath: entries[0].binaryPath, sha256: "0", permissions: entries[0].permissions)
         try JSONEncoder().encode(entries).write(to: url)
-        let supervisor = Supervisor()
+        let supervisor = Supervisor(launcherSignature: "test")
         XCTAssertThrowsError(try supervisor.verify(services: [service], manifestURL: url))
     }
 
     /// Control plane status endpoint lists running services.
     func testControlPlaneStatus() async throws {
-        let supervisor = Supervisor()
+        let supervisor = Supervisor(launcherSignature: "test")
         let service = Service(name: "Sleep", binaryPath: "/bin/sleep", arguments: ["10"])
         _ = try supervisor.start(service: service)
         let cp = ControlPlane(supervisor: supervisor, services: [service])
@@ -95,7 +95,7 @@ final class FountainAiLauncherTests: XCTestCase {
 
     /// Restart endpoint returns 200 for known service.
     func testControlPlaneRestart() async throws {
-        let supervisor = Supervisor()
+        let supervisor = Supervisor(launcherSignature: "test")
         let service = Service(name: "Sleep", binaryPath: "/bin/sleep", arguments: ["10"])
         _ = try supervisor.start(service: service)
         let cp = ControlPlane(supervisor: supervisor, services: [service])


### PR DESCRIPTION
## Summary
- generate build-time launcher signature and embed into services
- validate signature in service startup, failing fast on mismatch
- supervise child processes with propagated env secrets

## Testing
- `swift build`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68b3c6c1b9888333bb9643e527b3a038