### PR TITLE
feat: add FountainStoreClient package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -396,6 +396,11 @@ let fullTargets: [Target] = [
         path: "Tests/ResourceLoaderTests"
     ),
     .testTarget(
+        name: "FountainStoreClientTests",
+        dependencies: ["FountainStoreClient"],
+        path: "Tests/FountainStoreClientTests"
+    ),
+    .testTarget(
         name: "OpenAPIConformanceTests",
         dependencies: ["Yams", "AwarenessService", "BootstrapService", "FountainStoreClient", "FountainRuntime", "RoleHealthCheckGatewayPlugin"],
         path: "Tests/OpenAPIConformanceTests"
@@ -622,6 +627,11 @@ let leanTargets: [Target] = [
         name: "ResourceLoaderTests",
         dependencies: ["ResourceLoader"],
         path: "Tests/ResourceLoaderTests"
+    ),
+    .testTarget(
+        name: "FountainStoreClientTests",
+        dependencies: ["FountainStoreClient"],
+        path: "Tests/FountainStoreClientTests"
     ),
     .testTarget(
         name: "ToolServerTests",

--- a/Tests/FountainStoreClientTests/FountainStoreClientTests.swift
+++ b/Tests/FountainStoreClientTests/FountainStoreClientTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import FountainStoreClient
+
+final class FountainStoreClientTests: XCTestCase {
+    func testCorpusAndDocLifecycle() async throws {
+        let client = FountainStoreClient(client: MockFountainStoreClient())
+        _ = try await client.createCorpus("c1", metadata: ["owner": "me"])
+        let corpus = try await client.getCorpus("c1")
+        XCTAssertNotNil(corpus)
+
+        let body = Data("{\"foo\":\"bar\"}".utf8)
+        try await client.putDoc(corpusId: "c1", collection: "pages", id: "p1", body: body)
+        let fetched = try await client.getDoc(corpusId: "c1", collection: "pages", id: "p1")
+        XCTAssertNotNil(fetched)
+
+        var resp = try await client.query(corpusId: "c1", collection: "pages", query: Query(mode: .byId("p1")))
+        XCTAssertEqual(resp.total, 1)
+
+        try await client.snapshot(corpusId: "c1")
+        try await client.deleteDoc(corpusId: "c1", collection: "pages", id: "p1")
+        resp = try await client.query(corpusId: "c1", collection: "pages", query: Query())
+        XCTAssertEqual(resp.total, 0)
+        try await client.restore(corpusId: "c1")
+        resp = try await client.query(corpusId: "c1", collection: "pages", query: Query())
+        XCTAssertEqual(resp.total, 1)
+
+        try await client.deleteCorpus("c1")
+        let removed = try await client.getCorpus("c1")
+        XCTAssertNil(removed)
+    }
+
+    func testCapabilities() async throws {
+        let client = FountainStoreClient(client: MockFountainStoreClient())
+        let caps = try await client.capabilities()
+        XCTAssertTrue(caps.corpus)
+        XCTAssertTrue(caps.documents.contains("upsert"))
+    }
+}
+

--- a/libs/FountainStoreClient/ClientAbstraction.swift
+++ b/libs/FountainStoreClient/ClientAbstraction.swift
@@ -1,66 +1,164 @@
 import Foundation
 
 public protocol FountainStoreClientProtocol: Sendable {
-    func createCollection(name: String, fields: [(String, String)], defaultSortingField: String?) async throws
-    func upsert(collectionName: String, document: Data) async throws
-    func exportAll(collectionName: String) async throws -> Data
-    func searchFunctions(q: String, filterBy: String?, page: Int, perPage: Int) async throws -> (total: Int, functions: [FunctionModel])
+    // MARK: - Corpus
+    func createCorpus(id: String, metadata: [String: String]) async throws
+    func getCorpus(id: String) async throws -> Corpus?
+    func deleteCorpus(id: String) async throws
+    func listCorpora(limit: Int, offset: Int) async throws -> (total: Int, corpora: [String])
+
+    // MARK: - Documents
+    func putDoc(corpusId: String, collection: String, id: String, body: Data) async throws
+    func getDoc(corpusId: String, collection: String, id: String) async throws -> Data?
+    func deleteDoc(corpusId: String, collection: String, id: String) async throws
+    func query(corpusId: String, collection: String, query: Query) async throws -> QueryResponse
+
+    // MARK: - Capabilities
+    func capabilities() async throws -> Capabilities
+
+    // MARK: - Admin
+    func snapshot(corpusId: String) async throws
+    func restore(corpusId: String) async throws
+    func backup(corpusId: String) async throws
+    func compaction(corpusId: String) async throws
 }
 
 public final class MockFountainStoreClient: FountainStoreClientProtocol, @unchecked Sendable {
-    public private(set) var collections: [String: [[String: Any]]] = [:]
+    private struct StoredCorpus { var metadata: [String: String]; var collections: [String: [String: Data]] }
+    private var corpora: [String: StoredCorpus] = [:]
+    private var snapshots: [String: StoredCorpus] = [:]
 
     public init() {}
 
-    public func createCollection(name: String, fields: [(String, String)], defaultSortingField: String?) async throws {
-        if collections[name] == nil { collections[name] = [] }
+    // MARK: - Corpus
+    public func createCorpus(id: String, metadata: [String: String]) async throws {
+        if corpora[id] == nil { corpora[id] = StoredCorpus(metadata: metadata, collections: [:]) }
     }
 
-    public func upsert(collectionName: String, document: Data) async throws {
-        let obj = try JSONSerialization.jsonObject(with: document) as? [String: Any] ?? [:]
-        var list = collections[collectionName] ?? []
-        let preferredKeys = ["functionId", "baselineId", "reflectionId", "corpusId", "id"]
-        let idKey = preferredKeys.first(where: { obj[$0] is String }) ?? obj.keys.first(where: { $0.hasSuffix("Id") || $0 == "id" })
-        if let idKey, let id = obj[idKey] as? String, !id.isEmpty {
-            if let idx = list.firstIndex(where: { ($0[idKey] as? String) == id }) {
-                list[idx] = obj
-            } else {
-                list.append(obj)
+    public func getCorpus(id: String) async throws -> Corpus? {
+        guard let c = corpora[id] else { return nil }
+        return Corpus(id: id, metadata: c.metadata)
+    }
+
+    public func deleteCorpus(id: String) async throws {
+        corpora.removeValue(forKey: id)
+    }
+
+    public func listCorpora(limit: Int, offset: Int) async throws -> (total: Int, corpora: [String]) {
+        let ids = corpora.keys.sorted()
+        let total = ids.count
+        let slice = Array(ids.dropFirst(min(offset, total)).prefix(limit))
+        return (total, slice)
+    }
+
+    // MARK: - Documents
+    public func putDoc(corpusId: String, collection: String, id: String, body: Data) async throws {
+        var corpus = corpora[corpusId] ?? StoredCorpus(metadata: [:], collections: [:])
+        var coll = corpus.collections[collection] ?? [:]
+        coll[id] = body
+        corpus.collections[collection] = coll
+        corpora[corpusId] = corpus
+    }
+
+    public func getDoc(corpusId: String, collection: String, id: String) async throws -> Data? {
+        if corpusId.isEmpty {
+            for corpus in corpora.values {
+                if let data = corpus.collections[collection]?[id] { return data }
+            }
+            return nil
+        }
+        return corpora[corpusId]?.collections[collection]?[id]
+    }
+
+    public func deleteDoc(corpusId: String, collection: String, id: String) async throws {
+        if corpusId.isEmpty {
+            for key in corpora.keys {
+                corpora[key]?.collections[collection]?[id] = nil
             }
         } else {
-            list.append(obj)
+            corpora[corpusId]?.collections[collection]?[id] = nil
         }
-        collections[collectionName] = list
     }
 
-    public func exportAll(collectionName: String) async throws -> Data {
-        let list = collections[collectionName] ?? []
-        let lines = try list.map { try JSONSerialization.data(withJSONObject: $0) }.map { String(data: $0, encoding: .utf8) ?? "{}" }
-        return Data(lines.joined(separator: "\n").utf8)
+    public func query(corpusId: String, collection: String, query: Query) async throws -> QueryResponse {
+        var docs: [Data] = []
+        if corpusId.isEmpty {
+            for corpus in corpora.values {
+                if let coll = corpus.collections[collection] {
+                    docs.append(contentsOf: coll.values)
+                }
+            }
+        } else if let coll = corpora[corpusId]?.collections[collection] {
+            docs.append(contentsOf: coll.values)
+        }
+
+        func decode(_ data: Data) -> [String: Any] {
+            (try? JSONSerialization.jsonObject(with: data) as? [String: Any]) ?? [:]
+        }
+
+        if let mode = query.mode {
+            switch mode {
+            case .byId(let id):
+                if let data = try await getDoc(corpusId: corpusId, collection: collection, id: id) {
+                    return QueryResponse(total: 1, documents: [data])
+                } else { return QueryResponse(total: 0, documents: []) }
+            case .byIndexEq(let field, let value):
+                docs = docs.filter { decode($0)[field] as? String == value }
+            case .prefixScan(let field, let prefix):
+                docs = docs.filter { (decode($0)[field] as? String)?.hasPrefix(prefix) == true }
+            }
+        }
+
+        if !query.filters.isEmpty {
+            docs = docs.filter { data in
+                let obj = decode(data)
+                for (k, v) in query.filters { if (obj[k] as? String) != v { return false } }
+                return true
+            }
+        }
+
+        if let first = query.sort.first {
+            let field = first.field
+            let asc = first.ascending
+            docs.sort { a, b in
+                let av = decode(a)[field] as? String ?? ""
+                let bv = decode(b)[field] as? String ?? ""
+                return asc ? (av < bv) : (av > bv)
+            }
+        }
+
+        let total = docs.count
+        let offset = min(query.offset ?? 0, total)
+        let limit = query.limit ?? total
+        let slice = Array(docs.dropFirst(offset).prefix(limit))
+        return QueryResponse(total: total, documents: slice)
     }
 
-    public func searchFunctions(q: String, filterBy: String?, page: Int, perPage: Int) async throws -> (total: Int, functions: [FunctionModel]) {
-        let all = collections["functions"] ?? []
-        let needle = q == "*" ? nil : q.lowercased()
-        let filtered: [[String: Any]] = all.filter { obj in
-            if let fb = filterBy, fb.hasPrefix("corpusId:=") {
-                let val = String(fb.dropFirst("corpusId:=".count))
-                if (obj["corpusId"] as? String) != val { return false }
-            }
-            if let needle {
-                let fields = ["name","description","httpPath","functionId","corpusId"]
-                return fields.contains { key in (obj[key] as? String)?.lowercased().contains(needle) == true }
-            }
-            return true
-        }
-        let decoded: [FunctionModel] = try filtered.map { data in
-            let d = try JSONSerialization.data(withJSONObject: data)
-            return try JSONDecoder().decode(FunctionModel.self, from: d)
-        }.sorted { $0.functionId < $1.functionId }
-        let start = max((page - 1) * perPage, 0)
-        let slice = Array(decoded.dropFirst(min(start, decoded.count)).prefix(perPage))
-        return (decoded.count, slice)
+    // MARK: - Capabilities
+    public func capabilities() async throws -> Capabilities {
+        Capabilities(
+            corpus: true,
+            documents: ["upsert", "get", "delete"],
+            query: ["byId", "byIndexEq", "prefixScan", "filters", "sort"],
+            transactions: ["snapshot", "restore"],
+            admin: ["health", "backup", "compaction", "metrics"],
+            experimental: []
+        )
     }
+
+    // MARK: - Admin
+    public func snapshot(corpusId: String) async throws {
+        if let c = corpora[corpusId] { snapshots[corpusId] = c }
+    }
+
+    public func restore(corpusId: String) async throws {
+        if let snap = snapshots[corpusId] { corpora[corpusId] = snap }
+    }
+
+    public func backup(corpusId: String) async throws {}
+
+    public func compaction(corpusId: String) async throws {}
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+

--- a/libs/FountainStoreClient/FountainStoreClient.swift
+++ b/libs/FountainStoreClient/FountainStoreClient.swift
@@ -11,118 +11,112 @@ public actor FountainStoreClient {
         self.client = client
     }
 
-    // MARK: - Collections
-    public func ensureCollections() async {
-        try? await client.createCollection(name: "corpora", fields: [("corpusId", "string")], defaultSortingField: "corpusId")
-        try? await client.createCollection(name: "baselines", fields: [("corpusId", "string"), ("baselineId", "string"), ("content", "string"), ("ts", "float")], defaultSortingField: "baselineId")
-        try? await client.createCollection(name: "reflections", fields: [("corpusId", "string"), ("reflectionId", "string"), ("question", "string"), ("content", "string"), ("ts", "float")], defaultSortingField: "reflectionId")
-        try? await client.createCollection(name: "drifts", fields: [("corpusId", "string"), ("driftId", "string"), ("content", "string"), ("ts", "float")], defaultSortingField: "driftId")
-        try? await client.createCollection(name: "patterns", fields: [("corpusId", "string"), ("patternsId", "string"), ("content", "string"), ("ts", "float")], defaultSortingField: "patternsId")
-        try? await client.createCollection(name: "roles", fields: [("corpusId", "string"), ("name", "string"), ("prompt", "string")], defaultSortingField: "name")
-        try? await client.createCollection(name: "functions", fields: [("corpusId", "string"), ("functionId", "string"), ("name", "string"), ("description", "string"), ("httpMethod", "string"), ("httpPath", "string")], defaultSortingField: "functionId")
+    // MARK: - Corpus
+    public func createCorpus(_ id: String, metadata: [String: String] = [:]) async throws -> CorpusResponse {
+        try await client.createCorpus(id: id, metadata: metadata)
+        return CorpusResponse(corpusId: id, message: "created")
     }
 
-    // MARK: - Corpora
     public func createCorpus(_ req: CorpusCreateRequest) async throws -> CorpusResponse {
-        await ensureCollections()
-        let payload = try JSONEncoder().encode(["corpusId": req.corpusId])
-        try await client.upsert(collectionName: "corpora", document: payload)
-        return CorpusResponse(corpusId: req.corpusId, message: "created")
+        try await createCorpus(req.corpusId)
+    }
+
+    public func getCorpus(_ id: String) async throws -> Corpus? {
+        try await client.getCorpus(id: id)
+    }
+
+    public func deleteCorpus(_ id: String) async throws {
+        try await client.deleteCorpus(id: id)
     }
 
     public func listCorpora(limit: Int = 50, offset: Int = 0) async throws -> (total: Int, corpora: [String]) {
-        await ensureCollections()
-        let data = try await client.exportAll(collectionName: "corpora")
-        let items: [[String: Any]] = Self.parseJSONL(data)
-        let ids = items.compactMap { $0["corpusId"] as? String }.sorted()
-        let total = ids.count
-        let slice = Array(ids.dropFirst(min(offset, total)).prefix(limit))
-        return (total, slice)
+        try await client.listCorpora(limit: limit, offset: offset)
     }
 
-    // MARK: - Baselines
+    // MARK: - Documents
+    public func putDoc(corpusId: String, collection: String, id: String, body: Data) async throws {
+        try await client.putDoc(corpusId: corpusId, collection: collection, id: id, body: body)
+    }
+
+    public func getDoc(corpusId: String, collection: String, id: String) async throws -> Data? {
+        try await client.getDoc(corpusId: corpusId, collection: collection, id: id)
+    }
+
+    public func deleteDoc(corpusId: String, collection: String, id: String) async throws {
+        try await client.deleteDoc(corpusId: corpusId, collection: collection, id: id)
+    }
+
+    public func query(corpusId: String, collection: String, query: Query) async throws -> QueryResponse {
+        try await client.query(corpusId: corpusId, collection: collection, query: query)
+    }
+
+    // MARK: - Capabilities
+    public func capabilities() async throws -> Capabilities {
+        try await client.capabilities()
+    }
+
+    // MARK: - Admin
+    public func snapshot(corpusId: String) async throws { try await client.snapshot(corpusId: corpusId) }
+    public func restore(corpusId: String) async throws { try await client.restore(corpusId: corpusId) }
+    public func backup(corpusId: String) async throws { try await client.backup(corpusId: corpusId) }
+    public func compaction(corpusId: String) async throws { try await client.compaction(corpusId: corpusId) }
+
+    // MARK: - Convenience Helpers
     public func addBaseline(_ baseline: Baseline) async throws -> SuccessResponse {
-        await ensureCollections()
         let payload = try JSONEncoder().encode(baseline)
-        try await client.upsert(collectionName: "baselines", document: payload)
+        try await putDoc(corpusId: baseline.corpusId, collection: "baselines", id: baseline.baselineId, body: payload)
         return SuccessResponse(message: "ok")
     }
 
     public func listBaselines(corpusId: String, limit: Int = 50, offset: Int = 0) async throws -> (total: Int, baselines: [Baseline]) {
-        await ensureCollections()
-        let data = try await client.exportAll(collectionName: "baselines")
-        let items: [[String: Any]] = Self.parseJSONL(data)
-        let filtered = items.filter { ($0["corpusId"] as? String) == corpusId }
-        let decoded: [Baseline] = try filtered.map { try Self.decode($0) }
-        let total = decoded.count
-        let slice = Array(decoded.dropFirst(min(offset, total)).prefix(limit))
-        return (total, slice)
-     }
+        let q = Query(filters: ["corpusId": corpusId], limit: limit, offset: offset)
+        let resp = try await query(corpusId: corpusId, collection: "baselines", query: q)
+        let list = try resp.documents.map { try JSONDecoder().decode(Baseline.self, from: $0) }
+        return (resp.total, list)
+    }
 
-    // MARK: - Reflections
     public func addReflection(_ reflection: Reflection) async throws -> SuccessResponse {
-        await ensureCollections()
         let payload = try JSONEncoder().encode(reflection)
-        try await client.upsert(collectionName: "reflections", document: payload)
+        try await putDoc(corpusId: reflection.corpusId, collection: "reflections", id: reflection.reflectionId, body: payload)
         return SuccessResponse(message: "ok")
     }
 
     public func listReflections(corpusId: String, limit: Int = 50, offset: Int = 0) async throws -> (total: Int, reflections: [Reflection]) {
-        await ensureCollections()
-        let data = try await client.exportAll(collectionName: "reflections")
-        let items: [[String: Any]] = Self.parseJSONL(data)
-        let filtered = items.filter { ($0["corpusId"] as? String) == corpusId }
-        let decoded: [Reflection] = try filtered.map { try Self.decode($0) }
-        let total = decoded.count
-        let slice = Array(decoded.dropFirst(min(offset, total)).prefix(limit))
-        return (total, slice)
-     }
-
-    // MARK: - Drifts
-    public func listDrifts(corpusId: String, limit: Int = 50, offset: Int = 0) async throws -> (total: Int, drifts: [Drift]) {
-        await ensureCollections()
-        let data = try await client.exportAll(collectionName: "drifts")
-        let items: [[String: Any]] = Self.parseJSONL(data)
-        let filtered = items.filter { ($0["corpusId"] as? String) == corpusId }
-        let decoded: [Drift] = try filtered.map { try Self.decode($0) }
-        let total = decoded.count
-        let slice = Array(decoded.dropFirst(min(offset, total)).prefix(limit))
-        return (total, slice)
+        let q = Query(filters: ["corpusId": corpusId], limit: limit, offset: offset)
+        let resp = try await query(corpusId: corpusId, collection: "reflections", query: q)
+        let list = try resp.documents.map { try JSONDecoder().decode(Reflection.self, from: $0) }
+        return (resp.total, list)
     }
 
-    // MARK: - Patterns
-    public func listPatterns(corpusId: String, limit: Int = 50, offset: Int = 0) async throws -> (total: Int, patterns: [Patterns]) {
-        await ensureCollections()
-        let data = try await client.exportAll(collectionName: "patterns")
-        let items: [[String: Any]] = Self.parseJSONL(data)
-        let filtered = items.filter { ($0["corpusId"] as? String) == corpusId }
-        let decoded: [Patterns] = try filtered.map { try Self.decode($0) }
-        let total = decoded.count
-        let slice = Array(decoded.dropFirst(min(offset, total)).prefix(limit))
-        return (total, slice)
-    }
-
-    // MARK: - Drift
     public func addDrift(_ drift: Drift) async throws -> SuccessResponse {
-        await ensureCollections()
         let payload = try JSONEncoder().encode(drift)
-        try await client.upsert(collectionName: "drifts", document: payload)
+        try await putDoc(corpusId: drift.corpusId, collection: "drifts", id: drift.driftId, body: payload)
         return SuccessResponse(message: "ok")
     }
 
-    // MARK: - Patterns
+    public func listDrifts(corpusId: String, limit: Int = 50, offset: Int = 0) async throws -> (total: Int, drifts: [Drift]) {
+        let q = Query(filters: ["corpusId": corpusId], limit: limit, offset: offset)
+        let resp = try await query(corpusId: corpusId, collection: "drifts", query: q)
+        let list = try resp.documents.map { try JSONDecoder().decode(Drift.self, from: $0) }
+        return (resp.total, list)
+    }
+
     public func addPatterns(_ patterns: Patterns) async throws -> SuccessResponse {
-        await ensureCollections()
         let payload = try JSONEncoder().encode(patterns)
-        try await client.upsert(collectionName: "patterns", document: payload)
+        try await putDoc(corpusId: patterns.corpusId, collection: "patterns", id: patterns.patternsId, body: payload)
         return SuccessResponse(message: "ok")
     }
 
-    // MARK: - Roles
+    public func listPatterns(corpusId: String, limit: Int = 50, offset: Int = 0) async throws -> (total: Int, patterns: [Patterns]) {
+        let q = Query(filters: ["corpusId": corpusId], limit: limit, offset: offset)
+        let resp = try await query(corpusId: corpusId, collection: "patterns", query: q)
+        let list = try resp.documents.map { try JSONDecoder().decode(Patterns.self, from: $0) }
+        return (resp.total, list)
+    }
+
     public func addRole(_ role: Role) async throws -> SuccessResponse {
-        await ensureCollections()
         let payload = try JSONEncoder().encode(role)
-        try await client.upsert(collectionName: "roles", document: payload)
+        try await putDoc(corpusId: role.corpusId, collection: "roles", id: role.name, body: payload)
         return SuccessResponse(message: "ok")
     }
 
@@ -131,52 +125,48 @@ public actor FountainStoreClient {
         return SuccessResponse(message: "seeded")
     }
 
-    // MARK: - Functions
     public func addFunction(_ function: FunctionModel) async throws -> SuccessResponse {
-        await ensureCollections()
         let payload = try JSONEncoder().encode(function)
-        try await client.upsert(collectionName: "functions", document: payload)
+        try await putDoc(corpusId: function.corpusId, collection: "functions", id: function.functionId, body: payload)
         return SuccessResponse(message: "ok")
     }
 
     public func listFunctions(limit: Int = 50, offset: Int = 0, q: String? = nil) async throws -> (total: Int, functions: [FunctionModel]) {
-        await ensureCollections()
-        let page = max(offset / max(limit, 1) + 1, 1)
-        let perPage = max(limit, 1)
-        let (total, results) = try await client.searchFunctions(q: (q?.isEmpty == false ? q! : "*"), filterBy: nil, page: page, perPage: perPage)
-        return (total, results)
+        let resp = try await query(corpusId: "", collection: "functions", query: Query())
+        var list = try resp.documents.map { try JSONDecoder().decode(FunctionModel.self, from: $0) }
+        if let q = q, !q.isEmpty, q != "*" {
+            let needle = q.lowercased()
+            list = list.filter { fn in
+                [fn.name, fn.description, fn.httpPath, fn.functionId, fn.corpusId]
+                    .contains { $0.lowercased().contains(needle) }
+            }
+        }
+        let total = list.count
+        let slice = Array(list.dropFirst(min(offset, total)).prefix(limit))
+        return (total, slice)
     }
 
     public func getFunctionDetails(functionId: String) async throws -> FunctionModel? {
-        let (_, list) = try await listFunctions(limit: Int.max, offset: 0)
-        return list.first { $0.functionId == functionId }
+        let resp = try await query(corpusId: "", collection: "functions", query: Query(mode: .byId(functionId)))
+        return resp.documents.first.flatMap { try? JSONDecoder().decode(FunctionModel.self, from: $0) }
     }
 
     public func listFunctions(corpusId: String, limit: Int = 50, offset: Int = 0, q: String? = nil) async throws -> (total: Int, functions: [FunctionModel]) {
-        await ensureCollections()
-        let page = max(offset / max(limit, 1) + 1, 1)
-        let perPage = max(limit, 1)
-        let filterBy = "corpusId:=\(corpusId)"
-        let (total, results) = try await client.searchFunctions(q: (q?.isEmpty == false ? q! : "*"), filterBy: filterBy, page: page, perPage: perPage)
-        return (total, results)
-    }
-
-    // MARK: - Helpers
-    static func parseJSONL(_ data: Data) -> [[String: Any]] {
-        let str = String(data: data, encoding: .utf8) ?? ""
-        var out: [[String: Any]] = []
-        for line in str.split(separator: "\n") {
-            if let d = String(line).data(using: .utf8), let obj = try? JSONSerialization.jsonObject(with: d) as? [String: Any] {
-                out.append(obj)
+        let qobj = Query(filters: ["corpusId": corpusId])
+        let resp = try await query(corpusId: corpusId, collection: "functions", query: qobj)
+        var list = try resp.documents.map { try JSONDecoder().decode(FunctionModel.self, from: $0) }
+        if let q = q, !q.isEmpty, q != "*" {
+            let needle = q.lowercased()
+            list = list.filter { fn in
+                [fn.name, fn.description, fn.httpPath, fn.functionId, fn.corpusId]
+                    .contains { $0.lowercased().contains(needle) }
             }
         }
-        return out
-    }
-
-    static func decode<T: Decodable>(_ obj: [String: Any]) throws -> T {
-        let data = try JSONSerialization.data(withJSONObject: obj)
-        return try JSONDecoder().decode(T.self, from: data)
+        let total = list.count
+        let slice = Array(list.dropFirst(min(offset, total)).prefix(limit))
+        return (total, slice)
     }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+

--- a/libs/FountainStoreClient/Models.swift
+++ b/libs/FountainStoreClient/Models.swift
@@ -1,5 +1,14 @@
 import Foundation
 
+public struct Corpus: Codable, Sendable {
+    public let id: String
+    public var metadata: [String: String]
+    public init(id: String, metadata: [String: String] = [:]) {
+        self.id = id
+        self.metadata = metadata
+    }
+}
+
 public struct CorpusCreateRequest: Codable, Sendable {
     public let corpusId: String
     public init(corpusId: String) { self.corpusId = corpusId }
@@ -76,6 +85,52 @@ public struct Role: Codable, Sendable {
         self.corpusId = corpusId
         self.name = name
         self.prompt = prompt
+    }
+}
+
+public struct Query: Sendable {
+    public enum Mode: Sendable {
+        case byId(String)
+        case byIndexEq(String, String)
+        case prefixScan(String, String)
+    }
+    public var mode: Mode?
+    public var filters: [String: String]
+    public var sort: [(field: String, ascending: Bool)]
+    public var limit: Int?
+    public var offset: Int?
+    public init(mode: Mode? = nil, filters: [String: String] = [:], sort: [(field: String, ascending: Bool)] = [], limit: Int? = nil, offset: Int? = nil) {
+        self.mode = mode
+        self.filters = filters
+        self.sort = sort
+        self.limit = limit
+        self.offset = offset
+    }
+}
+
+public struct QueryResponse: Sendable {
+    public let total: Int
+    public let documents: [Data]
+    public init(total: Int, documents: [Data]) {
+        self.total = total
+        self.documents = documents
+    }
+}
+
+public struct Capabilities: Codable, Sendable {
+    public var corpus: Bool
+    public var documents: [String]
+    public var query: [String]
+    public var transactions: [String]
+    public var admin: [String]
+    public var experimental: [String]
+    public init(corpus: Bool = true, documents: [String] = [], query: [String] = [], transactions: [String] = [], admin: [String] = [], experimental: [String] = []) {
+        self.corpus = corpus
+        self.documents = documents
+        self.query = query
+        self.transactions = transactions
+        self.admin = admin
+        self.experimental = experimental
     }
 }
 


### PR DESCRIPTION
## Summary
- add FountainStoreClient protocol with corpus and document operations plus mock implementation
- expose corpus-first API helpers for roles, baselines, and functions
- introduce dedicated tests for core FountainStoreClient behavior

## Testing
- `swift test --filter FountainStoreClientTests`


------
https://chatgpt.com/codex/tasks/task_b_68b83ae9bd648333ae0a1df36e7da18d