### PR TITLE
Add basic tests for core libraries

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -341,6 +341,31 @@ let fullTargets: [Target] = [
         path: "Tests/ToolServerTests"
     ),
     .testTarget(
+        name: "FountainCodexTests",
+        dependencies: ["FountainCodex", .product(name: "NIOHTTP1", package: "swift-nio")],
+        path: "Tests/FountainCodexTests"
+    ),
+    .testTarget(
+        name: "FountainRuntimeTests",
+        dependencies: ["FountainRuntime", .product(name: "NIOHTTP1", package: "swift-nio")],
+        path: "Tests/FountainRuntimeTests"
+    ),
+    .testTarget(
+        name: "GatewayPluginsTests",
+        dependencies: ["RateLimiterGatewayPlugin", "FountainRuntime"],
+        path: "Tests/GatewayPluginsTests"
+    ),
+    .testTarget(
+        name: "LauncherSignatureTests",
+        dependencies: ["LauncherSignature"],
+        path: "Tests/LauncherSignatureTests"
+    ),
+    .testTarget(
+        name: "MIDI2Tests",
+        dependencies: ["MIDI2Models"],
+        path: "Tests/MIDI2Tests"
+    ),
+    .testTarget(
         name: "OpenAPICuratorTests",
         dependencies: [.product(name: "OpenAPICurator", package: "OpenAPICurator")],
         path: "Tests/OpenAPICuratorTests",
@@ -451,6 +476,12 @@ let leanTargets: [Target] = [
     ),
     .target(name: "ResourceLoader", path: "libs/ResourceLoader"),
     .target(
+        name: "MIDI2Models",
+        dependencies: ["ResourceLoader"],
+        path: "libs/MIDI2/MIDI2Models",
+        resources: [.process("MIDI2Models/Resources")]
+    ),
+    .target(
         name: "ToolServer",
         dependencies: [
             .product(name: "Crypto", package: "swift-crypto"),
@@ -476,6 +507,31 @@ let leanTargets: [Target] = [
         resources: [.process("Fixtures")]
     ),
     .testTarget(
+        name: "FountainCodexTests",
+        dependencies: ["FountainCodex", .product(name: "NIOHTTP1", package: "swift-nio")],
+        path: "Tests/FountainCodexTests"
+    ),
+    .testTarget(
+        name: "FountainRuntimeTests",
+        dependencies: ["FountainRuntime", .product(name: "NIOHTTP1", package: "swift-nio")],
+        path: "Tests/FountainRuntimeTests"
+    ),
+    .testTarget(
+        name: "GatewayPluginsTests",
+        dependencies: ["RateLimiterGatewayPlugin", "FountainRuntime"],
+        path: "Tests/GatewayPluginsTests"
+    ),
+    .testTarget(
+        name: "LauncherSignatureTests",
+        dependencies: ["LauncherSignature"],
+        path: "Tests/LauncherSignatureTests"
+    ),
+    .testTarget(
+        name: "MIDI2Tests",
+        dependencies: ["MIDI2Models"],
+        path: "Tests/MIDI2Tests"
+    ),
+    .testTarget(
         name: "ResourceLoaderTests",
         dependencies: ["ResourceLoader"],
         path: "Tests/ResourceLoaderTests"
@@ -498,6 +554,10 @@ var targets: [Target] = LEAN ? leanTargets : fullTargets
 #if os(Linux)
 products.append(.library(name: "PDFiumExtractor", targets: ["PDFiumExtractor"]))
 targets.append(.target(name: "PDFiumExtractor", dependencies: [], path: "libs/PDFiumExtractor"))
+#endif
+// After appending core targets, include Linux-specific tests.
+#if os(Linux)
+targets.append(.testTarget(name: "PDFiumExtractorTests", dependencies: ["PDFiumExtractor"], path: "Tests/PDFiumExtractorTests"))
 #endif
 
 let package = Package(

--- a/Tests/FountainCodexTests/FountainCodexTests.swift
+++ b/Tests/FountainCodexTests/FountainCodexTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+import FountainCodex
+import NIOHTTP1
+
+final class FountainCodexTests: XCTestCase {
+    func testHTTPRequestThroughCodex() {
+        let req = HTTPRequest(method: "GET", path: "/", headers: [:])
+        XCTAssertEqual(req.path, "/")
+    }
+
+    func testURLSessionClientError() async {
+        let client = URLSessionHTTPClient()
+        do {
+            _ = try await client.execute(method: .GET, url: "://bad", body: nil)
+            XCTFail("Expected to throw")
+        } catch {
+            // expected
+        }
+    }
+}

--- a/Tests/FountainRuntimeTests/FountainRuntimeTests.swift
+++ b/Tests/FountainRuntimeTests/FountainRuntimeTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+import Foundation
+import FountainRuntime
+import NIOHTTP1
+
+final class FountainRuntimeTests: XCTestCase {
+    func testHTTPRequestInitialization() {
+        let req = HTTPRequest(method: "GET", path: "/test", headers: ["A": "B"], body: Data("hi".utf8))
+        XCTAssertEqual(req.method, "GET")
+        XCTAssertEqual(req.path, "/test")
+        XCTAssertEqual(req.headers["A"], "B")
+    }
+
+    func testHTTPResponseDefault() {
+        let resp = HTTPResponse()
+        XCTAssertEqual(resp.status, 200)
+        XCTAssertTrue(resp.headers.isEmpty)
+    }
+
+    func testURLSessionHTTPClientBadURLThrows() async {
+        let client = URLSessionHTTPClient()
+        do {
+            _ = try await client.execute(method: .GET, url: "://bad", body: nil)
+            XCTFail("Expected to throw")
+        } catch {
+            // expected error
+        }
+    }
+}

--- a/Tests/GatewayPluginsTests/GatewayPluginsTests.swift
+++ b/Tests/GatewayPluginsTests/GatewayPluginsTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+import FountainRuntime
+import RateLimiterGatewayPlugin
+
+final class GatewayPluginsTests: XCTestCase {
+    func testInitialization() {
+        let plugin = RateLimiterGatewayPlugin(defaultLimit: 1)
+        XCTAssertNotNil(plugin.router)
+    }
+
+    func testAllowRespectsLimit() async {
+        let plugin = RateLimiterGatewayPlugin(defaultLimit: 1)
+        let first = await plugin.allow(routeId: "route", clientId: "client", limitPerMinute: nil)
+        let second = await plugin.allow(routeId: "route", clientId: "client", limitPerMinute: nil)
+        XCTAssertTrue(first)
+        XCTAssertFalse(second)
+    }
+
+    func testRateLimitCheckRequiresBody() async throws {
+        let handlers = Handlers()
+        let request = HTTPRequest(method: "POST", path: "/rate-limit/check")
+        let response = try await handlers.rateLimitCheck(request, body: nil)
+        XCTAssertEqual(response.status, 400)
+    }
+}

--- a/Tests/LauncherSignatureTests/LauncherSignatureTests.swift
+++ b/Tests/LauncherSignatureTests/LauncherSignatureTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+import LauncherSignature
+
+final class LauncherSignatureTests: XCTestCase {
+    func testEmbeddedSignatureConstant() {
+        XCTAssertEqual(embeddedLauncherSignature, "development")
+    }
+
+    func testVerifyLauncherSignaturePassesWhenEnvMatches() {
+        setenv("LAUNCHER_SIGNATURE", embeddedLauncherSignature, 1)
+        verifyLauncherSignature()
+        XCTAssertEqual(ProcessInfo.processInfo.environment["LAUNCHER_SIGNATURE"], embeddedLauncherSignature)
+    }
+
+    func testMissingSignatureDetected() {
+        unsetenv("LAUNCHER_SIGNATURE")
+        XCTAssertNotEqual(ProcessInfo.processInfo.environment["LAUNCHER_SIGNATURE"], embeddedLauncherSignature)
+    }
+}

--- a/Tests/MIDI2Tests/MIDI2Tests.swift
+++ b/Tests/MIDI2Tests/MIDI2Tests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import MIDI2Models
+
+final class MIDI2Tests: XCTestCase {
+    func testModelIndexInitialization() {
+        let doc = MIDIModelIndex.Document(fileName: "file", id: "1", pages: [], sha256: "abc", size: 1)
+        let index = MIDIModelIndex(documents: [doc])
+        XCTAssertEqual(index.documents.count, 1)
+        XCTAssertEqual(index.documents.first?.id, "1")
+    }
+
+    func testLoadFromValidJSON() throws {
+        let json = "{\"documents\":[]}" 
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("index.json")
+        try json.write(to: url, atomically: true, encoding: .utf8)
+        let index = try MIDIModelIndex.load(from: url.path)
+        XCTAssertEqual(index.documents.count, 0)
+    }
+
+    func testLoadInvalidJSONThrows() {
+        let bad = "not json"
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("bad.json")
+        try? bad.write(to: url, atomically: true, encoding: .utf8)
+        XCTAssertThrowsError(try MIDIModelIndex.load(from: url.path))
+    }
+}

--- a/Tests/PDFiumExtractorTests/PDFiumExtractorTests.swift
+++ b/Tests/PDFiumExtractorTests/PDFiumExtractorTests.swift
@@ -1,0 +1,23 @@
+#if os(Linux)
+import XCTest
+import PDFiumExtractor
+import Foundation
+
+final class PDFiumExtractorTests: XCTestCase {
+    func testInitialization() {
+        _ = PDFiumExtractor()
+    }
+
+    func testRectInit() {
+        let rect = Rect(x: 1, y: 2, width: 3, height: 4)
+        XCTAssertEqual(rect.height, 4)
+    }
+
+    func testExtractionUnsupportedPlatformThrows() {
+        let extractor = PDFiumExtractor()
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("dummy.pdf")
+        try? Data().write(to: url)
+        XCTAssertThrowsError(try extractor.extractText(from: url))
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add XCTest suites for FountainCodex, FountainRuntime, GatewayPlugins, LauncherSignature, MIDI2, and PDFiumExtractor
- register the new suites in Package.swift so `swift test` discovers them
- exercise basic initialization, behavior, and error paths for each library

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68b3da7c9d2c833392f3b3b4619d7e2e