### PR TITLE
Add tests for DestructiveGuardian unprotected paths

### DIFF
--- a/Tests/GatewayAppTests/DestructiveGuardianGatewayPluginTests.swift
+++ b/Tests/GatewayAppTests/DestructiveGuardianGatewayPluginTests.swift
@@ -22,7 +22,7 @@ final class DestructiveGuardianGatewayPluginTests: XCTestCase {
         let decision = try JSONDecoder().decode(GuardianEvaluateResponse.self, from: resp.body)
         XCTAssertEqual(decision.decision, "deny")
         let log = try String(contentsOf: logURL, encoding: .utf8)
-        XCTAssertTrue(log.contains("deny"))
+        XCTAssertTrue(log.contains("deny [missing]"))
         let before = await GatewayRequestMetrics.shared.snapshot()
         await GatewayRequestMetrics.shared.record(method: request.method, status: resp.status)
         let after = await GatewayRequestMetrics.shared.snapshot()
@@ -43,7 +43,7 @@ final class DestructiveGuardianGatewayPluginTests: XCTestCase {
         let decision = try JSONDecoder().decode(GuardianEvaluateResponse.self, from: resp.body)
         XCTAssertEqual(decision.decision, "allow")
         let log = try String(contentsOf: logURL, encoding: .utf8)
-        XCTAssertTrue(log.contains("allow"))
+        XCTAssertTrue(log.contains("allow [manual]"))
         let before = await GatewayRequestMetrics.shared.snapshot()
         await GatewayRequestMetrics.shared.record(method: request.method, status: resp.status)
         let after = await GatewayRequestMetrics.shared.snapshot()
@@ -64,7 +64,28 @@ final class DestructiveGuardianGatewayPluginTests: XCTestCase {
         let decision = try JSONDecoder().decode(GuardianEvaluateResponse.self, from: resp.body)
         XCTAssertEqual(decision.decision, "allow")
         let log = try String(contentsOf: logURL, encoding: .utf8)
-        XCTAssertTrue(log.contains("allow"))
+        XCTAssertTrue(log.contains("allow [token]"))
+        let before = await GatewayRequestMetrics.shared.snapshot()
+        await GatewayRequestMetrics.shared.record(method: request.method, status: resp.status)
+        let after = await GatewayRequestMetrics.shared.snapshot()
+        let key = "gateway_responses_status_200_total"
+        XCTAssertEqual((after[key] ?? 0) - (before[key] ?? 0), 1)
+    }
+
+    @MainActor
+    func testAllowsUnprotectedPath() async throws {
+        let logURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let plugin = makePlugin(logURL: logURL)
+        let eval = GuardianEvaluateRequest(method: "DELETE", path: "/public", manualApproval: false, serviceToken: nil)
+        let body = try JSONEncoder().encode(eval)
+        let request = HTTPRequest(method: "POST", path: "/guardian/evaluate", body: body)
+        guard let resp = try await plugin.router.route(request) else {
+            return XCTFail("no response")
+        }
+        let decision = try JSONDecoder().decode(GuardianEvaluateResponse.self, from: resp.body)
+        XCTAssertEqual(decision.decision, "allow")
+        let log = try String(contentsOf: logURL, encoding: .utf8)
+        XCTAssertTrue(log.contains("allow [unprotected]"))
         let before = await GatewayRequestMetrics.shared.snapshot()
         await GatewayRequestMetrics.shared.record(method: request.method, status: resp.status)
         let after = await GatewayRequestMetrics.shared.snapshot()


### PR DESCRIPTION
## Summary
- strengthen DestructiveGuardianGatewayPlugin tests to verify audit log reasons for deny, manual approval, and token overrides
- cover guardianEvaluate allowing unprotected paths and logging `[unprotected]`

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `Scripts/coverage.sh 90` *(fails: FountainRuntime line coverage 69.23% < 90%)*

------
https://chatgpt.com/codex/tasks/task_b_68b484870d048333acc07e0fa057754b