### PR TITLE
feat: add consult models

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -528,7 +528,8 @@ let leanTargets: [Target] = [
     .target(
         name: "SecuritySentinelGatewayPlugin",
         dependencies: ["FountainRuntime"],
-        path: "libs/GatewayPlugins/SecuritySentinelGatewayPlugin"
+        path: "libs/GatewayPlugins/SecuritySentinelGatewayPlugin",
+        exclude: ["security-sentinel-gateway-llm-integration.md"]
     ),
     .target(
         name: "RoleHealthCheckGatewayPlugin",

--- a/Tests/GatewayAppTests/SecuritySentinelGatewayPluginTests.swift
+++ b/Tests/GatewayAppTests/SecuritySentinelGatewayPluginTests.swift
@@ -8,11 +8,11 @@ final class SecuritySentinelGatewayPluginTests: XCTestCase {
     @MainActor
     func testDenyDecisionAndMetrics() async throws {
         let plugin = SecuritySentinelGatewayPlugin()
-        let body = SecurityCheckRequest(summary: "delete files", user: "u", resources: [])
+        let body = ConsultRequest(summary: "delete files", context: "u")
         let data = try JSONEncoder().encode(body)
         let request = HTTPRequest(method: "POST", path: "/sentinel/consult", body: data)
         let resp = try await plugin.router.route(request)
-        let decision = try JSONDecoder().decode(SecurityDecision.self, from: resp!.body)
+        let decision = try JSONDecoder().decode(ConsultResponse.self, from: resp!.body)
         XCTAssertEqual(decision.decision, "deny")
         let before = await GatewayRequestMetrics.shared.snapshot()
         await GatewayRequestMetrics.shared.record(method: request.method, status: resp!.status)
@@ -24,11 +24,11 @@ final class SecuritySentinelGatewayPluginTests: XCTestCase {
     @MainActor
     func testAllowDecisionAndMetrics() async throws {
         let plugin = SecuritySentinelGatewayPlugin()
-        let body = SecurityCheckRequest(summary: "safe", user: "u", resources: [])
+        let body = ConsultRequest(summary: "safe", context: "u")
         let data = try JSONEncoder().encode(body)
         let request = HTTPRequest(method: "POST", path: "/sentinel/consult", body: data)
         let resp = try await plugin.router.route(request)
-        let decision = try JSONDecoder().decode(SecurityDecision.self, from: resp!.body)
+        let decision = try JSONDecoder().decode(ConsultResponse.self, from: resp!.body)
         XCTAssertEqual(decision.decision, "allow")
         let before = await GatewayRequestMetrics.shared.snapshot()
         await GatewayRequestMetrics.shared.record(method: request.method, status: resp!.status)
@@ -40,11 +40,11 @@ final class SecuritySentinelGatewayPluginTests: XCTestCase {
     @MainActor
     func testEscalateDecisionAndMetrics() async throws {
         let plugin = SecuritySentinelGatewayPlugin()
-        let body = SecurityCheckRequest(summary: "please escalate", user: "u", resources: [])
+        let body = ConsultRequest(summary: "please escalate", context: "u")
         let data = try JSONEncoder().encode(body)
         let request = HTTPRequest(method: "POST", path: "/sentinel/consult", body: data)
         let resp = try await plugin.router.route(request)
-        let decision = try JSONDecoder().decode(SecurityDecision.self, from: resp!.body)
+        let decision = try JSONDecoder().decode(ConsultResponse.self, from: resp!.body)
         XCTAssertEqual(decision.decision, "escalate")
         let before = await GatewayRequestMetrics.shared.snapshot()
         await GatewayRequestMetrics.shared.record(method: request.method, status: resp!.status)

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Handlers.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Handlers.swift
@@ -5,18 +5,32 @@ import FountainRuntime
 public actor Handlers {
     public init() {}
 
-    /// Consults the security sentinel and returns a decision.
-    public func sentinelConsult(_ request: HTTPRequest, body: SecurityCheckRequest) async throws -> HTTPResponse {
+    /// Consults the security sentinel and returns a detailed decision.
+    public func sentinelConsult(_ request: HTTPRequest, body: ConsultRequest) async throws -> HTTPResponse {
         let summary = body.summary.lowercased()
         let decision: String
+        let reason: String
         if summary.contains("escalate") {
             decision = "escalate"
+            reason = "escalation keyword found"
         } else if summary.contains("delete") || summary.contains("deny") || summary.contains("danger") {
             decision = "deny"
+            reason = "dangerous keyword found"
         } else {
             decision = "allow"
+            reason = "no dangerous keywords"
         }
-        let respBody = try JSONEncoder().encode(SecurityDecision(decision: decision))
+        let response = ConsultResponse(
+            decision: decision,
+            reason: reason,
+            confidence: 0.5,
+            model: "mock-model",
+            requestID: UUID().uuidString,
+            latencyMS: 1,
+            source: "mock",
+            timestamp: Date()
+        )
+        let respBody = try JSONEncoder().encode(response)
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: respBody)
     }
 }

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Models.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Models.swift
@@ -1,23 +1,47 @@
 import Foundation
 
-/// Request model sent to Security Sentinel for evaluation.
-public struct SecurityCheckRequest: Codable, Sendable {
+/// Request model for consulting the Security Sentinel.
+public struct ConsultRequest: Codable, Sendable {
+    /// Summary of the action the user intends to perform.
     public let summary: String
-    public let user: String
-    public let resources: [String]
-    public init(summary: String, user: String, resources: [String]) {
+    /// Additional context describing the request.
+    public let context: String
+
+    public init(summary: String, context: String) {
         self.summary = summary
-        self.user = user
-        self.resources = resources
+        self.context = context
     }
 }
 
-/// Response decision returned by Security Sentinel.
-public struct SecurityDecision: Codable, Sendable {
+/// Response returned from the Security Sentinel consult endpoint.
+public struct ConsultResponse: Codable, Sendable {
+    /// Final decision such as allow, deny, or escalate.
     public let decision: String
-    public init(decision: String) {
+    /// Human readable explanation for the decision.
+    public let reason: String
+    /// Model’s confidence score for the decision.
+    public let confidence: Double
+    /// Identifier of the model that produced the decision.
+    public let model: String
+    /// Identifier for tracking the consult request.
+    public let requestID: String
+    /// Latency in milliseconds for generating the response.
+    public let latencyMS: Int
+    /// Source system that produced the decision.
+    public let source: String
+    /// Timestamp when the decision was produced.
+    public let timestamp: Date
+
+    public init(decision: String, reason: String, confidence: Double, model: String, requestID: String, latencyMS: Int, source: String, timestamp: Date) {
         self.decision = decision
+        self.reason = reason
+        self.confidence = confidence
+        self.model = model
+        self.requestID = requestID
+        self.latencyMS = latencyMS
+        self.source = source
+        self.timestamp = timestamp
     }
 }
 
-// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+// © 2025 Contexter alias Benedikt Eickhoff 🖚️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Router.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Router.swift
@@ -9,7 +9,7 @@ public struct Router: Sendable {
     public func route(_ request: HTTPRequest) async throws -> HTTPResponse? {
         switch (request.method, request.path) {
         case ("POST", "/sentinel/consult"):
-            if let body = try? JSONDecoder().decode(SecurityCheckRequest.self, from: request.body) {
+            if let body = try? JSONDecoder().decode(ConsultRequest.self, from: request.body) {
                 return try await handlers.sentinelConsult(request, body: body)
             } else {
                 return HTTPResponse(status: 400)


### PR DESCRIPTION
## Summary
- add ConsultRequest/ConsultResponse models for sentinel gateway
- wire router and handlers to consult models
- adjust sentinel plugin tests and exclude docs from build

## Testing
- `swift build -c debug -Xswiftc -Onone -Xswiftc -enable-testing -Xswiftc -warnings-as-errors`
- `swift test --enable-xctest --parallel --filter SecuritySentinelGatewayPluginTests` *(no matching test cases)*

------
https://chatgpt.com/codex/tasks/task_b_68b531627a6083339f8047493345986a