### PR TITLE
feat(sentinel): add LLM client with retries and fail modes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -147,7 +147,7 @@ let fullTargets: [Target] = [
     ),
     .target(
         name: "SecuritySentinelGatewayPlugin",
-        dependencies: ["FountainRuntime"],
+        dependencies: ["FountainRuntime", .product(name: "AsyncHTTPClient", package: "async-http-client")],
         path: "libs/GatewayPlugins/SecuritySentinelGatewayPlugin",
     ),
     .target(
@@ -527,7 +527,7 @@ let leanTargets: [Target] = [
     ),
     .target(
         name: "SecuritySentinelGatewayPlugin",
-        dependencies: ["FountainRuntime"],
+        dependencies: ["FountainRuntime", .product(name: "AsyncHTTPClient", package: "async-http-client")],
         path: "libs/GatewayPlugins/SecuritySentinelGatewayPlugin",
         exclude: ["security-sentinel-gateway-llm-integration.md"]
     ),

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/CircuitBreaker.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/CircuitBreaker.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Minimal circuit breaker protecting the LLM sentinel.
+actor CircuitBreaker {
+    private let failureThreshold: Int
+    private let openInterval: TimeInterval
+    private var failures: Int = 0
+    private var openedAt: Date?
+
+    init(failureThreshold: Int = 3, openInterval: TimeInterval = 30) {
+        self.failureThreshold = failureThreshold
+        self.openInterval = openInterval
+    }
+
+    /// Returns `true` if requests are allowed.
+    func allow() -> Bool {
+        if let openedAt = openedAt {
+            if Date().timeIntervalSince(openedAt) > openInterval {
+                self.openedAt = nil
+                self.failures = 0
+                return true
+            } else {
+                return false
+            }
+        }
+        return true
+    }
+
+    /// Records a successful call, resetting internal state.
+    func recordSuccess() {
+        failures = 0
+        openedAt = nil
+    }
+
+    /// Records a failed call. Opens the breaker when the
+    /// failure threshold is reached.
+    func recordFailure() {
+        failures += 1
+        if failures >= failureThreshold {
+            openedAt = Date()
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/LLMSecuritySentinelClient.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/LLMSecuritySentinelClient.swift
@@ -1,0 +1,157 @@
+import Foundation
+import AsyncHTTPClient
+import NIOCore
+
+/// Failure mode behaviour when the LLM call fails.
+enum FailMode: String {
+    case allow, deny, fallback
+}
+
+/// Environment configuration for the LLM Security Sentinel client.
+enum SentinelEnv {
+    static let url = ProcessInfo.processInfo.environment["SEC_SENTINEL_URL"]
+    static let apiKey = ProcessInfo.processInfo.environment["SEC_SENTINEL_API_KEY"]
+    static let timeoutMS = Int(ProcessInfo.processInfo.environment["SEC_SENTINEL_TIMEOUT_MS"] ?? "4000") ?? 4000
+    static let retries = Int(ProcessInfo.processInfo.environment["SEC_SENTINEL_RETRIES"] ?? "1") ?? 1
+    static let model = ProcessInfo.processInfo.environment["SEC_SENTINEL_MODEL"]
+    static let failMode = ProcessInfo.processInfo.environment["SEC_SENTINEL_FAIL_MODE"] ?? "fallback"
+}
+
+/// Client that consults an external LLM backed Security Sentinel service.
+final class LLMSecuritySentinelClient: SecuritySentinelClient {
+    private let http: HTTPClient
+    private let url: URL
+    private let apiKey: String
+    private let timeoutMS: Int
+    private let retries: Int
+    private let model: String?
+    private let failMode: FailMode
+    private let breaker: CircuitBreaker
+    private let ownsHTTPClient: Bool
+
+    init(http: HTTPClient? = nil) {
+        guard let urlString = SentinelEnv.url, let url = URL(string: urlString), let apiKey = SentinelEnv.apiKey else {
+            fatalError("SEC_SENTINEL_URL and SEC_SENTINEL_API_KEY must be set")
+        }
+        if let http = http {
+            self.http = http
+            self.ownsHTTPClient = false
+        } else {
+            self.http = HTTPClient(eventLoopGroupProvider: .singleton)
+            self.ownsHTTPClient = true
+        }
+        self.url = url
+        self.apiKey = apiKey
+        self.timeoutMS = SentinelEnv.timeoutMS
+        self.retries = SentinelEnv.retries
+        self.model = SentinelEnv.model
+        self.failMode = FailMode(rawValue: SentinelEnv.failMode) ?? .fallback
+        self.breaker = CircuitBreaker()
+    }
+
+    deinit {
+        if ownsHTTPClient {
+            try? http.syncShutdown()
+        }
+    }
+
+    private struct Payload: Codable {
+        let summary: String
+        let context: [String: String]?
+        let model: String?
+    }
+
+    private struct LLMResponse: Codable {
+        let decision: String
+        let reason: String
+        let confidence: Double?
+        let model: String?
+        let requestID: String?
+    }
+
+    func consult(summary: String, context: [String: (any Codable & Sendable)]?) async throws -> SentinelDecision {
+        guard await breaker.allow() else {
+            return try await applyFailMode(reason: "circuit open", summary: summary, context: context)
+        }
+        let payload = Payload(summary: summary, context: nil, model: model)
+        let body = try JSONEncoder().encode(payload)
+        var request = HTTPClientRequest(url: url.absoluteString)
+        request.method = .POST
+        request.headers.add(name: "Content-Type", value: "application/json")
+        request.headers.add(name: "Authorization", value: "Bearer \(apiKey)")
+        request.body = .bytes(body)
+
+        var attempt = 0
+        let start = Date()
+        while true {
+            attempt += 1
+            do {
+                let response = try await http.execute(request, timeout: .milliseconds(Int64(timeoutMS)))
+                if response.status.code >= 500 {
+                    throw NSError(domain: "llm", code: Int(response.status.code))
+                }
+                guard response.status.code < 400 else {
+                    return try await applyFailMode(reason: "LLM \(response.status.code)", summary: summary, context: context)
+                }
+                let buffer = try await response.body.collect(upTo: 1_048_576)
+                let data = Data(buffer.readableBytesView)
+                let decoded = try JSONDecoder().decode(LLMResponse.self, from: data)
+                let latency = Int(Date().timeIntervalSince(start) * 1000)
+                let decision = SentinelDecision(
+                    decision: SentinelVerdict(rawValue: decoded.decision) ?? .deny,
+                    reason: decoded.reason,
+                    confidence: decoded.confidence,
+                    model: decoded.model,
+                    requestID: decoded.requestID ?? UUID().uuidString,
+                    latencyMS: latency,
+                    source: .llm,
+                    timestamp: ISO8601DateFormatter().string(from: Date())
+                )
+                await breaker.recordSuccess()
+                return decision
+            } catch {
+                if attempt <= retries {
+                    let backoff = UInt64(pow(2.0, Double(attempt - 1))) * 100_000_000
+                    try await Task.sleep(nanoseconds: backoff)
+                    continue
+                } else {
+                    await breaker.recordFailure()
+                    return try await applyFailMode(reason: "LLM unavailable", summary: summary, context: context)
+                }
+            }
+        }
+    }
+
+    private func applyFailMode(reason: String, summary: String, context: [String: (any Codable & Sendable)]?) async throws -> SentinelDecision {
+        let ts = ISO8601DateFormatter().string(from: Date())
+        switch failMode {
+        case .allow:
+            return SentinelDecision(
+                decision: .allow,
+                reason: reason,
+                confidence: nil,
+                model: nil,
+                requestID: UUID().uuidString,
+                latencyMS: 0,
+                source: .llm,
+                timestamp: ts
+            )
+        case .deny:
+            return SentinelDecision(
+                decision: .deny,
+                reason: reason,
+                confidence: nil,
+                model: nil,
+                requestID: UUID().uuidString,
+                latencyMS: 0,
+                source: .llm,
+                timestamp: ts
+            )
+        case .fallback:
+            let fallback = RuleBasedSecuritySentinelClient()
+            return try await fallback.consult(summary: summary, context: context)
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/RuleBasedSecuritySentinelClient.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/RuleBasedSecuritySentinelClient.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Simple keyword based sentinel client used as a fallback.
+final class RuleBasedSecuritySentinelClient: SecuritySentinelClient {
+    func consult(summary: String, context: [String: (any Codable & Sendable)]?) async throws -> SentinelDecision {
+        let text = summary.lowercased()
+        let verdict: SentinelVerdict
+        let reason: String
+        if text.contains("escalate") {
+            verdict = .escalate
+            reason = "escalation keyword found"
+        } else if text.contains("delete") || text.contains("deny") || text.contains("danger") {
+            verdict = .deny
+            reason = "dangerous keyword found"
+        } else {
+            verdict = .allow
+            reason = "no dangerous keywords"
+        }
+        let ts = ISO8601DateFormatter().string(from: Date())
+        return SentinelDecision(
+            decision: verdict,
+            reason: reason,
+            confidence: 0.5,
+            model: "rule-based",
+            requestID: UUID().uuidString,
+            latencyMS: 1,
+            source: .fallback_rules,
+            timestamp: ts
+        )
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/SecuritySentinelClient.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/SecuritySentinelClient.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Abstraction over clients capable of consulting the Security Sentinel service.
+public protocol SecuritySentinelClient: Sendable {
+    /// Consult the Security Sentinel with a summary and optional context.
+    /// - Parameters:
+    ///   - summary: Concise description of the proposed action.
+    ///   - context: Additional metadata describing the request.
+    /// - Returns: A structured decision from the sentinel.
+    func consult(summary: String, context: [String: (any Codable & Sendable)]?) async throws -> SentinelDecision
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/SentinelDecision.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/SentinelDecision.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Origin of a decision returned by the Security Sentinel.
+public enum SentinelSource: String, Codable, Sendable {
+    /// Decision produced by a large language model backed sentinel service.
+    case llm
+    /// Decision produced by local fallback rules.
+    case fallback_rules
+}
+
+/// High level verdict returned by the Security Sentinel.
+public enum SentinelVerdict: String, Codable, Sendable {
+    /// Operation is permitted.
+    case allow
+    /// Operation is rejected.
+    case deny
+    /// Operation requires escalation or manual approval.
+    case escalate
+}
+
+/// Normalised decision payload produced by the Security Sentinel service.
+public struct SentinelDecision: Codable, Sendable {
+    /// Final verdict such as allow, deny or escalate.
+    public let decision: SentinelVerdict
+    /// Human readable explanation of the verdict.
+    public let reason: String
+    /// Optional confidence score from the model.
+    public let confidence: Double?
+    /// Identifier of the model that produced the decision, if available.
+    public let model: String?
+    /// Identifier for tracking this consult request.
+    public let requestID: String
+    /// Latency in milliseconds for generating the response.
+    public let latencyMS: Int
+    /// Source system that produced the verdict.
+    public let source: SentinelSource
+    /// RFC3339 timestamp when the decision was produced.
+    public let timestamp: String
+
+    public init(
+        decision: SentinelVerdict,
+        reason: String,
+        confidence: Double?,
+        model: String?,
+        requestID: String,
+        latencyMS: Int,
+        source: SentinelSource,
+        timestamp: String
+    ) {
+        self.decision = decision
+        self.reason = reason
+        self.confidence = confidence
+        self.model = model
+        self.requestID = requestID
+        self.latencyMS = latencyMS
+        self.source = source
+        self.timestamp = timestamp
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- implement `LLMSecuritySentinelClient` backed by AsyncHTTPClient with env configuration
- add fallback rule-based client and circuit breaker
- expose sentinel decision types and protocol for clients

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68b537de915c8333924788f23f8513f9