### PR TITLE
feat: add security sentinel gateway spec

### DIFF
--- a/openapi/README.md
+++ b/openapi/README.md
@@ -22,7 +22,28 @@ Versioned service definitions live here. Each YAML file describes a FountainAI s
 | Payload Inspection Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/payload-inspection-gateway.yml](v1/payload-inspection-gateway.yml) |
 | Budget Breaker Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/budget-breaker-gateway.yml](v1/budget-breaker-gateway.yml) |
 | Destructive Guardian Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/destructive-guardian-gateway.yml](v1/destructive-guardian-gateway.yml) |
+| Security Sentinel Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/security-sentinel-gateway.yml](v1/security-sentinel-gateway.yml) |
 | Tool Server | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/tool-server.yml](v1/tool-server.yml) |
 | OpenAPI Curator Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/openapi-curator.yml](v1/openapi-curator.yml) |
+
+
+## Gateway Plugins
+
+| Plugin | Owner | Status | Spec |
+| --- | --- | --- | --- |
+| Auth Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/auth-gateway.yml](v1/auth-gateway.yml) |
+| Role Health Check Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/role-health-check-gateway.yml](v1/role-health-check-gateway.yml) |
+| Rate Limiter Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/rate-limiter-gateway.yml](v1/rate-limiter-gateway.yml) |
+| Payload Inspection Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/payload-inspection-gateway.yml](v1/payload-inspection-gateway.yml) |
+| Budget Breaker Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/budget-breaker-gateway.yml](v1/budget-breaker-gateway.yml) |
+| Destructive Guardian Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/destructive-guardian-gateway.yml](v1/destructive-guardian-gateway.yml) |
+| Security Sentinel Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/security-sentinel-gateway.yml](v1/security-sentinel-gateway.yml) |
+
+## Persistence/Typesense
+
+| Service | Owner | Status | Spec |
+| --- | --- | --- | --- |
+| Persistence Service | Contexter alias Benedikt Eickhoff | ✅ | [v1/persist.yml](v1/persist.yml) |
+| Typesense API | Contexter alias Benedikt Eickhoff | ✅ | [typesense.yml](typesense.yml) |
 
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/security-sentinel-gateway.yml
+++ b/openapi/v1/security-sentinel-gateway.yml
@@ -1,0 +1,93 @@
+---
+openapi: 3.1.0
+info:
+  title: Security Sentinel Gateway Plugin
+  description: >
+    Consults the Security Sentinel role for allow/deny/escalate decisions.
+  version: 1.0.0
+servers:
+  - url: http://security-sentinel.fountain.coach/api/v1
+paths:
+  /sentinel/consult:
+    post:
+      tags:
+        - Sentinel
+      summary: Consult Security Sentinel
+      description: Sends a summary of a potentially destructive operation for a decision.
+      operationId: sentinelConsult
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SentinelConsultRequest'
+      responses:
+        '200':
+          description: Decision
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SentinelDecision'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    SentinelConsultRequest:
+      title: SentinelConsultRequest
+      type: object
+      required:
+        - summary
+      properties:
+        summary:
+          type: string
+        context:
+          type: string
+          nullable: true
+    SentinelDecision:
+      title: SentinelDecision
+      type: object
+      required:
+        - decision
+      properties:
+        decision:
+          type: string
+          enum:
+            - allow
+            - deny
+            - escalate
+    HTTPValidationError:
+      title: HTTPValidationError
+      type: object
+      properties:
+        detail:
+          type: array
+          title: Detail
+          items:
+            $ref: '#/components/schemas/ValidationError'
+    ValidationError:
+      title: ValidationError
+      type: object
+      required:
+        - loc
+        - msg
+        - type
+      properties:
+        loc:
+          type: array
+          title: Location
+          items:
+            anyOf:
+              - type: string
+              - type: integer
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- define security-sentinel gateway spec with POST /sentinel/consult and SentinelDecision model
- index security-sentinel gateway in OpenAPI README with gateway plugin table

## Testing
- `python3 scripts/validate_openapi.py`


------
https://chatgpt.com/codex/tasks/task_b_68b68eef16dc8333915f85126e35c953