### PR TITLE
test: add DNSMetrics wait tests

### DIFF
--- a/Tests/DNSTests/DNSEngineTests.swift
+++ b/Tests/DNSTests/DNSEngineTests.swift
@@ -191,23 +191,6 @@ final class DNSEngineTests: XCTestCase {
         XCTAssertTrue(text.contains("gateway_rate_limit_throttled_total 1"))
     }
 
-    func testWaitForQueriesWithTimeout() async throws {
-        await DNSMetrics.shared.reset()
-        let producer = Task {
-            for _ in 0..<5 {
-                await DNSMetrics.shared.record(query: "example.com", type: "A", hit: true)
-                try? await Task.sleep(nanoseconds: 10_000_000)
-            }
-        }
-        let reached = await DNSMetrics.shared.wait(forQueries: 5, timeout: 1.0)
-        XCTAssertTrue(reached)
-        _ = await producer.value
-
-        await DNSMetrics.shared.reset()
-        let timedOut = await DNSMetrics.shared.wait(forQueries: 1, timeout: 0.1)
-        XCTAssertFalse(timedOut)
-    }
-
     func testResetZeroesMetrics() async throws {
         await DNSMetrics.shared.reset()
         await DNSMetrics.shared.record(query: "example.com", type: "A", hit: true)

--- a/Tests/DNSTests/DNSMetricsTests.swift
+++ b/Tests/DNSTests/DNSMetricsTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import FountainRuntime
+
+final class DNSMetricsTests: XCTestCase {
+    func testWaitResolvesAfterTargetQueries() async throws {
+        await DNSMetrics.shared.reset()
+        let producer = Task {
+            for _ in 0..<3 {
+                await DNSMetrics.shared.record(query: "example.com", type: "A", hit: true)
+                try? await Task.sleep(nanoseconds: 10_000_000)
+            }
+        }
+        let reached = await DNSMetrics.shared.wait(forQueries: 3, timeout: 1.0)
+        XCTAssertTrue(reached)
+        _ = await producer.value
+    }
+
+    func testWaitTimesOutWhenNotReached() async throws {
+        await DNSMetrics.shared.reset()
+        let timedOut = await DNSMetrics.shared.wait(forQueries: 1, timeout: 0.05)
+        XCTAssertFalse(timedOut)
+    }
+}

--- a/to-do TESTing.md
+++ b/to-do TESTing.md
@@ -15,8 +15,8 @@
 4. **DNSServer**
    - Implement integration tests that start the server, send UDP/TCP queries, and verify responses, covering `start` and `stop` paths
 
-5. **DNSMetrics**
-   - Add async tests for `wait(forQueries:timeout:)` ensuring it resolves after expected query counts or times out correctly
+5. ~~**DNSMetrics**~~
+   - ~~Add async tests for `wait(forQueries:timeout:)` ensuring it resolves after expected query counts or times out correctly~~
 
 6. **ZoneManager**
    - Write tests for `updateRecord`, `record`, and persistence with optional signer, including file reload behavior when the YAML source changes


### PR DESCRIPTION
## Summary
- add dedicated DNSMetrics tests covering `wait(forQueries:timeout:)`
- drop duplicated wait test from DNSEngine tests
- mark DNSMetrics item as completed in test to-do list

## Testing
- `swift test --filter DNSMetricsTests` *(no tests run: DNSTests excluded by default)*
- `FULL_TESTS=1 swift test --filter DNSMetricsTests` *(fails: async call in a function that does not support concurrency)*

------
https://chatgpt.com/codex/tasks/task_b_68b4844adf90833390b86072f7458802