### PR TITLE
Add SecuritySentinel plugin edge-case tests

### DIFF
--- a/Tests/GatewayAppTests/SecuritySentinelGatewayPluginTests.swift
+++ b/Tests/GatewayAppTests/SecuritySentinelGatewayPluginTests.swift
@@ -36,6 +36,43 @@ final class SecuritySentinelGatewayPluginTests: XCTestCase {
         let key = "gateway_responses_status_200_total"
         XCTAssertEqual((after[key] ?? 0) - (before[key] ?? 0), 1)
     }
+
+    @MainActor
+    func testEscalateDecisionAndMetrics() async throws {
+        let plugin = SecuritySentinelGatewayPlugin()
+        let body = SecurityCheckRequest(summary: "please escalate", user: "u", resources: [])
+        let data = try JSONEncoder().encode(body)
+        let request = HTTPRequest(method: "POST", path: "/sentinel/consult", body: data)
+        let resp = try await plugin.router.route(request)
+        let decision = try JSONDecoder().decode(SecurityDecision.self, from: resp!.body)
+        XCTAssertEqual(decision.decision, "escalate")
+        let before = await GatewayRequestMetrics.shared.snapshot()
+        await GatewayRequestMetrics.shared.record(method: request.method, status: resp!.status)
+        let after = await GatewayRequestMetrics.shared.snapshot()
+        let key = "gateway_responses_status_200_total"
+        XCTAssertEqual((after[key] ?? 0) - (before[key] ?? 0), 1)
+    }
+
+    @MainActor
+    func testConsultMalformedBodyReturns400AndMetrics() async throws {
+        let plugin = SecuritySentinelGatewayPlugin()
+        let request = HTTPRequest(method: "POST", path: "/sentinel/consult", body: Data())
+        let resp = try await plugin.router.route(request)
+        XCTAssertEqual(resp?.status, 400)
+        let before = await GatewayRequestMetrics.shared.snapshot()
+        await GatewayRequestMetrics.shared.record(method: request.method, status: resp!.status)
+        let after = await GatewayRequestMetrics.shared.snapshot()
+        let key = "gateway_responses_status_400_total"
+        XCTAssertEqual((after[key] ?? 0) - (before[key] ?? 0), 1)
+    }
+
+    @MainActor
+    func testUnknownRouteReturnsNil() async throws {
+        let plugin = SecuritySentinelGatewayPlugin()
+        let request = HTTPRequest(method: "GET", path: "/unknown", body: Data())
+        let resp = try await plugin.router.route(request)
+        XCTAssertNil(resp)
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- expand SecuritySentinel plugin tests to cover escalate decisions, malformed consult bodies, and unknown routes

## Testing
- `swift build -c release -Xswiftc -O -Xswiftc -warnings-as-errors`
- `Scripts/coverage.sh 20` *(fails: BudgetBreakerGatewayPlugin coverage 0% < 20%)*

------
https://chatgpt.com/codex/tasks/task_b_68b48495b6948333b8cf5c2feedb9c55