### PR TITLE
Fix AuthGatewayPlugin initializer and Linux networking import

### DIFF
--- a/libs/GatewayPlugins/AuthGatewayPlugin/AuthGatewayPlugin/AuthGatewayPlugin.swift
+++ b/libs/GatewayPlugins/AuthGatewayPlugin/AuthGatewayPlugin/AuthGatewayPlugin.swift
@@ -5,8 +5,10 @@ import FountainRuntime
 public struct AuthGatewayPlugin: Sendable {
     public let router: Router
 
-    public init(secret: String = ProcessInfo.processInfo.environment["GATEWAY_JWT_SECRET"] ?? "secret") {
-        self.router = Router(handlers: Handlers(secret: secret))
+    /// Creates a plugin with the supplied router. Defaults to a router with
+    /// a fresh set of handlers.
+    public init(router: Router = Router()) {
+        self.router = router
     }
 }
 

--- a/libs/GatewayPlugins/AuthGatewayPlugin/AuthGatewayPlugin/Handlers.swift
+++ b/libs/GatewayPlugins/AuthGatewayPlugin/AuthGatewayPlugin/Handlers.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import FountainRuntime
 
 /// Collection of handlers for auth gateway endpoints backed by an LLM.


### PR DESCRIPTION
## Summary
- Simplify `AuthGatewayPlugin` to accept a configurable router and remove unused secret parameter
- Enable networking on Linux by conditionally importing `FoundationNetworking` in plugin handlers

## Testing
- `swift test --filter AuthGatewayPluginTests` *(fails: cannot find 'URLRequest' in scope in PayloadInspectionGatewayPlugin/Handlers.swift)*
- `swift build --target AuthGatewayPlugin`


------
https://chatgpt.com/codex/tasks/task_b_68b6a69aca6c8333870e7cb409f68d40