### PR TITLE
Add Security Sentinel gateway tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,7 @@ let fullProducts: [Product] = [
     .executable(name: "function-caller-server", targets: ["function-caller-server"]),
     .library(name: "ToolsFactoryService", targets: ["ToolsFactoryService"]),
     .executable(name: "openapi-curator-cli", targets: ["openapi-curator-cli"]),
-    .executable(name: "openapi-curator-service", targets: ["openapi-curator-service"])
-]
+    .executable(name: "openapi-curator-service", targets: ["openapi-curator-service"])]
 
 let leanProducts: [Product] = [
     .library(name: "FountainCodex", targets: ["FountainCodex"]),
@@ -342,6 +341,7 @@ let fullTargets: [Target] = [
     .testTarget(name: "MIDI2TransportsTests", dependencies: ["MIDI2Transports"], path: "Tests/MIDI2TransportsTests"),
     .testTarget(name: "FlexctlTests", dependencies: ["flexctl", "ResourceLoader"], path: "Tests/FlexctlTests"),
     .testTarget(name: "GatewayAppTests", dependencies: ["gateway-server", "LLMGatewayPlugin", "AuthGatewayPlugin", "DestructiveGuardianGatewayPlugin", "SecuritySentinelGatewayPlugin", "PayloadInspectionGatewayPlugin", "BudgetBreakerGatewayPlugin", "RateLimiterGatewayPlugin", "RoleHealthCheckGatewayPlugin", "persist-server"], path: "Tests/GatewayAppTests"),
+    .testTarget(name: "SecuritySentinelGatewayAppTests", dependencies: ["SecuritySentinelGatewayPlugin", .product(name: "AsyncHTTPClient", package: "async-http-client"), "FountainRuntime"], path: "SecuritySentinelGateway/Tests/AppTests"),
     .testTarget(name: "FountainOpsTests", dependencies: ["LLMGatewayPlugin"], path: "Tests/FountainOpsTests"),
     .testTarget(name: "ToolsFactoryServiceTests", dependencies: ["ToolsFactoryService", "TypesensePersistence"], path: "Tests/ToolsFactoryServiceTests"),
     .testTarget(
@@ -624,6 +624,7 @@ let leanTargets: [Target] = [
         path: "Tests/OpenAPICuratorTests",
         resources: [.copy("Fixtures")]
     ),
+    .testTarget(name: "SecuritySentinelGatewayAppTests", dependencies: ["SecuritySentinelGatewayPlugin", .product(name: "AsyncHTTPClient", package: "async-http-client"), "FountainRuntime"], path: "SecuritySentinelGateway/Tests/AppTests"),
 ]
 
 var targets: [Target] = LEAN ? leanTargets : fullTargets

--- a/SecuritySentinelGateway/Tests/AppTests/ConsultRequestValidationTests.swift
+++ b/SecuritySentinelGateway/Tests/AppTests/ConsultRequestValidationTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import SecuritySentinelGatewayPlugin
+
+final class ConsultRequestValidationTests: XCTestCase {
+    func testValidSummaryPasses() throws {
+        let req = ConsultRequest(summary: "do stuff", context: "ctx")
+        XCTAssertNoThrow(try req.validate())
+    }
+
+    func testEmptySummaryThrows() {
+        let req = ConsultRequest(summary: "   ", context: "ctx")
+        XCTAssertThrowsError(try req.validate())
+    }
+
+    func testTooLongSummaryThrows() {
+        let long = String(repeating: "a", count: 1001)
+        let req = ConsultRequest(summary: long, context: "ctx")
+        XCTAssertThrowsError(try req.validate())
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinelGateway/Tests/AppTests/LLMSecuritySentinelClientTests.swift
+++ b/SecuritySentinelGateway/Tests/AppTests/LLMSecuritySentinelClientTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+import AsyncHTTPClient
+@testable import SecuritySentinelGatewayPlugin
+
+final class LLMSecuritySentinelClientTests: XCTestCase {
+    override func tearDown() {
+        unsetenv("SEC_SENTINEL_URL")
+        unsetenv("SEC_SENTINEL_API_KEY")
+        unsetenv("SEC_SENTINEL_FAIL_MODE")
+        unsetenv("SEC_SENTINEL_TIMEOUT_MS")
+        unsetenv("SEC_SENTINEL_RETRIES")
+        super.tearDown()
+    }
+
+    private func makeClient(failMode: String) -> (LLMSecuritySentinelClient, HTTPClient) {
+        setenv("SEC_SENTINEL_URL", "http://127.0.0.1:9", 1)
+        setenv("SEC_SENTINEL_API_KEY", "test", 1)
+        setenv("SEC_SENTINEL_FAIL_MODE", failMode, 1)
+        setenv("SEC_SENTINEL_TIMEOUT_MS", "10", 1)
+        setenv("SEC_SENTINEL_RETRIES", "0", 1)
+        let http = HTTPClient(eventLoopGroupProvider: .singleton)
+        let client = LLMSecuritySentinelClient(http: http)
+        return (client, http)
+    }
+
+    func testFailModeFallbackUsesRuleBasedDecision() async throws {
+        let (client, http) = makeClient(failMode: "fallback")
+        let decision = try await client.consult(summary: "danger", context: nil)
+        XCTAssertEqual(decision.source, .fallback_rules)
+        XCTAssertEqual(decision.decision, .deny)
+        try await http.shutdown()
+    }
+
+    func testFailModeAllowReturnsLLMSourcedAllow() async throws {
+        let (client, http) = makeClient(failMode: "allow")
+        let decision = try await client.consult(summary: "danger", context: nil)
+        XCTAssertEqual(decision.source, .llm)
+        XCTAssertEqual(decision.decision, .allow)
+        try await http.shutdown()
+    }
+
+    func testFailModeDenyReturnsLLMSourcedDeny() async throws {
+        let (client, http) = makeClient(failMode: "deny")
+        let decision = try await client.consult(summary: "safe", context: nil)
+        XCTAssertEqual(decision.source, .llm)
+        XCTAssertEqual(decision.decision, .deny)
+        try await http.shutdown()
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinelGateway/Tests/AppTests/RouterSourceIntegrationTests.swift
+++ b/SecuritySentinelGateway/Tests/AppTests/RouterSourceIntegrationTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import Foundation
+import FountainRuntime
+@testable import SecuritySentinelGatewayPlugin
+
+final class RouterSourceIntegrationTests: XCTestCase {
+    override func tearDown() {
+        unsetenv("SEC_SENTINEL_URL")
+        unsetenv("SEC_SENTINEL_API_KEY")
+        unsetenv("SEC_SENTINEL_FAIL_MODE")
+        unsetenv("SEC_SENTINEL_TIMEOUT_MS")
+        unsetenv("SEC_SENTINEL_RETRIES")
+        super.tearDown()
+    }
+
+    func testRouterUsesRuleBasedSourceWhenDisabled() async throws {
+        let router = Router()
+        let body = ConsultRequest(summary: "ok", context: "ctx")
+        let data = try JSONEncoder().encode(body)
+        let request = HTTPRequest(method: "POST", path: "/sentinel/consult", body: data)
+        let resp = try await router.route(request)
+        let decision = try JSONDecoder().decode(SentinelDecision.self, from: resp!.body)
+        XCTAssertEqual(decision.source, .fallback_rules)
+    }
+
+    func testRouterUsesLLMSourceWhenAllowedFailMode() async throws {
+        setenv("SEC_SENTINEL_URL", "http://127.0.0.1:9", 1)
+        setenv("SEC_SENTINEL_API_KEY", "k", 1)
+        setenv("SEC_SENTINEL_FAIL_MODE", "allow", 1)
+        setenv("SEC_SENTINEL_TIMEOUT_MS", "10", 1)
+        setenv("SEC_SENTINEL_RETRIES", "0", 1)
+        let router = Router()
+        let body = ConsultRequest(summary: "anything", context: "ctx")
+        let data = try JSONEncoder().encode(body)
+        let request = HTTPRequest(method: "POST", path: "/sentinel/consult", body: data)
+        let resp = try await router.route(request)
+        let decision = try JSONDecoder().decode(SentinelDecision.self, from: resp!.body)
+        XCTAssertEqual(decision.source, .llm)
+        XCTAssertEqual(decision.decision, .allow)
+    }
+
+    func testRouterFallsBackWhenLLMUnavailable() async throws {
+        setenv("SEC_SENTINEL_URL", "http://127.0.0.1:9", 1)
+        setenv("SEC_SENTINEL_API_KEY", "k", 1)
+        setenv("SEC_SENTINEL_FAIL_MODE", "fallback", 1)
+        setenv("SEC_SENTINEL_TIMEOUT_MS", "10", 1)
+        setenv("SEC_SENTINEL_RETRIES", "0", 1)
+        let router = Router()
+        let body = ConsultRequest(summary: "danger", context: "ctx")
+        let data = try JSONEncoder().encode(body)
+        let request = HTTPRequest(method: "POST", path: "/sentinel/consult", body: data)
+        let resp = try await router.route(request)
+        let decision = try JSONDecoder().decode(SentinelDecision.self, from: resp!.body)
+        XCTAssertEqual(decision.source, .fallback_rules)
+        XCTAssertEqual(decision.decision, .deny)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinelGateway/Tests/AppTests/RuleBasedSecuritySentinelClientTests.swift
+++ b/SecuritySentinelGateway/Tests/AppTests/RuleBasedSecuritySentinelClientTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import SecuritySentinelGatewayPlugin
+
+final class RuleBasedSecuritySentinelClientTests: XCTestCase {
+    func testEscalateKeywordProducesEscalateDecision() async throws {
+        let client = RuleBasedSecuritySentinelClient()
+        let decision = try await client.consult(summary: "please escalate", context: nil)
+        XCTAssertEqual(decision.decision, .escalate)
+        XCTAssertEqual(decision.source, .fallback_rules)
+    }
+
+    func testDangerousKeywordProducesDenyDecision() async throws {
+        let client = RuleBasedSecuritySentinelClient()
+        let decision = try await client.consult(summary: "danger", context: nil)
+        XCTAssertEqual(decision.decision, .deny)
+        XCTAssertEqual(decision.source, .fallback_rules)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinelGateway/Tests/AppTests/SentinelClientFactoryFailModesTests.swift
+++ b/SecuritySentinelGateway/Tests/AppTests/SentinelClientFactoryFailModesTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import SecuritySentinelGatewayPlugin
+
+final class SentinelClientFactoryFailModesTests: XCTestCase {
+    override func tearDown() {
+        unsetenv("SEC_SENTINEL_ENABLED")
+        unsetenv("SEC_SENTINEL_URL")
+        unsetenv("SEC_SENTINEL_API_KEY")
+        super.tearDown()
+    }
+
+    func testDisabledReturnsRuleBasedClient() {
+        setenv("SEC_SENTINEL_ENABLED", "false", 1)
+        let client = SentinelClientFactory.make()
+        XCTAssertTrue(client is RuleBasedSecuritySentinelClient)
+    }
+
+    func testMissingConfigReturnsRuleBasedClient() {
+        setenv("SEC_SENTINEL_ENABLED", "true", 1)
+        unsetenv("SEC_SENTINEL_URL")
+        unsetenv("SEC_SENTINEL_API_KEY")
+        let client = SentinelClientFactory.make()
+        XCTAssertTrue(client is RuleBasedSecuritySentinelClient)
+    }
+
+    func testValidConfigReturnsLLMClient() {
+        setenv("SEC_SENTINEL_ENABLED", "true", 1)
+        setenv("SEC_SENTINEL_URL", "http://localhost", 1)
+        setenv("SEC_SENTINEL_API_KEY", "k", 1)
+        let client = SentinelClientFactory.make()
+        XCTAssertTrue(client is LLMSecuritySentinelClient)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add unit tests for rule-based and LLM Security Sentinel clients
- cover sentinel client factory modes and request validation
- integrate router tests validating decision source behavior

## Testing
- `swift build -c debug -Xswiftc -Onone -Xswiftc -enable-testing -Xswiftc -warnings-as-errors`
- `swift test --parallel --filter SecuritySentinelGatewayAppTests` *(test runner reported 0 tests but listed all SecuritySentinelGatewayAppTests cases)*

------
https://chatgpt.com/codex/tasks/task_b_68b54d118f908333a3a2b2118a6d4a74