### PR TITLE
Add structured sentinel audit logging

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -147,7 +147,11 @@ let fullTargets: [Target] = [
     ),
     .target(
         name: "SecuritySentinelGatewayPlugin",
-        dependencies: ["FountainRuntime", .product(name: "AsyncHTTPClient", package: "async-http-client")],
+        dependencies: [
+            "FountainRuntime",
+            .product(name: "AsyncHTTPClient", package: "async-http-client"),
+            .product(name: "Logging", package: "swift-log")
+        ],
         path: "libs/GatewayPlugins/SecuritySentinelGatewayPlugin",
     ),
     .target(

--- a/Tests/GatewayAppTests/AuditLoggerTests.swift
+++ b/Tests/GatewayAppTests/AuditLoggerTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import SecuritySentinelGatewayPlugin
+
+final class AuditLoggerTests: XCTestCase {
+    func testSHA256Hashing() {
+        let digest = Hashing.sha256Hex("hello")
+        XCTAssertEqual(digest, "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824")
+    }
+
+    func testContextRedaction() {
+        let context = ["token": "123", "apikey": "abc", "secretInfo": "shh", "other": "keep"]
+        let redacted = AuditLogger.redact(context)
+        XCTAssertEqual(redacted["token"], "[REDACTED]")
+        XCTAssertEqual(redacted["apikey"], "[REDACTED]")
+        XCTAssertEqual(redacted["secretInfo"], "[REDACTED]")
+        XCTAssertEqual(redacted["other"], "keep")
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/AuditLogger.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/AuditLogger.swift
@@ -1,9 +1,42 @@
 import Foundation
+import Logging
 
-/// Simple audit logger for Security Sentinel consults.
 enum AuditLogger {
-    static func logConsult(inputSummary: String, decision: SentinelDecision) {
-        // Placeholder: integrate with structured logging in real deployment.
+    private static let logger = Logger(label: "security-sentinel-audit")
+
+    static func logConsult(inputSummary: String, context: [String: String] = [:], decision: SentinelDecision) {
+        let hashed = Hashing.sha256Hex(inputSummary)
+        let redacted = redact(context)
+        var payload: [String: Any] = [
+            "requestID": decision.requestID,
+            "decision": decision.decision.rawValue,
+            "source": decision.source.rawValue,
+            "latencyMS": decision.latencyMS,
+            "hashedSummary": hashed
+        ]
+        if let model = decision.model {
+            payload["model"] = model
+        }
+        if !redacted.isEmpty {
+            payload["context"] = redacted
+        }
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let line = String(data: data, encoding: .utf8) {
+            logger.info(Logger.Message(stringLiteral: line))
+        }
+    }
+
+    static func redact(_ context: [String: String]) -> [String: String] {
+        let sensitive = ["token", "apikey", "secret"]
+        var result: [String: String] = [:]
+        for (key, value) in context {
+            if sensitive.contains(where: { key.lowercased().contains($0) }) {
+                result[key] = "[REDACTED]"
+            } else {
+                result[key] = value
+            }
+        }
+        return result
     }
 }
 

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Handlers.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Handlers.swift
@@ -8,8 +8,9 @@ public actor Handlers {
     /// Consults the security sentinel and returns a detailed decision.
     public func sentinelConsult(_ request: HTTPRequest, body: ConsultRequest) async throws -> HTTPResponse {
         let client = SentinelClientFactory.make()
-        let decision = try await client.consult(summary: body.summary, context: ["context": body.context])
-        AuditLogger.logConsult(inputSummary: body.summary, decision: decision)
+        let context = ["context": body.context]
+        let decision = try await client.consult(summary: body.summary, context: context)
+        AuditLogger.logConsult(inputSummary: body.summary, context: context, decision: decision)
         let respBody = try JSONEncoder().encode(decision)
         return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: respBody)
     }

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Hashing.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Hashing.swift
@@ -1,0 +1,11 @@
+import Foundation
+import Crypto
+
+enum Hashing {
+    static func sha256Hex(_ input: String) -> String {
+        let digest = SHA256.hash(data: Data(input.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- log Security Sentinel consults using swift-log with JSON fields: requestID, decision, source, latencyMS, model, hashed summary
- add SHA-256 hashing helper and redact sensitive context keys
- cover hashing and redaction utilities with unit tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68b546ee98d8833382681b1fcaa2d55d