### PR TITLE
Fix OpenAPI spec path in ToolServerHandlers tests

### DIFF
--- a/Tests/ToolServerTests/ToolServerHandlersTests.swift
+++ b/Tests/ToolServerTests/ToolServerHandlersTests.swift
@@ -61,7 +61,10 @@ final class ToolServerHandlersTests: XCTestCase {
     }
 
     func testOpenAPISpecLoads() throws {
-        let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // ToolServerHandlersTests.swift
+            .deletingLastPathComponent() // ToolServerTests
+            .deletingLastPathComponent() // Tests
         let url = root.appendingPathComponent("openapi/v1/tool-server.yml")
         let text = try String(contentsOf: url)
         let obj = try Yams.load(yaml: text)


### PR DESCRIPTION
## Summary
- derive OpenAPI spec path from test file location to avoid missing file errors

## Testing
- `swift test --filter ToolServerHandlersTests/testOpenAPISpecLoads` *(failed: build process timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68b3cdab12788333afd0bbd2ba1cb022