### PR TITLE
Add persona orchestrator and integrate with gateway

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,8 @@ let fullProducts: [Product] = [
     .executable(name: "function-caller-server", targets: ["function-caller-server"]),
     .library(name: "ToolsFactoryService", targets: ["ToolsFactoryService"]),
     .executable(name: "openapi-curator-cli", targets: ["openapi-curator-cli"]),
-    .executable(name: "openapi-curator-service", targets: ["openapi-curator-service"])]
+    .executable(name: "openapi-curator-service", targets: ["openapi-curator-service"]),
+    .library(name: "GatewayPersonaOrchestrator", targets: ["GatewayPersonaOrchestrator"])]
 
 let leanProducts: [Product] = [
     .library(name: "FountainCodex", targets: ["FountainCodex"]),
@@ -38,7 +39,8 @@ let leanProducts: [Product] = [
     .library(name: "PayloadInspectionGatewayPlugin", targets: ["PayloadInspectionGatewayPlugin"]),
     .library(name: "DestructiveGuardianGatewayPlugin", targets: ["DestructiveGuardianGatewayPlugin"]),
     .library(name: "RoleHealthCheckGatewayPlugin", targets: ["RoleHealthCheckGatewayPlugin"]),
-    .library(name: "SecuritySentinelGatewayPlugin", targets: ["SecuritySentinelGatewayPlugin"])
+    .library(name: "SecuritySentinelGatewayPlugin", targets: ["SecuritySentinelGatewayPlugin"]),
+    .library(name: "GatewayPersonaOrchestrator", targets: ["GatewayPersonaOrchestrator"])
 ]
 
 var products: [Product] = LEAN ? leanProducts : fullProducts
@@ -107,6 +109,7 @@ let fullTargets: [Target] = [
             "DestructiveGuardianGatewayPlugin",
             "RoleHealthCheckGatewayPlugin",
             "SecuritySentinelGatewayPlugin",
+            "GatewayPersonaOrchestrator",
             "LauncherSignature",
             .product(name: "Crypto", package: "swift-crypto"),
             .product(name: "X509", package: "swift-certificates"),
@@ -158,6 +161,15 @@ let fullTargets: [Target] = [
             .product(name: "Logging", package: "swift-log")
         ],
         path: "libs/GatewayPlugins/SecuritySentinelGatewayPlugin",
+    ),
+    .target(
+        name: "GatewayPersonaOrchestrator",
+        dependencies: [
+            "FountainRuntime",
+            "SecuritySentinelGatewayPlugin",
+            "DestructiveGuardianGatewayPlugin"
+        ],
+        path: "libs/GatewayPersonaOrchestrator"
     ),
     .target(
         name: "PublishingFrontend",
@@ -491,6 +503,7 @@ let leanTargets: [Target] = [
             "DestructiveGuardianGatewayPlugin",
             "RoleHealthCheckGatewayPlugin",
             "SecuritySentinelGatewayPlugin",
+            "GatewayPersonaOrchestrator",
             "LauncherSignature",
             .product(name: "Crypto", package: "swift-crypto"),
             .product(name: "X509", package: "swift-certificates"),
@@ -542,6 +555,15 @@ let leanTargets: [Target] = [
             .product(name: "Logging", package: "swift-log")
         ],
         path: "libs/GatewayPlugins/SecuritySentinelGatewayPlugin"
+    ),
+    .target(
+        name: "GatewayPersonaOrchestrator",
+        dependencies: [
+            "FountainRuntime",
+            "SecuritySentinelGatewayPlugin",
+            "DestructiveGuardianGatewayPlugin"
+        ],
+        path: "libs/GatewayPersonaOrchestrator"
     ),
     .target(
         name: "PublishingFrontend",

--- a/apps/GatewayServer/GatewayApp/GatewayServer.swift
+++ b/apps/GatewayServer/GatewayApp/GatewayServer.swift
@@ -7,6 +7,9 @@ import X509
 import LLMGatewayPlugin
 import AuthGatewayPlugin
 import RateLimiterGatewayPlugin
+#if canImport(GatewayPersonaOrchestrator)
+import GatewayPersonaOrchestrator
+#endif
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
@@ -35,6 +38,7 @@ public final class GatewayServer {
     private let rateLimiter: RateLimiterGatewayPlugin?
     private let breaker: CircuitBreaker = CircuitBreaker()
     private var roleGuardReloader: RoleGuardConfigReloader?
+    private let personaOrchestrator: GatewayPersonaOrchestrator?
 
     private struct ZoneCreateRequest: Codable { let name: String }
     private struct ZonesResponse: Codable { let zones: [ZoneManager.Zone] }
@@ -82,11 +86,13 @@ public final class GatewayServer {
                 routeStoreURL: URL? = nil,
                 certificatePath: String? = nil,
                 rateLimiter: RateLimiterGatewayPlugin? = nil,
-                roleGuardStore: RoleGuardStore? = nil) {
+                roleGuardStore: RoleGuardStore? = nil,
+                personaOrchestrator: GatewayPersonaOrchestrator? = nil) {
         self.manager = manager
         self.plugins = plugins
         self.zoneManager = zoneManager
         self.roleGuardStore = roleGuardStore
+        self.personaOrchestrator = personaOrchestrator
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         self.routes = [:]
         self.routesURL = routeStoreURL
@@ -115,6 +121,19 @@ public final class GatewayServer {
                 return HTTPResponse(status: 429, headers: ["Content-Type": "text/plain"], body: Data("too many requests".utf8))
             } catch is ServiceUnavailableError {
                 return HTTPResponse(status: 503, headers: ["Content-Type": "text/plain"], body: Data("service unavailable".utf8))
+            }
+
+            if let orchestrator = self.personaOrchestrator {
+                let verdict = await orchestrator.decide(for: request)
+                switch verdict {
+                case .allow:
+                    break
+                case .deny(let reason, _):
+                    return self.error(403, message: reason)
+                case .escalate(let reason, _):
+                    let json = try? JSONEncoder().encode(["decision": "escalate", "reason": reason])
+                    return HTTPResponse(status: 202, headers: ["Content-Type": "application/json"], body: json ?? Data())
+                }
             }
 
             // Allow plugins with routers to handle requests before builtin routes.

--- a/apps/GatewayServer/GatewayApp/main.swift
+++ b/apps/GatewayServer/GatewayApp/main.swift
@@ -6,6 +6,7 @@ import LLMGatewayPlugin
 import AuthGatewayPlugin
 import RateLimiterGatewayPlugin
 import LauncherSignature
+import GatewayPersonaOrchestrator
 
 verifyLauncherSignature()
 // Role guard plugin in this target
@@ -44,8 +45,12 @@ plugins.append(contentsOf: [
     LoggingPlugin() as any GatewayPlugin,
     PublishingFrontendPlugin(rootPath: publishingConfig?.rootPath ?? "./Public") as any GatewayPlugin
 ])
+let orchestrator = GatewayPersonaOrchestrator(personas: [
+    SecuritySentinelPersona(),
+    DestructiveGuardianPersona()
+])
 
-let server = GatewayServer(plugins: plugins, zoneManager: nil, routeStoreURL: routesFile, certificatePath: nil, rateLimiter: rateLimiter, roleGuardStore: roleGuardStore)
+let server = GatewayServer(plugins: plugins, zoneManager: nil, routeStoreURL: routesFile, certificatePath: nil, rateLimiter: rateLimiter, roleGuardStore: roleGuardStore, personaOrchestrator: orchestrator)
 Task { @MainActor in
     try await server.start(port: 8080)
 }

--- a/libs/GatewayPersonaOrchestrator/GatewayPersonaOrchestrator/GatewayPersonaOrchestrator.swift
+++ b/libs/GatewayPersonaOrchestrator/GatewayPersonaOrchestrator/GatewayPersonaOrchestrator.swift
@@ -1,0 +1,129 @@
+import Foundation
+import FountainRuntime
+import SecuritySentinelGatewayPlugin
+import DestructiveGuardianGatewayPlugin
+
+/// High level verdict returned by a persona evaluation.
+public enum GatewayPersonaVerdict: Sendable {
+    /// Request is permitted.
+    case allow
+    /// Request is rejected with a reason and the persona responsible.
+    case deny(reason: String, persona: String)
+    /// Persona cannot authorise the request and requires escalation.
+    case escalate(reason: String, persona: String)
+}
+
+/// Abstraction for individual personas participating in gateway decisions.
+public protocol GatewayPersona: Sendable {
+    /// Human readable identifier for the persona.
+    var name: String { get }
+    /// Evaluate a request and return a verdict.
+    func evaluate(_ request: HTTPRequest) async -> GatewayPersonaVerdict
+}
+
+/// Coordinates multiple personas and produces a combined decision.
+public struct GatewayPersonaOrchestrator: Sendable {
+    /// Personas consulted in sequence for each request.
+    public let personas: [GatewayPersona]
+
+    public init(personas: [GatewayPersona]) {
+        self.personas = personas
+    }
+
+    /// Consults all personas in order and merges their decisions.
+    /// - Parameter request: Incoming HTTP request under evaluation.
+    /// - Returns: The final verdict after consulting all personas.
+    public func decide(for request: HTTPRequest) async -> GatewayPersonaVerdict {
+        var escalation: (String, String)?
+        for persona in personas {
+            let verdict = await persona.evaluate(request)
+            switch verdict {
+            case .allow:
+                continue
+            case .deny:
+                return verdict
+            case .escalate(let reason, let name):
+                if escalation == nil { escalation = (reason, name) }
+            }
+        }
+        if let esc = escalation {
+            return .escalate(reason: esc.0, persona: esc.1)
+        }
+        return .allow
+    }
+}
+
+/// Baseline system persona description outlining collaboration rules.
+public let baselineSystemPersona: String = """
+You are the Gateway Persona Orchestrator. Coordinate specialised personas such as
+SecuritySentinel and DestructiveGuardian. Each persona independently evaluates
+incoming requests and returns *allow*, *deny* or *escalate*. A single *deny*
+from any persona yields an overall denial. If no persona denies but at least one
+escalates, return an *escalate* decision. Only if all personas allow may the
+request proceed.
+"""
+
+// MARK: - Built-in Personas
+
+/// Persona backed by the Security Sentinel service.
+public struct SecuritySentinelPersona: GatewayPersona {
+    public let client: SecuritySentinelClient
+    public var name: String { "SecuritySentinel" }
+
+    public init(client: SecuritySentinelClient = SentinelClientFactory.make()) {
+        self.client = client
+    }
+
+    public func evaluate(_ request: HTTPRequest) async -> GatewayPersonaVerdict {
+        let summary = "\(request.method) \(request.path)"
+        do {
+            let decision = try await client.consult(summary: summary, context: nil)
+            switch decision.decision {
+            case .allow:
+                return .allow
+            case .deny:
+                return .deny(reason: decision.reason, persona: name)
+            case .escalate:
+                return .escalate(reason: decision.reason, persona: name)
+            }
+        } catch {
+            return .escalate(reason: "error: \(error)", persona: name)
+        }
+    }
+}
+
+/// Persona enforcing destructive operation policies.
+public struct DestructiveGuardianPersona: GatewayPersona {
+    private let handlers: Handlers
+    public var name: String { "DestructiveGuardian" }
+
+    public init(sensitivePaths: [String] = ["/"],
+                privilegedTokens: [String] = [],
+                auditURL: URL = URL(fileURLWithPath: "logs/guardian.log")) {
+        self.handlers = Handlers(sensitivePaths: sensitivePaths,
+                                 privilegedTokens: Set(privilegedTokens),
+                                 auditURL: auditURL)
+    }
+
+    public func evaluate(_ request: HTTPRequest) async -> GatewayPersonaVerdict {
+        let body = GuardianEvaluateRequest(method: request.method,
+                                           path: request.path,
+                                           manualApproval: false,
+                                           serviceToken: nil)
+        do {
+            let resp = try await handlers.guardianEvaluate(request, body: body)
+            if let decision = try? JSONDecoder().decode(GuardianEvaluateResponse.self, from: resp.body) {
+                if decision.decision.lowercased() == "allow" {
+                    return .allow
+                } else {
+                    return .deny(reason: "guardian", persona: name)
+                }
+            }
+            return .escalate(reason: "invalid response", persona: name)
+        } catch {
+            return .escalate(reason: "error: \(error)", persona: name)
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add GatewayPersonaOrchestrator module sequencing SecuritySentinel and DestructiveGuardian personas
- introduce baseline system persona for collaborative decision rules
- route GatewayServer requests through the orchestrator before final response

## Testing
- `swift build --target GatewayPersonaOrchestrator` *(timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68b696d6339083339e9b4a78ae7a1af9