### PR TITLE
Add integration test scaffolds for app targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -263,6 +263,66 @@ let fullTargets: [Target] = [
         dependencies: ["TypesensePersistence", "BootstrapService", "LauncherSignature"],
         path: "apps/BootstrapServer"
     ),
+    .testTarget(
+        name: "SSEClientIntegrationTests",
+        dependencies: ["sse-client"],
+        path: "Tests/SSEClientIntegrationTests"
+    ),
+    .testTarget(
+        name: "OpenAPICuratorCLIIntegrationTests",
+        dependencies: ["openapi-curator-cli"],
+        path: "Tests/OpenAPICuratorCLIIntegrationTests"
+    ),
+    .testTarget(
+        name: "OpenAPICuratorServiceIntegrationTests",
+        dependencies: ["openapi-curator-service"],
+        path: "Tests/OpenAPICuratorServiceIntegrationTests"
+    ),
+    .testTarget(
+        name: "GatewayServerIntegrationTests",
+        dependencies: ["gateway-server"],
+        path: "Tests/GatewayServerIntegrationTests"
+    ),
+    .testTarget(
+        name: "PublishingFrontendIntegrationTests",
+        dependencies: ["publishing-frontend"],
+        path: "Tests/PublishingFrontendIntegrationTests"
+    ),
+    .testTarget(
+        name: "FlexctlIntegrationTests",
+        dependencies: ["flexctl"],
+        path: "Tests/FlexctlIntegrationTests"
+    ),
+    .testTarget(
+        name: "ToolsFactoryServerIntegrationTests",
+        dependencies: ["tools-factory-server"],
+        path: "Tests/ToolsFactoryServerIntegrationTests"
+    ),
+    .testTarget(
+        name: "PlannerServerIntegrationTests",
+        dependencies: ["planner-server"],
+        path: "Tests/PlannerServerIntegrationTests"
+    ),
+    .testTarget(
+        name: "FunctionCallerServerIntegrationTests",
+        dependencies: ["function-caller-server"],
+        path: "Tests/FunctionCallerServerIntegrationTests"
+    ),
+    .testTarget(
+        name: "PersistServerIntegrationTests",
+        dependencies: ["persist-server"],
+        path: "Tests/PersistServerIntegrationTests"
+    ),
+    .testTarget(
+        name: "BaselineAwarenessServerIntegrationTests",
+        dependencies: ["baseline-awareness-server"],
+        path: "Tests/BaselineAwarenessServerIntegrationTests"
+    ),
+    .testTarget(
+        name: "BootstrapServerIntegrationTests",
+        dependencies: ["bootstrap-server"],
+        path: "Tests/BootstrapServerIntegrationTests"
+    ),
     .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainRuntime"], path: "Tests/ClientGeneratorTests"),
     .testTarget(name: "PublishingFrontendTests", dependencies: ["PublishingFrontend"], path: "Tests/PublishingFrontendTests"),
     .testTarget(name: "DNSTests", dependencies: ["PublishingFrontend", "FountainRuntime", .product(name: "Crypto", package: "swift-crypto"), .product(name: "NIOEmbedded", package: "swift-nio"), .product(name: "NIO", package: "swift-nio")], path: "Tests/DNSTests"),

--- a/Tests/BaselineAwarenessServerIntegrationTests/IntegrationTests.swift
+++ b/Tests/BaselineAwarenessServerIntegrationTests/IntegrationTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+import Foundation
+
+/// Prerequisites: built executable in .build/debug; no special environment variables.
+final class BaselineAwarenessServerIntegrationTests: XCTestCase {
+    func testRunsWithHelp() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: ".build/debug/baseline-awareness-server")
+        process.arguments = ["--help"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(decoding: data, as: UTF8.self)
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertFalse(output.isEmpty)
+    }
+}

--- a/Tests/BootstrapServerIntegrationTests/IntegrationTests.swift
+++ b/Tests/BootstrapServerIntegrationTests/IntegrationTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+import Foundation
+
+/// Prerequisites: built executable in .build/debug; no special environment variables.
+final class BootstrapServerIntegrationTests: XCTestCase {
+    func testRunsWithHelp() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: ".build/debug/bootstrap-server")
+        process.arguments = ["--help"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(decoding: data, as: UTF8.self)
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertFalse(output.isEmpty)
+    }
+}

--- a/Tests/FlexctlIntegrationTests/IntegrationTests.swift
+++ b/Tests/FlexctlIntegrationTests/IntegrationTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+import Foundation
+
+/// Prerequisites: built executable in .build/debug; no special environment variables.
+final class FlexctlIntegrationTests: XCTestCase {
+    func testRunsWithHelp() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: ".build/debug/flexctl")
+        process.arguments = ["--help"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(decoding: data, as: UTF8.self)
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertFalse(output.isEmpty)
+    }
+}

