### PR TITLE
Add Security Sentinel gateway plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,8 @@ let leanProducts: [Product] = [
     .library(name: "BudgetBreakerGatewayPlugin", targets: ["BudgetBreakerGatewayPlugin"]),
     .library(name: "PayloadInspectionGatewayPlugin", targets: ["PayloadInspectionGatewayPlugin"]),
     .library(name: "DestructiveGuardianGatewayPlugin", targets: ["DestructiveGuardianGatewayPlugin"]),
-    .library(name: "RoleHealthCheckGatewayPlugin", targets: ["RoleHealthCheckGatewayPlugin"])
+    .library(name: "RoleHealthCheckGatewayPlugin", targets: ["RoleHealthCheckGatewayPlugin"]),
+    .library(name: "SecuritySentinelGatewayPlugin", targets: ["SecuritySentinelGatewayPlugin"])
 ]
 
 var products: [Product] = LEAN ? leanProducts : fullProducts
@@ -105,7 +106,7 @@ let fullTargets: [Target] = [
             "PayloadInspectionGatewayPlugin",
             "DestructiveGuardianGatewayPlugin",
             "RoleHealthCheckGatewayPlugin",
-            .product(name: "SecuritySentinelGatewayPlugin", package: "security-sentinel"),
+            "SecuritySentinelGatewayPlugin",
             "LauncherSignature",
             .product(name: "Crypto", package: "swift-crypto"),
             .product(name: "X509", package: "swift-certificates"),
@@ -147,6 +148,16 @@ let fullTargets: [Target] = [
         name: "RoleHealthCheckGatewayPlugin",
         dependencies: ["FountainRuntime"],
         path: "libs/GatewayPlugins/RoleHealthCheckGatewayPlugin",
+    ),
+    .target(
+        name: "SecuritySentinelGatewayPlugin",
+        dependencies: [
+            "FountainRuntime",
+            .product(name: "AsyncHTTPClient", package: "async-http-client"),
+            .product(name: "NIOCore", package: "swift-nio"),
+            .product(name: "Logging", package: "swift-log")
+        ],
+        path: "libs/GatewayPlugins/SecuritySentinelGatewayPlugin",
     ),
     .target(
         name: "PublishingFrontend",
@@ -479,7 +490,7 @@ let leanTargets: [Target] = [
             "PayloadInspectionGatewayPlugin",
             "DestructiveGuardianGatewayPlugin",
             "RoleHealthCheckGatewayPlugin",
-            .product(name: "SecuritySentinelGatewayPlugin", package: "security-sentinel"),
+            "SecuritySentinelGatewayPlugin",
             "LauncherSignature",
             .product(name: "Crypto", package: "swift-crypto"),
             .product(name: "X509", package: "swift-certificates"),
@@ -521,6 +532,16 @@ let leanTargets: [Target] = [
         name: "RoleHealthCheckGatewayPlugin",
         dependencies: ["FountainRuntime"],
         path: "libs/GatewayPlugins/RoleHealthCheckGatewayPlugin"
+    ),
+    .target(
+        name: "SecuritySentinelGatewayPlugin",
+        dependencies: [
+            "FountainRuntime",
+            .product(name: "AsyncHTTPClient", package: "async-http-client"),
+            .product(name: "NIOCore", package: "swift-nio"),
+            .product(name: "Logging", package: "swift-log")
+        ],
+        path: "libs/GatewayPlugins/SecuritySentinelGatewayPlugin"
     ),
     .target(
         name: "PublishingFrontend",
@@ -635,7 +656,6 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
         .package(url: "https://github.com/Fountain-Coach/midi2.git", from: "0.3.1"),
-        .package(url: "https://github.com/Fountain-Coach/security-sentinel.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-numerics.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.3.0"),
         .package(path: "libs/OpenAPICurator"),

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/AuditLogger.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/AuditLogger.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Logging
+
+enum AuditLogger {
+    private static let logger = Logger(label: "security-sentinel-audit")
+
+    static func logConsult(inputSummary: String, context: [String: String] = [:], decision: SentinelDecision) {
+        let hashed = Hashing.sha256Hex(inputSummary)
+        let redacted = redact(context)
+        var payload: [String: Any] = [
+            "requestID": decision.requestID,
+            "decision": decision.decision.rawValue,
+            "source": decision.source.rawValue,
+            "latencyMS": decision.latencyMS,
+            "hashedSummary": hashed
+        ]
+        if let model = decision.model {
+            payload["model"] = model
+        }
+        if !redacted.isEmpty {
+            payload["context"] = redacted
+        }
+        if let data = try? JSONSerialization.data(withJSONObject: payload),
+           let line = String(data: data, encoding: .utf8) {
+            logger.info(Logger.Message(stringLiteral: line))
+        }
+    }
+
+    static func redact(_ context: [String: String]) -> [String: String] {
+        let sensitive = ["token", "apikey", "secret"]
+        var result: [String: String] = [:]
+        for (key, value) in context {
+            if sensitive.contains(where: { key.lowercased().contains($0) }) {
+                result[key] = "[REDACTED]"
+            } else {
+                result[key] = value
+            }
+        }
+        return result
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/CircuitBreaker.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/CircuitBreaker.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Minimal circuit breaker protecting the LLM sentinel.
+actor CircuitBreaker {
+    private let failureThreshold: Int
+    private let openInterval: TimeInterval
+    private var failures: Int = 0
+    private var openedAt: Date?
+
+    init(failureThreshold: Int = 3, openInterval: TimeInterval = 30) {
+        self.failureThreshold = failureThreshold
+        self.openInterval = openInterval
+    }
+
+    /// Returns `true` if requests are allowed.
+    func allow() -> Bool {
+        if let openedAt = openedAt {
+            if Date().timeIntervalSince(openedAt) > openInterval {
+                self.openedAt = nil
+                self.failures = 0
+                return true
+            } else {
+                return false
+            }
+        }
+        return true
+    }
+
+    /// Records a successful call, resetting internal state.
+    func recordSuccess() {
+        failures = 0
+        openedAt = nil
+    }
+
+    /// Records a failed call. Opens the breaker when the
+    /// failure threshold is reached.
+    func recordFailure() {
+        failures += 1
+        if failures >= failureThreshold {
+            openedAt = Date()
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Config/Env.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Config/Env.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Environment configuration for the LLM Security Sentinel client.
+enum SentinelEnv {
+    static var enabled: Bool {
+        (ProcessInfo.processInfo.environment["SEC_SENTINEL_ENABLED"] ?? "true").lowercased() != "false"
+    }
+    static var url: String? {
+        ProcessInfo.processInfo.environment["SEC_SENTINEL_URL"]
+    }
+    static var apiKey: String? {
+        ProcessInfo.processInfo.environment["SEC_SENTINEL_API_KEY"]
+    }
+    static var timeoutMS: Int {
+        Int(ProcessInfo.processInfo.environment["SEC_SENTINEL_TIMEOUT_MS"] ?? "4000") ?? 4000
+    }
+    static var retries: Int {
+        Int(ProcessInfo.processInfo.environment["SEC_SENTINEL_RETRIES"] ?? "1") ?? 1
+    }
+    static var model: String? {
+        ProcessInfo.processInfo.environment["SEC_SENTINEL_MODEL"]
+    }
+    static var failMode: String {
+        ProcessInfo.processInfo.environment["SEC_SENTINEL_FAIL_MODE"] ?? "fallback" // allow|deny|fallback
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Handlers.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Handlers.swift
@@ -1,0 +1,19 @@
+import Foundation
+import FountainRuntime
+
+/// Actor housing Security Sentinel handlers.
+public actor Handlers {
+    public init() {}
+
+    /// Consults the security sentinel and returns a detailed decision.
+    public func sentinelConsult(_ request: HTTPRequest, body: ConsultRequest) async throws -> HTTPResponse {
+        let client = SentinelClientFactory.make()
+        let context = ["context": body.context]
+        let decision = try await client.consult(summary: body.summary, context: context)
+        AuditLogger.logConsult(inputSummary: body.summary, context: context, decision: decision)
+        let respBody = try JSONEncoder().encode(decision)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: respBody)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Hashing.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Hashing.swift
@@ -1,0 +1,18 @@
+import Foundation
+/// Lightweight hashing helper avoiding external crypto dependencies.
+enum Hashing {
+    /// Returns a deterministic hex string derived from the input.
+    ///
+    /// This is **not** cryptographically secure; it exists solely to avoid
+    /// depending on additional crypto packages while still providing a stable
+    /// obfuscation of logged summaries.
+    static func sha256Hex(_ input: String) -> String {
+        var hash: UInt64 = 5381
+        for byte in input.utf8 {
+            hash = (hash &* 33) &+ UInt64(byte)
+        }
+        return String(format: "%016llx", hash)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/LLMSecuritySentinelClient.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/LLMSecuritySentinelClient.swift
@@ -1,0 +1,147 @@
+import Foundation
+import AsyncHTTPClient
+import NIOCore
+
+/// Failure mode behaviour when the LLM call fails.
+enum FailMode: String {
+    case allow, deny, fallback
+}
+
+/// Client that consults an external LLM backed Security Sentinel service.
+final class LLMSecuritySentinelClient: SecuritySentinelClient {
+    private let http: HTTPClient
+    private let url: URL
+    private let apiKey: String
+    private let timeoutMS: Int
+    private let retries: Int
+    private let model: String?
+    private let failMode: FailMode
+    private let breaker: CircuitBreaker
+    private let ownsHTTPClient: Bool
+
+    init(http: HTTPClient? = nil) {
+        guard let urlString = SentinelEnv.url, let url = URL(string: urlString), let apiKey = SentinelEnv.apiKey else {
+            fatalError("SEC_SENTINEL_URL and SEC_SENTINEL_API_KEY must be set")
+        }
+        if let http = http {
+            self.http = http
+            self.ownsHTTPClient = false
+        } else {
+            self.http = HTTPClient(eventLoopGroupProvider: .singleton)
+            self.ownsHTTPClient = true
+        }
+        self.url = url
+        self.apiKey = apiKey
+        self.timeoutMS = SentinelEnv.timeoutMS
+        self.retries = SentinelEnv.retries
+        self.model = SentinelEnv.model
+        self.failMode = FailMode(rawValue: SentinelEnv.failMode) ?? .fallback
+        self.breaker = CircuitBreaker()
+    }
+
+    deinit {
+        if ownsHTTPClient {
+            try? http.syncShutdown()
+        }
+    }
+
+    private struct Payload: Codable {
+        let summary: String
+        let context: [String: String]?
+        let model: String?
+    }
+
+    private struct LLMResponse: Codable {
+        let decision: String
+        let reason: String
+        let confidence: Double?
+        let model: String?
+        let requestID: String?
+    }
+
+    func consult(summary: String, context: [String: (any Codable & Sendable)]?) async throws -> SentinelDecision {
+        guard await breaker.allow() else {
+            return try await applyFailMode(reason: "circuit open", summary: summary, context: context)
+        }
+        let payload = Payload(summary: summary, context: nil, model: model)
+        let body = try JSONEncoder().encode(payload)
+        var request = HTTPClientRequest(url: url.absoluteString)
+        request.method = .POST
+        request.headers.add(name: "Content-Type", value: "application/json")
+        request.headers.add(name: "Authorization", value: "Bearer \(apiKey)")
+        request.body = .bytes(body)
+
+        var attempt = 0
+        let start = Date()
+        while true {
+            attempt += 1
+            do {
+                let response = try await http.execute(request, timeout: .milliseconds(Int64(timeoutMS)))
+                if response.status.code >= 500 {
+                    throw NSError(domain: "llm", code: Int(response.status.code))
+                }
+                guard response.status.code < 400 else {
+                    return try await applyFailMode(reason: "LLM \(response.status.code)", summary: summary, context: context)
+                }
+                let buffer = try await response.body.collect(upTo: 1_048_576)
+                let data = Data(buffer.readableBytesView)
+                let decoded = try JSONDecoder().decode(LLMResponse.self, from: data)
+                let latency = Int(Date().timeIntervalSince(start) * 1000)
+                let decision = SentinelDecision(
+                    decision: SentinelVerdict(rawValue: decoded.decision) ?? .deny,
+                    reason: decoded.reason,
+                    confidence: decoded.confidence,
+                    model: decoded.model,
+                    requestID: decoded.requestID ?? UUID().uuidString,
+                    latencyMS: latency,
+                    source: .llm,
+                    timestamp: ISO8601DateFormatter().string(from: Date())
+                )
+                await breaker.recordSuccess()
+                return decision
+            } catch {
+                if attempt <= retries {
+                    let backoff = UInt64(pow(2.0, Double(attempt - 1))) * 100_000_000
+                    try await Task.sleep(nanoseconds: backoff)
+                    continue
+                } else {
+                    await breaker.recordFailure()
+                    return try await applyFailMode(reason: "LLM unavailable", summary: summary, context: context)
+                }
+            }
+        }
+    }
+
+    private func applyFailMode(reason: String, summary: String, context: [String: (any Codable & Sendable)]?) async throws -> SentinelDecision {
+        let ts = ISO8601DateFormatter().string(from: Date())
+        switch failMode {
+        case .allow:
+            return SentinelDecision(
+                decision: .allow,
+                reason: reason,
+                confidence: nil,
+                model: nil,
+                requestID: UUID().uuidString,
+                latencyMS: 0,
+                source: .llm,
+                timestamp: ts
+            )
+        case .deny:
+            return SentinelDecision(
+                decision: .deny,
+                reason: reason,
+                confidence: nil,
+                model: nil,
+                requestID: UUID().uuidString,
+                latencyMS: 0,
+                source: .llm,
+                timestamp: ts
+            )
+        case .fallback:
+            let fallback = RuleBasedSecuritySentinelClient()
+            return try await fallback.consult(summary: summary, context: context)
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Models.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Models.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Request model for consulting the Security Sentinel.
+public struct ConsultRequest: Codable, Sendable {
+    /// Summary of the action the user intends to perform.
+    public let summary: String
+    /// Additional context describing the request.
+    public let context: String
+
+    public init(summary: String, context: String) {
+        self.summary = summary
+        self.context = context
+    }
+
+    enum ValidationError: Error {
+        case invalidSummary
+    }
+
+    /// Validates that the summary is non-empty and no longer than 1000 characters.
+    public func validate() throws {
+        let trimmed = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed.count <= 1000 else {
+            throw ValidationError.invalidSummary
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🖚️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Router.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/Router.swift
@@ -1,0 +1,28 @@
+import Foundation
+import FountainRuntime
+
+/// Routes Security Sentinel consult requests.
+public struct Router: Sendable {
+    public var handlers: Handlers
+    public init(handlers: Handlers = Handlers()) { self.handlers = handlers }
+
+    public func route(_ request: HTTPRequest) async throws -> HTTPResponse? {
+        switch (request.method, request.path) {
+        case ("POST", "/sentinel/consult"):
+            if let body = try? JSONDecoder().decode(ConsultRequest.self, from: request.body) {
+                do {
+                    try body.validate()
+                } catch {
+                    return HTTPResponse(status: 400)
+                }
+                return try await handlers.sentinelConsult(request, body: body)
+            } else {
+                return HTTPResponse(status: 400)
+            }
+        default:
+            return nil
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/RuleBasedSecuritySentinelClient.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/RuleBasedSecuritySentinelClient.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Simple keyword based sentinel client used as a fallback.
+final class RuleBasedSecuritySentinelClient: SecuritySentinelClient {
+    func consult(summary: String, context: [String: (any Codable & Sendable)]?) async throws -> SentinelDecision {
+        let text = summary.lowercased()
+        let verdict: SentinelVerdict
+        let reason: String
+        if text.contains("escalate") {
+            verdict = .escalate
+            reason = "escalation keyword found"
+        } else if text.contains("delete") || text.contains("deny") || text.contains("danger") {
+            verdict = .deny
+            reason = "dangerous keyword found"
+        } else {
+            verdict = .allow
+            reason = "no dangerous keywords"
+        }
+        let ts = ISO8601DateFormatter().string(from: Date())
+        return SentinelDecision(
+            decision: verdict,
+            reason: reason,
+            confidence: nil,
+            model: nil,
+            requestID: UUID().uuidString,
+            latencyMS: 1,
+            source: .fallback_rules,
+            timestamp: ts
+        )
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/SecuritySentinelClient.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/SecuritySentinelClient.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Abstraction over clients capable of consulting the Security Sentinel service.
+public protocol SecuritySentinelClient: Sendable {
+    /// Consult the Security Sentinel with a summary and optional context.
+    /// - Parameters:
+    ///   - summary: Concise description of the proposed action.
+    ///   - context: Additional metadata describing the request.
+    /// - Returns: A structured decision from the sentinel.
+    func consult(summary: String, context: [String: (any Codable & Sendable)]?) async throws -> SentinelDecision
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin.swift
@@ -1,0 +1,16 @@
+import Foundation
+import FountainRuntime
+
+/// Plugin providing Security Sentinel consult routing for the gateway.
+public struct SecuritySentinelGatewayPlugin: Sendable {
+    public let router: Router
+    private let handlers: Handlers
+
+    public init() {
+        let h = Handlers()
+        self.handlers = h
+        self.router = Router(handlers: h)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/SentinelClientFactory.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/SentinelClientFactory.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Factory that selects the appropriate Security Sentinel client based on environment.
+enum SentinelClientFactory {
+    static func make() -> SecuritySentinelClient {
+        guard SentinelEnv.enabled,
+              SentinelEnv.url != nil,
+              SentinelEnv.apiKey != nil else {
+            return RuleBasedSecuritySentinelClient()
+        }
+        return LLMSecuritySentinelClient()
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/SentinelDecision.swift
+++ b/libs/GatewayPlugins/SecuritySentinelGatewayPlugin/SecuritySentinelGatewayPlugin/SentinelDecision.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Origin of a decision returned by the Security Sentinel.
+public enum SentinelSource: String, Codable, Sendable {
+    /// Decision produced by a large language model backed sentinel service.
+    case llm
+    /// Decision produced by local fallback rules.
+    case fallback_rules
+}
+
+/// High level verdict returned by the Security Sentinel.
+public enum SentinelVerdict: String, Codable, Sendable {
+    /// Operation is permitted.
+    case allow
+    /// Operation is rejected.
+    case deny
+    /// Operation requires escalation or manual approval.
+    case escalate
+}
+
+/// Normalised decision payload produced by the Security Sentinel service.
+public struct SentinelDecision: Codable, Sendable {
+    /// Final verdict such as allow, deny or escalate.
+    public let decision: SentinelVerdict
+    /// Human readable explanation of the verdict.
+    public let reason: String
+    /// Optional confidence score from the model.
+    public let confidence: Double?
+    /// Identifier of the model that produced the decision, if available.
+    public let model: String?
+    /// Identifier for tracking this consult request.
+    public let requestID: String
+    /// Latency in milliseconds for generating the response.
+    public let latencyMS: Int
+    /// Source system that produced the verdict.
+    public let source: SentinelSource
+    /// RFC3339 timestamp when the decision was produced.
+    public let timestamp: String
+
+    public init(
+        decision: SentinelVerdict,
+        reason: String,
+        confidence: Double?,
+        model: String?,
+        requestID: String,
+        latencyMS: Int,
+        source: SentinelSource,
+        timestamp: String
+    ) {
+        self.decision = decision
+        self.reason = reason
+        self.confidence = confidence
+        self.model = model
+        self.requestID = requestID
+        self.latencyMS = latencyMS
+        self.source = source
+        self.timestamp = timestamp
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add Security Sentinel gateway plugin with consult handler and router
- wire plugin into package and gateway server target

## Testing
- `swift build --target SecuritySentinelGatewayPlugin` *(fails: build timed out or terminated early)*

------
https://chatgpt.com/codex/tasks/task_b_68b671d2c7a48333bbeb07a1235a0fd8