### PR TITLE
Add DNSSECSigner public key verification test

### DIFF
--- a/Tests/DNSTests/DNSSECSignerTests.swift
+++ b/Tests/DNSTests/DNSSECSignerTests.swift
@@ -27,6 +27,14 @@ final class DNSSECSignerTests: XCTestCase {
         let sig = try signer1.sign(zone: zone)
         XCTAssertFalse(signer2.verify(zone: zone, signature: sig))
     }
+
+    func testPublicKeyValidatesSignature() throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let signer = DNSSECSigner(privateKey: key)
+        let zone = "example.com: 1.2.3.4"
+        let sig = try signer.sign(zone: zone)
+        XCTAssertTrue(signer.publicKey.isValidSignature(sig, for: Data(zone.utf8)))
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/to-do TESTing.md
+++ b/to-do TESTing.md
@@ -9,8 +9,8 @@
 2. **DNSHandler**
    - Write NIO pipeline tests verifying that `channelRead` forwards responses and `channelReadComplete` flushes writes
 
-3. **DNSSECSigner**
-   - Create tests for `sign(zone:)` and `verify(zone:signature:)` using generated key pairs to validate signing correctness
+3. ~~**DNSSECSigner**~~
+   - ~~Create tests for `sign(zone:)` and `verify(zone:signature:)` using generated key pairs to validate signing correctness~~
 
 4. **DNSServer**
    - Implement integration tests that start the server, send UDP/TCP queries, and verify responses, covering `start` and `stop` paths


### PR DESCRIPTION
## Summary
- cover DNSSECSigner signatures with public key verification
- strike completed DNSSECSigner item from testing to-do list

## Testing
- `swift test`
- `FULL_TESTS=1 swift test --filter DNSSECSignerTests` *(fails: no such module 'CryptoKit')*
- `FULL_TESTS=1 swift build --target DNSTests`


------
https://chatgpt.com/codex/tasks/task_b_68b48401f65883339b12db4d0e990d71