### PR TITLE
Handle URLSession error bridging and fix deprecated String API

### DIFF
--- a/Tests/IntegrationRuntimeTests/URLSessionHTTPClientTests.swift
+++ b/Tests/IntegrationRuntimeTests/URLSessionHTTPClientTests.swift
@@ -110,10 +110,12 @@ final class URLSessionHTTPClientTests: XCTestCase {
             do {
                 _ = try await client.execute(method: .GET, url: "http://localhost", body: nil)
                 XCTFail("Expected to throw")
-            } catch is TestError {
-                // expected
             } catch {
-                XCTFail("Unexpected error: \(error)")
+                if error is TestError || (error as NSError).domain.contains("TestError") {
+                    // expected
+                } else {
+                    XCTFail("Unexpected error: \(error)")
+                }
             }
         }
         waitForExpectations(timeout: 1)

--- a/Tests/ToolServerTests/ToolServerHandlersTests.swift
+++ b/Tests/ToolServerTests/ToolServerHandlersTests.swift
@@ -66,7 +66,7 @@ final class ToolServerHandlersTests: XCTestCase {
             .deletingLastPathComponent() // ToolServerTests
             .deletingLastPathComponent() // Tests
         let url = root.appendingPathComponent("openapi/v1/tool-server.yml")
-        let text = try String(contentsOf: url)
+        let text = try String(contentsOf: url, encoding: .utf8)
         let obj = try Yams.load(yaml: text)
         XCTAssertNotNil(obj)
     }


### PR DESCRIPTION
## Summary
- make `URLSessionHTTPClientTests` resilient to bridged `NSError` when propagating session errors
- replace deprecated `String(contentsOf:)` usage with explicit UTF-8 encoding

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68b676dd88448333976acdbff3a4a27e