### PR TITLE
test: cover launcher signature validation

### DIFF
--- a/Tests/LauncherSignatureTests/LauncherSignatureTests.swift
+++ b/Tests/LauncherSignatureTests/LauncherSignatureTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import LauncherSignature
+@testable import LauncherSignature
 
 final class LauncherSignatureTests: XCTestCase {
     func testEmbeddedSignatureConstant() {
@@ -9,11 +9,19 @@ final class LauncherSignatureTests: XCTestCase {
     func testVerifyLauncherSignaturePassesWhenEnvMatches() {
         setenv("LAUNCHER_SIGNATURE", embeddedLauncherSignature, 1)
         verifyLauncherSignature()
-        XCTAssertEqual(ProcessInfo.processInfo.environment["LAUNCHER_SIGNATURE"], embeddedLauncherSignature)
+        XCTAssertEqual(
+            ProcessInfo.processInfo.environment["LAUNCHER_SIGNATURE"],
+            embeddedLauncherSignature
+        )
     }
 
-    func testMissingSignatureDetected() {
+    func testMissingSignatureFailsValidation() {
         unsetenv("LAUNCHER_SIGNATURE")
-        XCTAssertNotEqual(ProcessInfo.processInfo.environment["LAUNCHER_SIGNATURE"], embeddedLauncherSignature)
+        XCTAssertFalse(isLauncherSignatureValid())
+    }
+
+    func testInvalidSignatureFailsValidation() {
+        setenv("LAUNCHER_SIGNATURE", "bogus", 1)
+        XCTAssertFalse(isLauncherSignatureValid())
     }
 }

--- a/libs/LauncherSignature/Verifier.swift
+++ b/libs/LauncherSignature/Verifier.swift
@@ -1,8 +1,16 @@
 import Foundation
 
+// Internal helper for validating the runtime signature without exiting. This
+// allows unit tests to exercise both the success and failure paths.
+func isLauncherSignatureValid(
+    environment: [String: String] = ProcessInfo.processInfo.environment
+) -> Bool {
+    guard let runtimeSig = environment["LAUNCHER_SIGNATURE"] else { return false }
+    return runtimeSig == embeddedLauncherSignature
+}
+
 public func verifyLauncherSignature() {
-    let env = ProcessInfo.processInfo.environment
-    guard let runtimeSig = env["LAUNCHER_SIGNATURE"], runtimeSig == embeddedLauncherSignature else {
+    guard isLauncherSignatureValid() else {
         FileHandle.standardError.write(Data("Missing or invalid launcher signature\n".utf8))
         exit(1)
     }


### PR DESCRIPTION
## Summary
- add helper to validate launcher signature without exiting
- cover missing and invalid signature cases in LauncherSignature tests

## Testing
- `swift test --enable-code-coverage --filter LauncherSignatureTests`


------
https://chatgpt.com/codex/tasks/task_b_68b3eaceb1dc8333872a7ded27c272a1