### PR TITLE
Fix hanging URLSession error propagation test

### DIFF
--- a/Tests/IntegrationRuntimeTests/URLSessionHTTPClientTests.swift
+++ b/Tests/IntegrationRuntimeTests/URLSessionHTTPClientTests.swift
@@ -95,19 +95,28 @@ final class URLSessionHTTPClientTests: XCTestCase {
         XCTAssertEqual(headers.first(name: "X-B"), "b")
     }
 
-    func testExecutePropagatesSessionError() async {
+    @MainActor
+    func testExecutePropagatesSessionError() {
         let config = URLSessionConfiguration.ephemeral
         config.protocolClasses = [MockURLProtocol.self]
         let session = URLSession(configuration: config)
         struct TestError: Error {}
         MockURLProtocol.handler = { _ in throw TestError() }
         let client = URLSessionHTTPClient(session: session)
-        do {
-            _ = try await client.execute(method: .GET, url: "http://localhost", body: nil)
-            XCTFail("Expected to throw")
-        } catch let error as NSError {
-            XCTAssertEqual(error.domain, String(reflecting: TestError.self), "Unexpected error: \(error)")
+
+        let expectation = expectation(description: "wait for execute")
+        Task {
+            defer { expectation.fulfill() }
+            do {
+                _ = try await client.execute(method: .GET, url: "http://localhost", body: nil)
+                XCTFail("Expected to throw")
+            } catch is TestError {
+                // expected
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
         }
+        waitForExpectations(timeout: 1)
     }
 
     func testExecuteThrowsOnInvalidURL() async {


### PR DESCRIPTION
## Summary
- ensure `URLSessionHTTPClientTests.testExecutePropagatesSessionError` uses a stubbed `URLProtocol` and times out quickly

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `swift test --filter URLSessionHTTPClientTests/testExecutePropagatesSessionError`
- `Scripts/coverage.sh 90` *(fails: FountainRuntime coverage 69.23% < 90%)*

------
https://chatgpt.com/codex/tasks/task_b_68b3f0fcfa48833384c8cb74a0791328