--- a/Tests/FunctionCallerServerIntegrationTests/IntegrationTests.swift
+++ b/Tests/FunctionCallerServerIntegrationTests/IntegrationTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+import Foundation
+
+/// Prerequisites: built executable in .build/debug; no special environment variables.
+final class FunctionCallerServerIntegrationTests: XCTestCase {
+    func testRunsWithHelp() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: ".build/debug/function-caller-server")
+        process.arguments = ["--help"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(decoding: data, as: UTF8.self)
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertFalse(output.isEmpty)
+    }
+}

--- a/Tests/GatewayServerIntegrationTests/IntegrationTests.swift
+++ b/Tests/GatewayServerIntegrationTests/IntegrationTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+import Foundation
+
+/// Prerequisites: built executable in .build/debug; no special environment variables.
+final class GatewayServerIntegrationTests: XCTestCase {
+    func testRunsWithHelp() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: ".build/debug/gateway-server")
+        process.arguments = ["--help"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(decoding: data, as: UTF8.self)
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertFalse(output.isEmpty)
+    }
+}

--- a/Tests/OpenAPICuratorCLIIntegrationTests/IntegrationTests.swift
+++ b/Tests/OpenAPICuratorCLIIntegrationTests/IntegrationTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+import Foundation
+
+/// Prerequisites: built executable in .build/debug; no special environment variables.
+final class OpenAPICuratorCLIIntegrationTests: XCTestCase {
+    func testRunsWithHelp() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: ".build/debug/openapi-curator-cli")
+        process.arguments = ["--help"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(decoding: data, as: UTF8.self)
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertFalse(output.isEmpty)
+    }
+}

--- a/Tests/OpenAPICuratorServiceIntegrationTests/IntegrationTests.swift
+++ b/Tests/OpenAPICuratorServiceIntegrationTests/IntegrationTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+import Foundation
+
+/// Prerequisites: built executable in .build/debug; no special environment variables.
+final class OpenAPICuratorServiceIntegrationTests: XCTestCase {
+    func testRunsWithHelp() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: ".build/debug/openapi-curator-service")
+        process.arguments = ["--help"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(decoding: data, as: UTF8.self)
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertFalse(output.isEmpty)
+    }
+}

--- a/Tests/PersistServerIntegrationTests/IntegrationTests.swift
+++ b/Tests/PersistServerIntegrationTests/IntegrationTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+import Foundation
+
+/// Prerequisites: built executable in .build/debug; no special environment variables.
+final class PersistServerIntegrationTests: XCTestCase {
+    func testRunsWithHelp() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: ".build/debug/persist-server")
+        process.arguments = ["--help"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(decoding: data, as: UTF8.self)
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertFalse(output.isEmpty)
+    }
+}

--- a/Tests/PlannerServerIntegrationTests/IntegrationTests.swift
+++ b/Tests/PlannerServerIntegrationTests/IntegrationTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+import Foundation
+
+/// Prerequisites: built executable in .build/debug; no special environment variables.
+final class PlannerServerIntegrationTests: XCTestCase {
+    func testRunsWithHelp() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: ".build/debug/planner-server")
+        process.arguments = ["--help"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(decoding: data, as: UTF8.self)
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertFalse(output.isEmpty)
+    }
+}

--- a/Tests/PublishingFrontendIntegrationTests/IntegrationTests.swift
+++ b/Tests/PublishingFrontendIntegrationTests/IntegrationTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+import Foundation
+
+/// Prerequisites: built executable in .build/debug; no special environment variables.
+final class PublishingFrontendIntegrationTests: XCTestCase {
+    func testRunsWithHelp() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: ".build/debug/publishing-frontend")
+        process.arguments = ["--help"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(decoding: data, as: UTF8.self)
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertFalse(output.isEmpty)
+    }
+}

--- a/Tests/SSEClientIntegrationTests/IntegrationTests.swift
+++ b/Tests/SSEClientIntegrationTests/IntegrationTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+import Foundation
+
+/// Prerequisites: built executable in .build/debug; no special environment variables.
+final class SSEClientIntegrationTests: XCTestCase {
+    func testRunsWithHelp() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: ".build/debug/sse-client")
+        process.arguments = ["--help"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(decoding: data, as: UTF8.self)
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertFalse(output.isEmpty)
+    }
+}

--- a/Tests/ToolsFactoryServerIntegrationTests/IntegrationTests.swift
+++ b/Tests/ToolsFactoryServerIntegrationTests/IntegrationTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+import Foundation
+
+/// Prerequisites: built executable in .build/debug; no special environment variables.
+final class ToolsFactoryServerIntegrationTests: XCTestCase {
+    func testRunsWithHelp() throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: ".build/debug/tools-factory-server")
+        process.arguments = ["--help"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        process.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(decoding: data, as: UTF8.self)
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertFalse(output.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- add basic integration tests launching each app executable with `--help`
- register new integration test targets in `Package.swift`

## Testing
- `FULL_TESTS=1 swift test --filter GatewayServerIntegrationTests/testRunsWithHelp -v` *(failed: cancelled during dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_b_68b3dff7f3d883338115ac4958542034