### PR TITLE
feat: extract SecuritySentinel plugin package

### DIFF
--- a/SecuritySentinel/Package.swift
+++ b/SecuritySentinel/Package.swift
@@ -1,0 +1,42 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "SecuritySentinel",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .library(
+            name: "SecuritySentinelGatewayPlugin",
+            targets: ["SecuritySentinelGatewayPluginModule"]
+        )
+    ],
+    dependencies: [
+        .package(path: ".."),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.21.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0")
+    ],
+    targets: [
+        .target(
+            name: "SecuritySentinelGatewayPluginModule",
+            dependencies: [
+                .product(name: "FountainRuntime", package: "the-fountainai"),
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
+                .product(name: "Logging", package: "swift-log")
+            ],
+            path: "Sources/SecuritySentinelGatewayPlugin"
+        ),
+        .testTarget(
+            name: "SecuritySentinelGatewayPluginTests",
+            dependencies: [
+                "SecuritySentinelGatewayPluginModule",
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
+                .product(name: "FountainRuntime", package: "the-fountainai")
+            ],
+            path: "Tests/SecuritySentinelGatewayPluginTests"
+        )
+    ]
+)
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/AuditLogger.swift
+++ b/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/AuditLogger.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Logging
+
+enum AuditLogger {
+    private static let logger = Logger(label: "security-sentinel-audit")
+
+    static func logConsult(inputSummary: String, context: [String: String] = [:], decision: SentinelDecision) {
+        let hashed = Hashing.sha256Hex(inputSummary)
+        let redacted = redact(context)
+        var payload: [String: Any] = [
+            "requestID": decision.requestID,
+            "decision": decision.decision.rawValue,
+            "source": decision.source.rawValue,
+            "latencyMS": decision.latencyMS,
+            "hashedSummary": hashed
+        ]
+        if let model = decision.model {
+            payload["model"] = model
+        }
+        if !redacted.isEmpty {
+            payload["context"] = redacted
+        }
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let line = String(data: data, encoding: .utf8) {
+            logger.info(Logger.Message(stringLiteral: line))
+        }
+    }
+
+    static func redact(_ context: [String: String]) -> [String: String] {
+        let sensitive = ["token", "apikey", "secret"]
+        var result: [String: String] = [:]
+        for (key, value) in context {
+            if sensitive.contains(where: { key.lowercased().contains($0) }) {
+                result[key] = "[REDACTED]"
+            } else {
+                result[key] = value
+            }
+        }
+        return result
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/CircuitBreaker.swift
+++ b/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/CircuitBreaker.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Minimal circuit breaker protecting the LLM sentinel.
+actor CircuitBreaker {
+    private let failureThreshold: Int
+    private let openInterval: TimeInterval
+    private var failures: Int = 0
+    private var openedAt: Date?
+
+    init(failureThreshold: Int = 3, openInterval: TimeInterval = 30) {
+        self.failureThreshold = failureThreshold
+        self.openInterval = openInterval
+    }
+
+    /// Returns `true` if requests are allowed.
+    func allow() -> Bool {
+        if let openedAt = openedAt {
+            if Date().timeIntervalSince(openedAt) > openInterval {
+                self.openedAt = nil
+                self.failures = 0
+                return true
+            } else {
+                return false
+            }
+        }
+        return true
+    }
+
+    /// Records a successful call, resetting internal state.
+    func recordSuccess() {
+        failures = 0
+        openedAt = nil
+    }
+
+    /// Records a failed call. Opens the breaker when the
+    /// failure threshold is reached.
+    func recordFailure() {
+        failures += 1
+        if failures >= failureThreshold {
+            openedAt = Date()
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/Config/Env.swift
+++ b/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/Config/Env.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+/// Environment configuration for the LLM Security Sentinel client.
+enum SentinelEnv {
+    static let enabled = (ProcessInfo.processInfo.environment["SEC_SENTINEL_ENABLED"] ?? "true").lowercased() != "false"
+    static let url = ProcessInfo.processInfo.environment["SEC_SENTINEL_URL"]
+    static let apiKey = ProcessInfo.processInfo.environment["SEC_SENTINEL_API_KEY"]
+    static let timeoutMS = Int(ProcessInfo.processInfo.environment["SEC_SENTINEL_TIMEOUT_MS"] ?? "4000") ?? 4000
+    static let retries = Int(ProcessInfo.processInfo.environment["SEC_SENTINEL_RETRIES"] ?? "1") ?? 1
+    static let model = ProcessInfo.processInfo.environment["SEC_SENTINEL_MODEL"]
+    static let failMode = ProcessInfo.processInfo.environment["SEC_SENTINEL_FAIL_MODE"] ?? "fallback" // allow|deny|fallback
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/Handlers.swift
+++ b/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/Handlers.swift
@@ -1,0 +1,19 @@
+import Foundation
+import FountainRuntime
+
+/// Actor housing Security Sentinel handlers.
+public actor Handlers {
+    public init() {}
+
+    /// Consults the security sentinel and returns a detailed decision.
+    public func sentinelConsult(_ request: HTTPRequest, body: ConsultRequest) async throws -> HTTPResponse {
+        let client = SentinelClientFactory.make()
+        let context = ["context": body.context]
+        let decision = try await client.consult(summary: body.summary, context: context)
+        AuditLogger.logConsult(inputSummary: body.summary, context: context, decision: decision)
+        let respBody = try JSONEncoder().encode(decision)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: respBody)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/Hashing.swift
+++ b/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/Hashing.swift
@@ -1,0 +1,11 @@
+import Foundation
+import Crypto
+
+enum Hashing {
+    static func sha256Hex(_ input: String) -> String {
+        let digest = SHA256.hash(data: Data(input.utf8))
+        return digest.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/LLMSecuritySentinelClient.swift
+++ b/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/LLMSecuritySentinelClient.swift
@@ -1,0 +1,147 @@
+import Foundation
+import AsyncHTTPClient
+import NIOCore
+
+/// Failure mode behaviour when the LLM call fails.
+enum FailMode: String {
+    case allow, deny, fallback
+}
+
+/// Client that consults an external LLM backed Security Sentinel service.
+final class LLMSecuritySentinelClient: SecuritySentinelClient {
+    private let http: HTTPClient
+    private let url: URL
+    private let apiKey: String
+    private let timeoutMS: Int
+    private let retries: Int
+    private let model: String?
+    private let failMode: FailMode
+    private let breaker: CircuitBreaker
+    private let ownsHTTPClient: Bool
+
+    init(http: HTTPClient? = nil) {
+        guard let urlString = SentinelEnv.url, let url = URL(string: urlString), let apiKey = SentinelEnv.apiKey else {
+            fatalError("SEC_SENTINEL_URL and SEC_SENTINEL_API_KEY must be set")
+        }
+        if let http = http {
+            self.http = http
+            self.ownsHTTPClient = false
+        } else {
+            self.http = HTTPClient(eventLoopGroupProvider: .singleton)
+            self.ownsHTTPClient = true
+        }
+        self.url = url
+        self.apiKey = apiKey
+        self.timeoutMS = SentinelEnv.timeoutMS
+        self.retries = SentinelEnv.retries
+        self.model = SentinelEnv.model
+        self.failMode = FailMode(rawValue: SentinelEnv.failMode) ?? .fallback
+        self.breaker = CircuitBreaker()
+    }
+
+    deinit {
+        if ownsHTTPClient {
+            try? http.syncShutdown()
+        }
+    }
+
+    private struct Payload: Codable {
+        let summary: String
+        let context: [String: String]?
+        let model: String?
+    }
+
+    private struct LLMResponse: Codable {
+        let decision: String
+        let reason: String
+        let confidence: Double?
+        let model: String?
+        let requestID: String?
+    }
+
+    func consult(summary: String, context: [String: (any Codable & Sendable)]?) async throws -> SentinelDecision {
+        guard await breaker.allow() else {
+            return try await applyFailMode(reason: "circuit open", summary: summary, context: context)
+        }
+        let payload = Payload(summary: summary, context: nil, model: model)
+        let body = try JSONEncoder().encode(payload)
+        var request = HTTPClientRequest(url: url.absoluteString)
+        request.method = .POST
+        request.headers.add(name: "Content-Type", value: "application/json")
+        request.headers.add(name: "Authorization", value: "Bearer \(apiKey)")
+        request.body = .bytes(body)
+
+        var attempt = 0
+        let start = Date()
+        while true {
+            attempt += 1
+            do {
+                let response = try await http.execute(request, timeout: .milliseconds(Int64(timeoutMS)))
+                if response.status.code >= 500 {
+                    throw NSError(domain: "llm", code: Int(response.status.code))
+                }
+                guard response.status.code < 400 else {
+                    return try await applyFailMode(reason: "LLM \(response.status.code)", summary: summary, context: context)
+                }
+                let buffer = try await response.body.collect(upTo: 1_048_576)
+                let data = Data(buffer.readableBytesView)
+                let decoded = try JSONDecoder().decode(LLMResponse.self, from: data)
+                let latency = Int(Date().timeIntervalSince(start) * 1000)
+                let decision = SentinelDecision(
+                    decision: SentinelVerdict(rawValue: decoded.decision) ?? .deny,
+                    reason: decoded.reason,
+                    confidence: decoded.confidence,
+                    model: decoded.model,
+                    requestID: decoded.requestID ?? UUID().uuidString,
+                    latencyMS: latency,
+                    source: .llm,
+                    timestamp: ISO8601DateFormatter().string(from: Date())
+                )
+                await breaker.recordSuccess()
+                return decision
+            } catch {
+                if attempt <= retries {
+                    let backoff = UInt64(pow(2.0, Double(attempt - 1))) * 100_000_000
+                    try await Task.sleep(nanoseconds: backoff)
+                    continue
+                } else {
+                    await breaker.recordFailure()
+                    return try await applyFailMode(reason: "LLM unavailable", summary: summary, context: context)
+                }
+            }
+        }
+    }
+
+    private func applyFailMode(reason: String, summary: String, context: [String: (any Codable & Sendable)]?) async throws -> SentinelDecision {
+        let ts = ISO8601DateFormatter().string(from: Date())
+        switch failMode {
+        case .allow:
+            return SentinelDecision(
+                decision: .allow,
+                reason: reason,
+                confidence: nil,
+                model: nil,
+                requestID: UUID().uuidString,
+                latencyMS: 0,
+                source: .llm,
+                timestamp: ts
+            )
+        case .deny:
+            return SentinelDecision(
+                decision: .deny,
+                reason: reason,
+                confidence: nil,
+                model: nil,
+                requestID: UUID().uuidString,
+                latencyMS: 0,
+                source: .llm,
+                timestamp: ts
+            )
+        case .fallback:
+            let fallback = RuleBasedSecuritySentinelClient()
+            return try await fallback.consult(summary: summary, context: context)
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/Models.swift
+++ b/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/Models.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Request model for consulting the Security Sentinel.
+public struct ConsultRequest: Codable, Sendable {
+    /// Summary of the action the user intends to perform.
+    public let summary: String
+    /// Additional context describing the request.
+    public let context: String
+
+    public init(summary: String, context: String) {
+        self.summary = summary
+        self.context = context
+    }
+
+    enum ValidationError: Error {
+        case invalidSummary
+    }
+
+    /// Validates that the summary is non-empty and no longer than 1000 characters.
+    public func validate() throws {
+        let trimmed = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed.count <= 1000 else {
+            throw ValidationError.invalidSummary
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🖚️ All rights reserved.

--- a/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/Router.swift
+++ b/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/Router.swift
@@ -1,0 +1,28 @@
+import Foundation
+import FountainRuntime
+
+/// Routes Security Sentinel consult requests.
+public struct Router: Sendable {
+    public var handlers: Handlers
+    public init(handlers: Handlers = Handlers()) { self.handlers = handlers }
+
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse? {
+        switch (request.method, request.path) {
+        case ("POST", "/sentinel/consult"):
+            if let body = try? JSONDecoder().decode(ConsultRequest.self, from: request.body) {
+                do {
+                    try body.validate()
+                } catch {
+                    return HTTPResponse(status: 400)
+                }
+                return try await handlers.sentinelConsult(request, body: body)
+            } else {
+                return HTTPResponse(status: 400)
+            }
+        default:
+            return nil
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/RuleBasedSecuritySentinelClient.swift
+++ b/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/RuleBasedSecuritySentinelClient.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Simple keyword based sentinel client used as a fallback.
+final class RuleBasedSecuritySentinelClient: SecuritySentinelClient {
+    func consult(summary: String, context: [String: (any Codable & Sendable)]?) async throws -> SentinelDecision {
+        let text = summary.lowercased()
+        let verdict: SentinelVerdict
+        let reason: String
+        if text.contains("escalate") {
+            verdict = .escalate
+            reason = "escalation keyword found"
+        } else if text.contains("delete") || text.contains("deny") || text.contains("danger") {
+            verdict = .deny
+            reason = "dangerous keyword found"
+        } else {
+            verdict = .allow
+            reason = "no dangerous keywords"
+        }
+        let ts = ISO8601DateFormatter().string(from: Date())
+        return SentinelDecision(
+            decision: verdict,
+            reason: reason,
+            confidence: nil,
+            model: nil,
+            requestID: UUID().uuidString,
+            latencyMS: 1,
+            source: .fallback_rules,
+            timestamp: ts
+        )
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/SecuritySentinelClient.swift
+++ b/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/SecuritySentinelClient.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Abstraction over clients capable of consulting the Security Sentinel service.
+public protocol SecuritySentinelClient: Sendable {
+    /// Consult the Security Sentinel with a summary and optional context.
+    /// - Parameters:
+    ///   - summary: Concise description of the proposed action.
+    ///   - context: Additional metadata describing the request.
+    /// - Returns: A structured decision from the sentinel.
+    func consult(summary: String, context: [String: (any Codable & Sendable)]?) async throws -> SentinelDecision
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin.swift
+++ b/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin.swift
@@ -1,0 +1,16 @@
+import Foundation
+import FountainRuntime
+
+/// Plugin providing Security Sentinel consult routing for the gateway.
+public struct SecuritySentinelGatewayPlugin: Sendable {
+    public let router: Router
+    private let handlers: Handlers
+
+    public init() {
+        let h = Handlers()
+        self.handlers = h
+        self.router = Router(handlers: h)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/SentinelClientFactory.swift
+++ b/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/SentinelClientFactory.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Factory that selects the appropriate Security Sentinel client based on environment.
+enum SentinelClientFactory {
+    static func make() -> SecuritySentinelClient {
+        guard SentinelEnv.enabled,
+              SentinelEnv.url != nil,
+              SentinelEnv.apiKey != nil else {
+            return RuleBasedSecuritySentinelClient()
+        }
+        return LLMSecuritySentinelClient()
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/SentinelDecision.swift
+++ b/SecuritySentinel/Sources/SecuritySentinelGatewayPlugin/SentinelDecision.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Origin of a decision returned by the Security Sentinel.
+public enum SentinelSource: String, Codable, Sendable {
+    /// Decision produced by a large language model backed sentinel service.
+    case llm
+    /// Decision produced by local fallback rules.
+    case fallback_rules
+}
+
+/// High level verdict returned by the Security Sentinel.
+public enum SentinelVerdict: String, Codable, Sendable {
+    /// Operation is permitted.
+    case allow
+    /// Operation is rejected.
+    case deny
+    /// Operation requires escalation or manual approval.
+    case escalate
+}
+
+/// Normalised decision payload produced by the Security Sentinel service.
+public struct SentinelDecision: Codable, Sendable {
+    /// Final verdict such as allow, deny or escalate.
+    public let decision: SentinelVerdict
+    /// Human readable explanation of the verdict.
+    public let reason: String
+    /// Optional confidence score from the model.
+    public let confidence: Double?
+    /// Identifier of the model that produced the decision, if available.
+    public let model: String?
+    /// Identifier for tracking this consult request.
+    public let requestID: String
+    /// Latency in milliseconds for generating the response.
+    public let latencyMS: Int
+    /// Source system that produced the verdict.
+    public let source: SentinelSource
+    /// RFC3339 timestamp when the decision was produced.
+    public let timestamp: String
+
+    public init(
+        decision: SentinelVerdict,
+        reason: String,
+        confidence: Double?,
+        model: String?,
+        requestID: String,
+        latencyMS: Int,
+        source: SentinelSource,
+        timestamp: String
+    ) {
+        self.decision = decision
+        self.reason = reason
+        self.confidence = confidence
+        self.model = model
+        self.requestID = requestID
+        self.latencyMS = latencyMS
+        self.source = source
+        self.timestamp = timestamp
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/SecuritySentinel/Tests/SecuritySentinelGatewayPluginTests/ConsultRequestValidationTests.swift
+++ b/SecuritySentinel/Tests/SecuritySentinelGatewayPluginTests/ConsultRequestValidationTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import SecuritySentinelGatewayPlugin
+@testable import SecuritySentinelGatewayPluginModule
 
 final class ConsultRequestValidationTests: XCTestCase {
     func testValidSummaryPasses() throws {

--- a/SecuritySentinel/Tests/SecuritySentinelGatewayPluginTests/LLMSecuritySentinelClientTests.swift
+++ b/SecuritySentinel/Tests/SecuritySentinelGatewayPluginTests/LLMSecuritySentinelClientTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import AsyncHTTPClient
-@testable import SecuritySentinelGatewayPlugin
+@testable import SecuritySentinelGatewayPluginModule
 
 final class LLMSecuritySentinelClientTests: XCTestCase {
     override func tearDown() {

--- a/SecuritySentinel/Tests/SecuritySentinelGatewayPluginTests/RouterSourceIntegrationTests.swift
+++ b/SecuritySentinel/Tests/SecuritySentinelGatewayPluginTests/RouterSourceIntegrationTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import Foundation
 import FountainRuntime
-@testable import SecuritySentinelGatewayPlugin
+@testable import SecuritySentinelGatewayPluginModule
 
 final class RouterSourceIntegrationTests: XCTestCase {
     override func tearDown() {

--- a/SecuritySentinel/Tests/SecuritySentinelGatewayPluginTests/RuleBasedSecuritySentinelClientTests.swift
+++ b/SecuritySentinel/Tests/SecuritySentinelGatewayPluginTests/RuleBasedSecuritySentinelClientTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import SecuritySentinelGatewayPlugin
+@testable import SecuritySentinelGatewayPluginModule
 
 final class RuleBasedSecuritySentinelClientTests: XCTestCase {
     func testEscalateKeywordProducesEscalateDecision() async throws {

--- a/SecuritySentinel/Tests/SecuritySentinelGatewayPluginTests/SecuritySentinelGatewayPluginTests.swift
+++ b/SecuritySentinel/Tests/SecuritySentinelGatewayPluginTests/SecuritySentinelGatewayPluginTests.swift
@@ -1,12 +1,11 @@
 import XCTest
 import Foundation
-@testable import SecuritySentinelGatewayPlugin
+@testable import SecuritySentinelGatewayPluginModule
 import FountainRuntime
-import gateway_server
 
 final class SecuritySentinelGatewayPluginTests: XCTestCase {
     @MainActor
-    func testDenyDecisionAndMetrics() async throws {
+    func testDenyDecision() async throws {
         let plugin = SecuritySentinelGatewayPlugin()
         let body = ConsultRequest(summary: "delete files", context: "u")
         let data = try JSONEncoder().encode(body)
@@ -15,15 +14,10 @@ final class SecuritySentinelGatewayPluginTests: XCTestCase {
         let decision = try JSONDecoder().decode(SentinelDecision.self, from: resp!.body)
         XCTAssertEqual(decision.decision, .deny)
         XCTAssertEqual(decision.source, .fallback_rules)
-        let before = await GatewayRequestMetrics.shared.snapshot()
-        await GatewayRequestMetrics.shared.record(method: request.method, status: resp!.status)
-        let after = await GatewayRequestMetrics.shared.snapshot()
-        let key = "gateway_responses_status_200_total"
-        XCTAssertEqual((after[key] ?? 0) - (before[key] ?? 0), 1)
     }
 
     @MainActor
-    func testAllowDecisionAndMetrics() async throws {
+    func testAllowDecision() async throws {
         let plugin = SecuritySentinelGatewayPlugin()
         let body = ConsultRequest(summary: "safe", context: "u")
         let data = try JSONEncoder().encode(body)
@@ -32,15 +26,10 @@ final class SecuritySentinelGatewayPluginTests: XCTestCase {
         let decision = try JSONDecoder().decode(SentinelDecision.self, from: resp!.body)
         XCTAssertEqual(decision.decision, .allow)
         XCTAssertEqual(decision.source, .fallback_rules)
-        let before = await GatewayRequestMetrics.shared.snapshot()
-        await GatewayRequestMetrics.shared.record(method: request.method, status: resp!.status)
-        let after = await GatewayRequestMetrics.shared.snapshot()
-        let key = "gateway_responses_status_200_total"
-        XCTAssertEqual((after[key] ?? 0) - (before[key] ?? 0), 1)
     }
 
     @MainActor
-    func testEscalateDecisionAndMetrics() async throws {
+    func testEscalateDecision() async throws {
         let plugin = SecuritySentinelGatewayPlugin()
         let body = ConsultRequest(summary: "please escalate", context: "u")
         let data = try JSONEncoder().encode(body)
@@ -49,24 +38,14 @@ final class SecuritySentinelGatewayPluginTests: XCTestCase {
         let decision = try JSONDecoder().decode(SentinelDecision.self, from: resp!.body)
         XCTAssertEqual(decision.decision, .escalate)
         XCTAssertEqual(decision.source, .fallback_rules)
-        let before = await GatewayRequestMetrics.shared.snapshot()
-        await GatewayRequestMetrics.shared.record(method: request.method, status: resp!.status)
-        let after = await GatewayRequestMetrics.shared.snapshot()
-        let key = "gateway_responses_status_200_total"
-        XCTAssertEqual((after[key] ?? 0) - (before[key] ?? 0), 1)
     }
 
     @MainActor
-    func testConsultMalformedBodyReturns400AndMetrics() async throws {
+    func testConsultMalformedBodyReturns400() async throws {
         let plugin = SecuritySentinelGatewayPlugin()
         let request = HTTPRequest(method: "POST", path: "/sentinel/consult", body: Data())
         let resp = try await plugin.router.route(request)
         XCTAssertEqual(resp?.status, 400)
-        let before = await GatewayRequestMetrics.shared.snapshot()
-        await GatewayRequestMetrics.shared.record(method: request.method, status: resp!.status)
-        let after = await GatewayRequestMetrics.shared.snapshot()
-        let key = "gateway_responses_status_400_total"
-        XCTAssertEqual((after[key] ?? 0) - (before[key] ?? 0), 1)
     }
 
     @MainActor

--- a/SecuritySentinel/Tests/SecuritySentinelGatewayPluginTests/SentinelClientFactoryFailModesTests.swift
+++ b/SecuritySentinel/Tests/SecuritySentinelGatewayPluginTests/SentinelClientFactoryFailModesTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import SecuritySentinelGatewayPlugin
+@testable import SecuritySentinelGatewayPluginModule
 
 final class SentinelClientFactoryFailModesTests: XCTestCase {
     override func tearDown() {


### PR DESCRIPTION
## Summary
- add standalone SecuritySentinel package exposing `SecuritySentinelGatewayPlugin`
- relocate plugin sources and tests to new package and drop server-only dependencies

## Testing
- `swift test` *(fails: LLMSecuritySentinelClientTests.testFailModeDenyReturnsLLMSourcedDeny, LLMSecuritySentinelClientTests.testFailModeFallbackUsesRuleBasedDecision, RouterSourceIntegrationTests.testRouterFallsBackWhenLLMUnavailable, RouterSourceIntegrationTests.testRouterUsesRuleBasedSourceWhenDisabled, SecuritySentinelGatewayPluginTests.testAllowDecision, SecuritySentinelGatewayPluginTests.testDenyDecision, SecuritySentinelGatewayPluginTests.testEscalateDecision, SentinelClientFactoryFailModesTests.testDisabledReturnsRuleBasedClient, SentinelClientFactoryFailModesTests.testMissingConfigReturnsRuleBasedClient)*


------
https://chatgpt.com/codex/tasks/task_b_68b55ed16b788333b644572037750ff4