### PR TITLE
Refactor gateway plugins to LLM client and document personas

### DIFF
--- a/Tests/GatewayPluginsTests/AuthGatewayPluginTests.swift
+++ b/Tests/GatewayPluginsTests/AuthGatewayPluginTests.swift
@@ -1,37 +1,10 @@
 import XCTest
 import FountainRuntime
 import AuthGatewayPlugin
-import Crypto
-
 final class AuthGatewayPluginTests: XCTestCase {
-    private func makeToken(secret: String, payload: [String: Any]) throws -> String {
-        let headerData = try JSONSerialization.data(withJSONObject: ["alg": "HS256", "typ": "JWT"])
-        let payloadData = try JSONSerialization.data(withJSONObject: payload)
-        func b64(_ data: Data) -> String {
-            data.base64EncodedString().replacingOccurrences(of: "+", with: "-").replacingOccurrences(of: "/", with: "_").replacingOccurrences(of: "=", with: "")
-        }
-        let header = b64(headerData)
-        let payload = b64(payloadData)
-        let signingInput = "\(header).\(payload)"
-        let key = SymmetricKey(data: Data(secret.utf8))
-        let sig = HMAC<SHA256>.authenticationCode(for: Data(signingInput.utf8), using: key)
-        let signature = b64(Data(sig))
-        return "\(signingInput).\(signature)"
-    }
-
-    func testBlocksUnauthorizedAccess() async throws {
-        let plugin = AuthGatewayPlugin(secret: "secret")
-        let body = try JSONEncoder().encode(ValidateRequest(token: "invalid"))
-        let request = HTTPRequest(method: "POST", path: "/auth/validate", body: body)
-        let response = try await plugin.router.route(request)
-        XCTAssertEqual(response?.status, 401)
-    }
-
-    func testAllowsAuthorizedAccess() async throws {
-        let plugin = AuthGatewayPlugin(secret: "secret")
-        let payload: [String: Any] = ["exp": Int(Date().timeIntervalSince1970) + 60, "role": "user"]
-        let token = try makeToken(secret: "secret", payload: payload)
-        let body = try JSONEncoder().encode(ValidateRequest(token: token))
+    func testValidateUsesLLM() async throws {
+        let plugin = AuthGatewayPlugin()
+        let body = try JSONEncoder().encode(ValidateRequest(token: "anything"))
         let request = HTTPRequest(method: "POST", path: "/auth/validate", body: body)
         let response = try await plugin.router.route(request)
         XCTAssertEqual(response?.status, 200)

--- a/Tests/GatewayPluginsTests/PayloadInspectionGatewayPluginTests.swift
+++ b/Tests/GatewayPluginsTests/PayloadInspectionGatewayPluginTests.swift
@@ -3,17 +3,8 @@ import FountainRuntime
 import PayloadInspectionGatewayPlugin
 
 final class PayloadInspectionGatewayPluginTests: XCTestCase {
-    func testRejectsOversizedPayload() async throws {
-        let plugin = PayloadInspectionGatewayPlugin(maxPayloadBytes: 10)
-        let large = String(repeating: "a", count: 20)
-        let body = try JSONEncoder().encode(PayloadInspectionRequest(payload: large))
-        let request = HTTPRequest(method: "POST", path: "/inspect", body: body)
-        let response = try await plugin.router.route(request)
-        XCTAssertEqual(response?.status, 413)
-    }
-
-    func testAcceptsPayloadWithinLimit() async throws {
-        let plugin = PayloadInspectionGatewayPlugin(maxPayloadBytes: 10)
+    func testInspectionUsesLLM() async throws {
+        let plugin = PayloadInspectionGatewayPlugin()
         let body = try JSONEncoder().encode(PayloadInspectionRequest(payload: "hi"))
         let request = HTTPRequest(method: "POST", path: "/inspect", body: body)
         let response = try await plugin.router.route(request)

--- a/Tests/GatewayPluginsTests/RateLimiterGatewayPluginTests.swift
+++ b/Tests/GatewayPluginsTests/RateLimiterGatewayPluginTests.swift
@@ -3,29 +3,11 @@ import FountainRuntime
 import RateLimiterGatewayPlugin
 
 final class RateLimiterGatewayPluginTests: XCTestCase {
-    func testThrottlesRequests() async throws {
-        let plugin = RateLimiterGatewayPlugin(defaultLimit: 1)
+    func testCheckUsesLLM() async throws {
+        let plugin = RateLimiterGatewayPlugin()
         let body = try JSONEncoder().encode(RateLimitCheckRequest(routeId: "r", clientId: "c", limitPerMinute: nil))
         let request = HTTPRequest(method: "POST", path: "/rate-limit/check", body: body)
-        let first = try await plugin.router.route(request)
-        let second = try await plugin.router.route(request)
-        let decoder = JSONDecoder()
-        let firstResp = try decoder.decode(RateLimitCheckResponse.self, from: first?.body ?? Data())
-        let secondResp = try decoder.decode(RateLimitCheckResponse.self, from: second?.body ?? Data())
-        XCTAssertTrue(firstResp.allowed)
-        XCTAssertFalse(secondResp.allowed)
-    }
-
-    func testLegitimateRequestsUnderLimitPass() async throws {
-        let plugin = RateLimiterGatewayPlugin(defaultLimit: 2)
-        let body = try JSONEncoder().encode(RateLimitCheckRequest(routeId: "r", clientId: "c", limitPerMinute: nil))
-        let request = HTTPRequest(method: "POST", path: "/rate-limit/check", body: body)
-        let first = try await plugin.router.route(request)
-        let second = try await plugin.router.route(request)
-        let decoder = JSONDecoder()
-        let firstResp = try decoder.decode(RateLimitCheckResponse.self, from: first?.body ?? Data())
-        let secondResp = try decoder.decode(RateLimitCheckResponse.self, from: second?.body ?? Data())
-        XCTAssertTrue(firstResp.allowed)
-        XCTAssertTrue(secondResp.allowed)
+        let response = try await plugin.router.route(request)
+        XCTAssertEqual(response?.status, 200)
     }
 }

--- a/libs/GatewayPlugins/AuthGatewayPlugin/AuthGatewayPlugin/Handlers.swift
+++ b/libs/GatewayPlugins/AuthGatewayPlugin/AuthGatewayPlugin/Handlers.swift
@@ -1,68 +1,46 @@
 import Foundation
 import FountainRuntime
-import Crypto
 
-/// Collection of handlers for auth gateway endpoints.
-public struct Handlers: Sendable {
-    private let secret: String
+/// Collection of handlers for auth gateway endpoints backed by an LLM.
+public actor Handlers {
+    private let client = LLMPluginClient(personaPath: "openapi/personas/auth.md")
 
-    public init(secret: String = ProcessInfo.processInfo.environment["GATEWAY_JWT_SECRET"] ?? "secret") {
-        self.secret = secret
-    }
+    public init() {}
 
-    private func claims(for token: String) -> ClaimsResponse? {
-        let segments = token.split(separator: ".")
-        guard segments.count == 3 else { return nil }
-        let signingInput = segments[0] + "." + segments[1]
-        guard let signatureData = Data(base64URLEncoded: String(segments[2])) else { return nil }
-        let key = SymmetricKey(data: Data(secret.utf8))
-        let expected = HMAC<SHA256>.authenticationCode(for: Data(signingInput.utf8), using: key)
-        guard Data(expected) == signatureData,
-              let payloadData = Data(base64URLEncoded: String(segments[1])),
-              let payload = try? JSONDecoder().decode(JWTPayload.self, from: payloadData) else { return nil }
-        let now = Int(Date().timeIntervalSince1970)
-        let leeway = Int(ProcessInfo.processInfo.environment["GATEWAY_JWT_LEEWAY"] ?? "60") ?? 60
-        if payload.exp + leeway < now { return nil }
-        if let nbf = payload.nbf, nbf - leeway > now { return nil }
-        if let iss = ProcessInfo.processInfo.environment["GATEWAY_JWT_ISS"], let pi = payload.iss, iss != pi { return nil }
-        if let aud = ProcessInfo.processInfo.environment["GATEWAY_JWT_AUD"], let pa = payload.aud, aud != pa { return nil }
-        if ((ProcessInfo.processInfo.environment["GATEWAY_JWT_REQUIRE_JTI"] as NSString?)?.boolValue ?? false) && (payload.jti ?? "").isEmpty { return nil }
-        let scopes = payload.role.map { [$0] } ?? []
-        return ClaimsResponse(role: payload.role, scopes: scopes)
-    }
-
-    private struct JWTPayload: Decodable { let iss: String?; let aud: String?; let nbf: Int?; let exp: Int; let jti: String?; let role: String? }
-
-    /// Validates a provided bearer token.
+    /// Delegates validation to the LLM using the Auth persona.
     public func authValidate(_ request: HTTPRequest, body: ValidateRequest?) async throws -> HTTPResponse {
-        guard let token = body?.token, let claims = claims(for: token) else {
-            return HTTPResponse(status: 401)
-        }
-        let resp = ValidationResponse(valid: true, role: claims.role)
-        let data = try JSONEncoder().encode(resp)
-        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+        let prompt = body.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) } ?? ""
+        let result = try await client.call(prompt: prompt)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: Data(result.utf8))
     }
 
-    /// Returns claims for the bearer token in the Authorization header.
+    /// Retrieves claims for the supplied token via the LLM.
     public func authClaims(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        guard let auth = request.headers["Authorization"], auth.hasPrefix("Bearer "),
-              let claims = claims(for: String(auth.dropFirst(7))) else {
-            return HTTPResponse(status: 401)
-        }
-        let data = try JSONEncoder().encode(claims)
-        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+        let token = request.headers["Authorization"] ?? ""
+        let result = try await client.call(prompt: token)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: Data(result.utf8))
     }
 }
 
-private extension Data {
-    init?(base64URLEncoded input: String) {
-        var base64 = input
-            .replacingOccurrences(of: "-", with: "+")
-            .replacingOccurrences(of: "_", with: "/")
-        let padding = 4 - base64.count % 4
-        if padding < 4 { base64 += String(repeating: "=", count: padding) }
-        guard let data = Data(base64Encoded: base64) else { return nil }
-        self = data
+/// Minimal client that forwards prompts and persona to the LLM Gateway.
+struct LLMPluginClient {
+    let persona: String
+    let url: URL
+
+    init(personaPath: String,
+         url: URL = URL(string: ProcessInfo.processInfo.environment["LLM_GATEWAY_URL"] ?? "http://localhost:8080/chat")!) {
+        self.persona = (try? String(contentsOfFile: personaPath, encoding: .utf8)) ?? ""
+        self.url = url
+    }
+
+    func call(prompt: String) async throws -> String {
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        let payload = ["persona": persona, "prompt": prompt]
+        req.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        let (data, _) = try await URLSession.shared.data(for: req)
+        return String(data: data, encoding: .utf8) ?? "{}"
     }
 }
 

--- a/libs/GatewayPlugins/PayloadInspectionGatewayPlugin/PayloadInspectionGatewayPlugin/Handlers.swift
+++ b/libs/GatewayPlugins/PayloadInspectionGatewayPlugin/PayloadInspectionGatewayPlugin/Handlers.swift
@@ -1,23 +1,39 @@
 import Foundation
 import FountainRuntime
 
-/// Actor housing payload inspection handlers.
+/// Actor housing payload inspection handlers backed by an LLM.
 public actor Handlers {
-    private let maxSize: Int
+    private let client = LLMPluginClient(personaPath: "openapi/personas/payload-inspection.md")
 
-    /// Creates a new handlers instance.
-    /// - Parameter maxSize: Maximum allowed payload size in bytes.
-    public init(maxSize: Int = 1024) {
-        self.maxSize = maxSize
+    public init() {}
+
+    /// Delegates payload inspection to the LLM.
+    public func inspectPayload(_ request: HTTPRequest, body: PayloadInspectionRequest?) async throws -> HTTPResponse {
+        let prompt = body.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) } ?? ""
+        let result = try await client.call(prompt: prompt)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: Data(result.utf8))
+    }
+}
+
+/// Minimal client that forwards prompts and persona to the LLM Gateway.
+struct LLMPluginClient {
+    let persona: String
+    let url: URL
+
+    init(personaPath: String,
+         url: URL = URL(string: ProcessInfo.processInfo.environment["LLM_GATEWAY_URL"] ?? "http://localhost:8080/chat")!) {
+        self.persona = (try? String(contentsOfFile: personaPath, encoding: .utf8)) ?? ""
+        self.url = url
     }
 
-    /// Inspects the provided payload and returns sanitized content with any violations.
-    public func inspectPayload(_ request: HTTPRequest, body: PayloadInspectionRequest?) async throws -> HTTPResponse {
-        guard let body else { return HTTPResponse(status: 400) }
-        guard body.payload.utf8.count <= maxSize else { return HTTPResponse(status: 413) }
-        let response = PayloadInspectionResponse(sanitized: body.payload, violations: [])
-        let data = try JSONEncoder().encode(response)
-        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+    func call(prompt: String) async throws -> String {
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        let payload = ["persona": persona, "prompt": prompt]
+        req.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        let (data, _) = try await URLSession.shared.data(for: req)
+        return String(data: data, encoding: .utf8) ?? "{}"
     }
 }
 

--- a/libs/GatewayPlugins/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin/Handlers.swift
+++ b/libs/GatewayPlugins/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin/Handlers.swift
@@ -1,64 +1,45 @@
 import Foundation
 import FountainRuntime
 
-/// Collection of handlers for rate limiter gateway endpoints.
+/// Handlers for rate limiter gateway endpoints using an LLM backend.
 public actor Handlers {
-    private struct Bucket { var tokens: Double; var lastRefill: TimeInterval; let capacity: Double; let rate: Double }
-    private var buckets: [String: Bucket] = [:]
-    private var allowed = 0
-    private var throttled = 0
-    private let defaultLimit: Int
+    private let client = LLMPluginClient(personaPath: "openapi/personas/rate-limiter.md")
 
-    public init(defaultLimit: Int = 60) {
-        self.defaultLimit = defaultLimit
-    }
+    public init() {}
 
-    /// Checks and consumes a token for the given route and client.
-    public func allow(routeId: String, clientId: String, limitPerMinute: Int?) -> Bool {
-        let limit = limitPerMinute ?? defaultLimit
-        if limit <= 0 {
-            allowed += 1
-            Task { await DNSMetrics.shared.recordRateLimit(allowed: true) }
-            return true
-        }
-        let key = "\(routeId)#\(clientId)"
-        let ratePerSecond = Double(limit) / 60.0
-        let now = Date().timeIntervalSince1970
-        var bucket = buckets[key] ?? Bucket(tokens: Double(limit), lastRefill: now, capacity: Double(limit), rate: ratePerSecond)
-        let elapsed = max(0, now - bucket.lastRefill)
-        bucket.tokens = min(bucket.capacity, bucket.tokens + elapsed * bucket.rate)
-        bucket.lastRefill = now
-        if bucket.tokens >= 1.0 {
-            bucket.tokens -= 1.0
-            buckets[key] = bucket
-            allowed += 1
-            Task { await DNSMetrics.shared.recordRateLimit(allowed: true) }
-            return true
-        }
-        buckets[key] = bucket
-        throttled += 1
-        Task { await DNSMetrics.shared.recordRateLimit(allowed: false) }
-        return false
-    }
-
-    /// Returns accumulated allowed and throttled counts.
-    public func stats() -> (allowed: Int, throttled: Int) { (allowed, throttled) }
-
-    /// Handler for rate limit checks.
+    /// Delegates rate limit checks to the LLM.
     public func rateLimitCheck(_ request: HTTPRequest, body: RateLimitCheckRequest?) async throws -> HTTPResponse {
-        guard let body else { return HTTPResponse(status: 400) }
-        let permitted = allow(routeId: body.routeId, clientId: body.clientId, limitPerMinute: body.limitPerMinute)
-        let resp = RateLimitCheckResponse(allowed: permitted)
-        let data = try JSONEncoder().encode(resp)
-        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+        let prompt = body.flatMap { try? String(data: JSONEncoder().encode($0), encoding: .utf8) } ?? ""
+        let result = try await client.call(prompt: prompt)
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: Data(result.utf8))
     }
 
-    /// Handler returning aggregated statistics.
+    /// Requests aggregated statistics from the LLM.
     public func rateLimitStats(_ request: HTTPRequest, body: NoBody?) async throws -> HTTPResponse {
-        let (allowed, throttled) = stats()
-        let resp = RateLimitStatsResponse(allowed: allowed, throttled: throttled)
-        let data = try JSONEncoder().encode(resp)
-        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+        let result = try await client.call(prompt: "stats")
+        return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: Data(result.utf8))
+    }
+}
+
+/// Minimal client that forwards prompts and persona to the LLM Gateway.
+struct LLMPluginClient {
+    let persona: String
+    let url: URL
+
+    init(personaPath: String,
+         url: URL = URL(string: ProcessInfo.processInfo.environment["LLM_GATEWAY_URL"] ?? "http://localhost:8080/chat")!) {
+        self.persona = (try? String(contentsOfFile: personaPath, encoding: .utf8)) ?? ""
+        self.url = url
+    }
+
+    func call(prompt: String) async throws -> String {
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        let payload = ["persona": persona, "prompt": prompt]
+        req.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        let (data, _) = try await URLSession.shared.data(for: req)
+        return String(data: data, encoding: .utf8) ?? "{}"
     }
 }
 

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -47,4 +47,13 @@ Persona definitions for Gateway plugins live in `personas/` and are referenced v
 | Persistence Service | Contexter alias Benedikt Eickhoff | ✅ | [v1/persist.yml](v1/persist.yml) |
 | Typesense API | Contexter alias Benedikt Eickhoff | ✅ | [typesense.yml](typesense.yml) |
 
+## Personas
+
+The following personas drive Gateway plugin behaviour via the LLM:
+
+- [Auth Gateway Persona](personas/auth.md)
+- [Rate Limiter Persona](personas/rate-limiter.md)
+- [Payload Inspection Persona](personas/payload-inspection.md)
+- [Security Sentinel Persona](personas/security-sentinel.md)
+
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/personas/auth.md
+++ b/openapi/personas/auth.md
@@ -1,0 +1,4 @@
+# Auth Gateway Persona
+
+The Auth Gateway Plugin relies on this persona to reason about authentication
+requests and emit token validation or claim details via the LLM.

--- a/openapi/personas/payload-inspection.md
+++ b/openapi/personas/payload-inspection.md
@@ -1,0 +1,4 @@
+# Payload Inspection Persona
+
+Guides the Payload Inspection plugin in assessing request bodies, surfacing
+violations, and suggesting sanitised outputs through the LLM.

--- a/openapi/personas/rate-limiter.md
+++ b/openapi/personas/rate-limiter.md
@@ -1,0 +1,4 @@
+# Rate Limiter Persona
+
+This persona empowers the Rate Limiter plugin to evaluate client and route
+information and decide whether a request should proceed or be throttled.

--- a/openapi/v1/auth-gateway.yml
+++ b/openapi/v1/auth-gateway.yml
@@ -6,6 +6,7 @@ info:
     Lightweight authentication gateway plugin exposing token validation
     and claims retrieval endpoints.
   version: 1.0.0
+x-persona: ../personas/auth.md
 servers:
   - url: https://gateway.fountain.coach/api/v1
 paths:

--- a/openapi/v1/payload-inspection-gateway.yml
+++ b/openapi/v1/payload-inspection-gateway.yml
@@ -5,6 +5,7 @@ info:
   description: >
     Inspects payloads for forbidden content and either sanitizes them or reports violations.
   version: 1.0.0
+x-persona: ../personas/payload-inspection.md
 servers:
   - url: http://payload-inspection.fountain.coach/api/v1
 paths:

--- a/openapi/v1/rate-limiter-gateway.yml
+++ b/openapi/v1/rate-limiter-gateway.yml
@@ -5,6 +5,7 @@ info:
   description: >
     Token bucket rate limiter for FountainAI gateway.
   version: 1.0.0
+x-persona: ../personas/rate-limiter.md
 servers:
   - url: http://rate-limiter.fountain.coach/api/v1
 paths:


### PR DESCRIPTION
## Summary
- replace Auth, Rate Limiter, and Payload Inspection plugin handlers with LLMPluginClient invoking personas
- document plugin personas in OpenAPI specs and README
- simplify gateway plugin tests for new LLM-driven flow

## Testing
- `python3 scripts/validate_openapi.py`
- `swift build --target AuthGatewayPlugin --target RateLimiterGatewayPlugin --target PayloadInspectionGatewayPlugin` *(fails: run interrupted after prolonged dependency fetch)*
- `swift test --filter GatewayPluginsTests` *(fails: build interrupted due to long compile time)*


------
https://chatgpt.com/codex/tasks/task_b_68b692d819a883339c18482513ff42d6