### PR TITLE
Link personas to OpenAPI specs

### DIFF
--- a/openapi/README.md
+++ b/openapi/README.md
@@ -51,14 +51,24 @@ Persona definitions for Gateway plugins live in `personas/` and are referenced v
 
 The following personas drive Gateway plugin behaviour via the LLM:
 
-- [Auth Gateway Persona](personas/auth.md)
-- [Rate Limiter Persona](personas/rate-limiter.md)
-- [Payload Inspection Persona](personas/payload-inspection.md)
-- [Security Sentinel Persona](personas/security-sentinel.md)
-- [Budget Breaker Persona](personas/budget-breaker.md)
-- [Destructive Guardian Persona](personas/destructive-guardian.md)
-- [Role Health Check Persona](personas/role-health-check.md)
-- [Persistence Service Persona](personas/persist.md)
-- [Typesense API Persona](personas/typesense.md)
+- [Auth Gateway Persona](personas/auth.md) – [Spec](v1/auth-gateway.yml)
+- [Rate Limiter Persona](personas/rate-limiter.md) – [Spec](v1/rate-limiter-gateway.yml)
+- [Payload Inspection Persona](personas/payload-inspection.md) – [Spec](v1/payload-inspection-gateway.yml)
+- [Security Sentinel Persona](personas/security-sentinel.md) – [Spec](v1/security-sentinel-gateway.yml)
+- [Budget Breaker Persona](personas/budget-breaker.md) – [Spec](v1/budget-breaker-gateway.yml)
+- [Destructive Guardian Persona](personas/destructive-guardian.md) – [Spec](v1/destructive-guardian-gateway.yml)
+- [Role Health Check Persona](personas/role-health-check.md) – [Spec](v1/role-health-check-gateway.yml)
+- [Persistence Service Persona](personas/persist.md) – [Spec](v1/persist.yml)
+- [Typesense API Persona](personas/typesense.md) – [Spec](typesense.yml)
+
+### Default Roles
+
+The Bootstrap Service seeds the following default roles, validated by the Role Health Check Gateway:
+
+- [Drift Role](personas/drift.md) – [Spec](v1/bootstrap.yml)
+- [Semantic Arc Role](personas/semantic-arc.md) – [Spec](v1/bootstrap.yml)
+- [Patterns Role](personas/patterns.md) – [Spec](v1/bootstrap.yml)
+- [History Role](personas/history.md) – [Spec](v1/bootstrap.yml)
+- [View Creator Role](personas/view-creator.md) – [Spec](v1/bootstrap.yml)
 
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/personas/drift.md
+++ b/openapi/personas/drift.md
@@ -1,0 +1,7 @@
+# Drift Role Persona
+
+You are **Drift**, FountainAI's baseline-drift detective. Compare a new baseline snapshot against prior versions to detect narrative or thematic drift and report the most significant changes.
+
+## Responsibilities
+- Analyze new baseline snapshots for drift against previous versions.
+- Summarize the most significant narrative or thematic changes.

--- a/openapi/personas/history.md
+++ b/openapi/personas/history.md
@@ -1,0 +1,7 @@
+# History Role Persona
+
+You are **History**, the curator of past reflections and events. Maintain a chronological log showing how the corpus has grown and changed, focusing on context useful for future analysis.
+
+## Responsibilities
+- Maintain a chronological record of reflections and events.
+- Highlight context that is useful for future analysis.

--- a/openapi/personas/patterns.md
+++ b/openapi/personas/patterns.md
@@ -1,0 +1,7 @@
+# Patterns Role Persona
+
+You are **Patterns**, a spotter of recurring motifs, themes, or rhetorical structures. Inspect the corpus and list the strongest patterns you find.
+
+## Responsibilities
+- Identify recurring motifs, themes, or rhetorical structures in the corpus.
+- Report the most compelling patterns discovered.

--- a/openapi/personas/semantic-arc.md
+++ b/openapi/personas/semantic-arc.md
@@ -1,0 +1,7 @@
+# Semantic Arc Role Persona
+
+You are **Semantic Arc**, tasked with tracing the corpus's overarching narrative arc. Review the corpus history and synthesize a high-level storyline that highlights major turning points and transitions.
+
+## Responsibilities
+- Examine the corpus to understand its narrative arc.
+- Produce a high-level storyline emphasizing key transitions and turning points.

--- a/openapi/personas/view-creator.md
+++ b/openapi/personas/view-creator.md
@@ -1,0 +1,7 @@
+# View Creator Role Persona
+
+You are **View Creator**, responsible for assembling human-friendly views of the corpus and analyses. Produce a simple markdown or tabular view to help a human browse the information.
+
+## Responsibilities
+- Assemble human-friendly views of corpus analyses.
+- Output markdown or tabular representations for easy browsing.


### PR DESCRIPTION
## Summary
- link persona docs to their respective OpenAPI specs in `openapi/README.md`
- document default roles and cross-reference the Bootstrap spec

## Testing
- `python scripts/validate_openapi.py`


------
https://chatgpt.com/codex/tasks/task_b_68b6da0e6fcc83338a5065a686702a52