### PR TITLE
feat: integrate teatro dashboard

### DIFF
--- a/platform/FountainAILauncher/Package.swift
+++ b/platform/FountainAILauncher/Package.swift
@@ -11,7 +11,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-crypto.git", from: "3.0.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0")
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),
+        .package(url: "https://github.com/Fountain-Coach/Teatro.git", branch: "main")
     ],
     targets: [
         .executableTarget(
@@ -19,7 +20,9 @@ let package = Package(
             dependencies: [
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "NIO", package: "swift-nio"),
-                .product(name: "NIOHTTP1", package: "swift-nio")
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "Teatro", package: "teatro"),
+                .product(name: "TeatroRenderAPI", package: "teatro")
             ],
             path: "Sources",
             resources: [

--- a/platform/FountainAILauncher/Sources/ControlPlane/UI/DashboardModel.swift
+++ b/platform/FountainAILauncher/Sources/ControlPlane/UI/DashboardModel.swift
@@ -1,0 +1,52 @@
+#if canImport(SwiftUI) && canImport(Teatro) && canImport(TeatroRenderAPI)
+import SwiftUI
+import Teatro
+import TeatroRenderAPI
+
+/// Observable model powering the control plane dashboard.
+public final class ControlPlaneUIModel: ObservableObject {
+    /// Latest service statuses reported by the control plane.
+    @Published public var statuses: [ServiceStatus] = []
+    /// Accumulated log lines streamed from supervised services.
+    @Published public var logs: [String] = []
+    /// Optional Teatro SVG scene and timeline.
+    @Published public var svg: Data = Data()
+    @Published public var timeline: Data?
+
+    private let supervisor: Supervisor
+    private let services: [String: Service]
+
+    public init(supervisor: Supervisor, services: [Service]) {
+        self.supervisor = supervisor
+        self.services = Dictionary(uniqueKeysWithValues: services.map { ($0.name, $0) })
+    }
+
+    /// Update the dashboard with freshly polled service statuses.
+    @MainActor
+    public func update(statuses: [ServiceStatus]) {
+        self.statuses = statuses
+    }
+
+    /// Append a new log line to the dashboard's log view.
+    @MainActor
+    public func appendLog(_ line: String) {
+        logs.append(line)
+    }
+
+    /// Toggle execution state of the given service.
+    public func toggle(service name: String) {
+        if supervisor.isRunning(serviceName: name) {
+            supervisor.terminate(serviceName: name)
+        } else if let svc = services[name] {
+            try? supervisor.start(service: svc)
+        }
+    }
+
+    /// Restart the specified service using the supervisor.
+    public func restart(service name: String) {
+        if let svc = services[name] {
+            supervisor.restart(service: svc)
+        }
+    }
+}
+#endif

--- a/platform/FountainAILauncher/Sources/ControlPlane/UI/DashboardView.swift
+++ b/platform/FountainAILauncher/Sources/ControlPlane/UI/DashboardView.swift
@@ -1,0 +1,45 @@
+#if canImport(SwiftUI) && canImport(TeatroRenderAPI)
+import SwiftUI
+import TeatroRenderAPI
+
+/// SwiftUI view displaying supervisor state, logs and Teatro scene.
+public struct ControlPlaneDashboardView: View {
+    @ObservedObject var model: ControlPlaneUIModel
+
+    public init(model: ControlPlaneUIModel) {
+        self.model = model
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            List(model.statuses, id: \.name) { status in
+                HStack {
+                    Text(status.name)
+                    Spacer()
+                    Circle()
+                        .fill(status.healthy ? Color.green : Color.red)
+                        .frame(width: 8, height: 8)
+                    Button(status.running ? "Stop" : "Start") {
+                        model.toggle(service: status.name)
+                    }
+                    Button("Restart") {
+                        model.restart(service: status.name)
+                    }
+                }
+            }
+            if !model.svg.isEmpty {
+                TeatroPlayerView(svg: model.svg, timeline: model.timeline)
+                    .frame(height: 200)
+            }
+            ScrollView {
+                ForEach(model.logs, id: \.self) { line in
+                    Text(line)
+                        .font(.system(.footnote, design: .monospaced))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+        }
+        .padding()
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add Teatro dependency and link its products to FountainAILauncher
- introduce ControlPlane UI model and SwiftUI dashboard with TeatroPlayerView

## Testing
- `swift build --package-path platform/FountainAILauncher` *(fails: build interrupted due to time/environment)*

------
https://chatgpt.com/codex/tasks/task_b_68b3ca5399008333b6444954c678dad8