### PR TITLE
Add Security Sentinel client factory with environment-based fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,12 @@ LLM_GATEWAY_URL=
 FUNCTION_CALLER_URL=
 TOOLSERVER_URL=http://localhost:8080
 
+# Security Sentinel configuration
+SEC_SENTINEL_ENABLED=true
+SEC_SENTINEL_URL=
+SEC_SENTINEL_API_KEY=
+SEC_SENTINEL_FAIL_MODE=fallback   # fallback | allow | deny
+
 # Paths and miscellaneous
 FUNCTIONS_CACHE_PATH=
 FOUNTAINAI_SERVICES_DIR=

--- a/Tests/GatewayAppTests/SentinelClientFactoryTests.swift
+++ b/Tests/GatewayAppTests/SentinelClientFactoryTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import SecuritySentinelGatewayPlugin
+
+final class SentinelClientFactoryTests: XCTestCase {
+    override func tearDown() {
+        unsetenv("SEC_SENTINEL_ENABLED")
+        unsetenv("SEC_SENTINEL_URL")
+        unsetenv("SEC_SENTINEL_API_KEY")
+        super.tearDown()
+    }
+
+    func testReturnsRuleBasedWhenDisabled() {
+        setenv("SEC_SENTINEL_ENABLED", "false", 1)
+        let client = SentinelClientFactory.make()
+        XCTAssertTrue(client is RuleBasedSecuritySentinelClient)
+    }
+
+    func testReturnsRuleBasedWhenMissingConfig() {
+        setenv("SEC_SENTINEL_ENABLED", "true", 1)
+        unsetenv("SEC_SENTINEL_URL")
+        unsetenv("SEC_SENTINEL_API_KEY")
+        let client = SentinelClientFactory.make()
+        XCTAssertTrue(client is RuleBasedSecuritySentinelClient)
+    }
+
+    func testReturnsLLMWhenEnabledAndConfigured() {
+        setenv("SEC_SENTINEL_ENABLED", "true", 1)
+        setenv("SEC_SENTINEL_URL", "http://localhost", 1)
+        setenv("SEC_SENTINEL_API_KEY", "test", 1)
+        let client = SentinelClientFactory.make()
+        XCTAssertTrue(client is LLMSecuritySentinelClient)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Handlers.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Handlers.swift
@@ -3,11 +3,14 @@ import FountainRuntime
 
 /// Actor housing Security Sentinel handlers.
 public actor Handlers {
-    public init() {}
+    private let client: SecuritySentinelClient
+
+    public init(client: SecuritySentinelClient = SentinelClientFactory.make()) {
+        self.client = client
+    }
 
     /// Consults the security sentinel and returns a detailed decision.
     public func sentinelConsult(_ request: HTTPRequest, body: ConsultRequest) async throws -> HTTPResponse {
-        let client = RuleBasedSecuritySentinelClient()
         let decision = try await client.consult(summary: body.summary, context: ["context": body.context])
         let respBody = try JSONEncoder().encode(decision)
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: respBody)

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/LLMSecuritySentinelClient.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/LLMSecuritySentinelClient.swift
@@ -9,6 +9,7 @@ enum FailMode: String {
 
 /// Environment configuration for the LLM Security Sentinel client.
 enum SentinelEnv {
+    static let enabled = (ProcessInfo.processInfo.environment["SEC_SENTINEL_ENABLED"] ?? "true").lowercased() != "false"
     static let url = ProcessInfo.processInfo.environment["SEC_SENTINEL_URL"]
     static let apiKey = ProcessInfo.processInfo.environment["SEC_SENTINEL_API_KEY"]
     static let timeoutMS = Int(ProcessInfo.processInfo.environment["SEC_SENTINEL_TIMEOUT_MS"] ?? "4000") ?? 4000

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/SentinelClientFactory.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/SentinelClientFactory.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Factory that selects the appropriate Security Sentinel client based on environment.
+enum SentinelClientFactory {
+    static func make() -> SecuritySentinelClient {
+        guard SentinelEnv.enabled,
+              SentinelEnv.url != nil,
+              SentinelEnv.apiKey != nil else {
+            return RuleBasedSecuritySentinelClient()
+        }
+        return LLMSecuritySentinelClient()
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- Select Security Sentinel client based on SEC_SENTINEL_* env vars
- Cache chosen client in handlers
- Provide example env vars and unit tests for factory selection

## Testing
- `swift test --filter SentinelClientFactoryTests --verbose` *(fails: build canceled after long dependency resolution)*

------
https://chatgpt.com/codex/tasks/task_b_68b53fe5ce808333a8549c491dfc72e3