### PR TITLE
Use remote fountainai runtime in SecuritySentinel

### DIFF
--- a/SecuritySentinel/Package.swift
+++ b/SecuritySentinel/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(path: ".."),
+        .package(url: "https://github.com/Fountain-Coach/the-fountainai.git", from: "1.0.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.21.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0")
     ],


### PR DESCRIPTION
## Summary
- replace local path dependency with remote `the-fountainai` package in SecuritySentinel
- tag repository at `1.0.0` for release

## Testing
- `swift test` *(fails: Dependencies could not be resolved because no versions of 'the-fountainai' match the requirement 1.0.0..<2.0.0)*

------
https://chatgpt.com/codex/tasks/task_b_68b56f7a1da48333a28726a33e0f3895