### PR TITLE
refactor: switch to FountainStore env vars

### DIFF
--- a/internal/FountainOps/Generated/Server/Server/Shared/TypesenseClient.swift
+++ b/internal/FountainOps/Generated/Server/Server/Shared/TypesenseClient.swift
@@ -12,8 +12,8 @@ private struct BaselineList: Codable {
     let baselines: [Baseline]
 }
 
-/// Optional remote Typesense configuration loaded from the environment.
-/// When `TYPESENSE_URL` is set the client will persist data using HTTP
+/// Optional remote FountainStore configuration loaded from the environment.
+/// When `FOUNTAINSTORE_URL` is set the client will persist data using HTTP
 /// requests instead of the in-memory store.
 
 /// Minimal in-memory representation of a Typesense service used for testing.
@@ -55,9 +55,9 @@ public actor TypesenseClient {
                 self.functions = cached
             }
         }
-        if let url = ProcessInfo.processInfo.environment["TYPESENSE_URL"] {
+        if let url = ProcessInfo.processInfo.environment["FOUNTAINSTORE_URL"] {
             self.baseURL = URL(string: url)
-            self.apiKey = ProcessInfo.processInfo.environment["TYPESENSE_API_KEY"]
+            self.apiKey = ProcessInfo.processInfo.environment["FOUNTAINSTORE_API_KEY"]
         } else {
             self.baseURL = nil
             self.apiKey = nil

--- a/internal/FountainOps/Generated/Server/Server/typesense/HTTPKernel.swift
+++ b/internal/FountainOps/Generated/Server/Server/typesense/HTTPKernel.swift
@@ -5,7 +5,7 @@ public struct HTTPKernel {
     let proxyKey: String?
 
     public init(handlers: Handlers = Handlers(),
-                proxyKey: String? = ProcessInfo.processInfo.environment["TYPESENSE_PROXY_KEY"]) {
+                proxyKey: String? = ProcessInfo.processInfo.environment["FOUNTAINSTORE_PROXY_KEY"]) {
         self.router = Router(handlers: handlers)
         self.proxyKey = proxyKey
     }

--- a/internal/FountainOps/Generated/Server/Server/typesense/TypesenseService.swift
+++ b/internal/FountainOps/Generated/Server/Server/typesense/TypesenseService.swift
@@ -10,9 +10,9 @@ public enum TypesenseServiceError: LocalizedError {
 
     public var errorDescription: String? {
         switch self {
-        case .missingURL: return "TYPESENSE_URL environment variable is not set"
-        case .missingAPIKey: return "TYPESENSE_API_KEY environment variable is not set"
-        case .invalidURL(let value): return "TYPESENSE_URL is invalid: \(value)"
+        case .missingURL: return "FOUNTAINSTORE_URL environment variable is not set"
+        case .missingAPIKey: return "FOUNTAINSTORE_API_KEY environment variable is not set"
+        case .invalidURL(let value): return "FOUNTAINSTORE_URL is invalid: \(value)"
         }
     }
 }
@@ -22,16 +22,16 @@ public final actor TypesenseService {
 
     public init(environment: [String: String] = ProcessInfo.processInfo.environment,
                 session: HTTPSession = URLSession.shared) throws {
-        guard let urlString = environment["TYPESENSE_URL"], !urlString.isEmpty else {
+        guard let urlString = environment["FOUNTAINSTORE_URL"], !urlString.isEmpty else {
             throw TypesenseServiceError.missingURL
         }
-        guard let apiKey = environment["TYPESENSE_API_KEY"], !apiKey.isEmpty else {
+        guard let apiKey = environment["FOUNTAINSTORE_API_KEY"], !apiKey.isEmpty else {
             throw TypesenseServiceError.missingAPIKey
         }
         guard let url = URL(string: urlString) else {
             throw TypesenseServiceError.invalidURL(urlString)
         }
-        self.client = APIClient(baseURL: url, session: session, defaultHeaders: ["X-TYPESENSE-API-KEY": apiKey])
+        self.client = APIClient(baseURL: url, session: session, defaultHeaders: ["X-FOUNTAINSTORE-API-KEY": apiKey])
     }
 
     public func listCollections() async throws -> getCollectionsResponse {

--- a/platform/FountainAILauncher/README.md
+++ b/platform/FountainAILauncher/README.md
@@ -32,12 +32,11 @@ This README covers operations and deployment. For the golden-key specification a
 | Bootstrap              | `bootstrap`            | 8002  | Corpus and rules initializer |
 | Planner                | `planner`              | 8003  | Delegates tasks and goals |
 | Function Caller        | `function-caller`      | 8004  | Maps operationIds to HTTP |
-| Persist                | `persist`              | 8005  | Typesense-backed corpus storage |
+| Persist                | `persist`              | 8005  | FountainStore-backed corpus storage |
 | **LLM Gateway**        | `llm-gateway`          | 8006  | Connects to external LLMs (OpenAI, Claude) |
 | Semantic Browser       | `semantic-browser`     | 8007  | Headless browsing and semantic dissection |
 | **Gateway**            | `fountain-gateway`     | 8010  | HTTPS, authentication, route proxying |
 | Tools Factory          | `tools-factory`        | 8011  | Registers callable OpenAPI tools |
-| Typesense              | `typesense`            | 8100  | Swift-native wrapper around Typesense |
 
 ---
 
@@ -99,7 +98,6 @@ The launcher expects the following executables to exist on disk. Install each se
 | Semantic Browser     | `/usr/local/bin/semantic-browser`         |
 | Gateway              | `/usr/local/bin/fountain-gateway`         |
 | Tools Factory        | `/usr/local/bin/tools-factory`            |
-| Typesense            | `/usr/local/bin/typesense`                |
 
 ---
 

--- a/platform/FountainAILauncher/Sources/Diagnostics/Diagnostics.swift
+++ b/platform/FountainAILauncher/Sources/Diagnostics/Diagnostics.swift
@@ -15,7 +15,7 @@ enum DiagnosticsError: Error, CustomStringConvertible {
 }
 
 struct Diagnostics {
-    static let requiredKeys = ["OPENAI_API_KEY", "TYPESENSE_URL", "TYPESENSE_API_KEY"]
+    static let requiredKeys = ["OPENAI_API_KEY", "FOUNTAINSTORE_URL", "FOUNTAINSTORE_API_KEY"]
 
     static func loadEnv() throws {
         let url = URL(fileURLWithPath: ".env")

--- a/platform/FountainAILauncher/Sources/services.json
+++ b/platform/FountainAILauncher/Sources/services.json
@@ -61,12 +61,5 @@
     "binaryPath" : "\/usr\/local\/bin\/tools-factory",
     "port" : 8011,
     "shouldRestart" : true
-  },
-  {
-    "healthPath" : "\/metrics",
-    "name" : "Typesense",
-    "binaryPath" : "\/usr\/local\/bin\/typesense",
-    "port" : 8100,
-    "shouldRestart" : true
   }
 ]

--- a/platform/FountainAILauncher/agent.md
+++ b/platform/FountainAILauncher/agent.md
@@ -18,8 +18,8 @@ For runtime usage and deployment instructions, consult [README.md](README.md).
 ## 🧱 Build-Time Responsibilities
 1. Load `.env` (or injected environment) and verify required secrets:
    - `OPENAI_API_KEY`
-   - `TYPESENSE_URL`
-   - `TYPESENSE_API_KEY`
+   - `FOUNTAINSTORE_URL`
+   - `FOUNTAINSTORE_API_KEY`
    - any gateway credentials and TLS config
 2. Run diagnostics equivalent to `scripts/start-diagnostics.swift`.
 3. Execute `swift build --configuration release` for every package.

--- a/scripts/boot.sh
+++ b/scripts/boot.sh
@@ -25,7 +25,7 @@ LAUNCH_DEMO="${LAUNCH_DEMO:-1}"
 # Step 1: verify required environment variables
 if [[ "$CHECK_ENV" == "1" ]]; then
   echo "==> Checking environment variables"
-  REQUIRED_VARS=(OPENAI_API_KEY TYPESENSE_URL TYPESENSE_API_KEY)
+  REQUIRED_VARS=(OPENAI_API_KEY FOUNTAINSTORE_URL FOUNTAINSTORE_API_KEY)
   for var in "${REQUIRED_VARS[@]}"; do
     if [[ -z "${!var:-}" ]]; then
       echo "Missing required env var: $var" >&2

--- a/scripts/generate-service-registry.swift
+++ b/scripts/generate-service-registry.swift
@@ -25,8 +25,7 @@ let templates: [Template] = [
     Template(name: "LLM Gateway", binary: "llm-gateway", port: 8006, healthPath: "/metrics", shouldRestart: true),
     Template(name: "Semantic Browser", binary: "semantic-browser", port: 8007, healthPath: "/metrics", shouldRestart: true),
     Template(name: "Gateway", binary: "fountain-gateway", port: 8010, healthPath: "/metrics", shouldRestart: true),
-    Template(name: "Tools Factory", binary: "tools-factory", port: 8011, healthPath: "/metrics", shouldRestart: true),
-    Template(name: "Typesense", binary: "typesense", port: 8100, healthPath: "/metrics", shouldRestart: true)
+    Template(name: "Tools Factory", binary: "tools-factory", port: 8011, healthPath: "/metrics", shouldRestart: true)
 ]
 
 let servicesDir = ProcessInfo.processInfo.environment["FOUNTAINAI_SERVICES_DIR"] ?? "/usr/local/bin"

--- a/scripts/start-diagnostics.swift
+++ b/scripts/start-diagnostics.swift
@@ -45,7 +45,7 @@ if fm.fileExists(atPath: servicesURL.path) {
     fail("Services configuration not found at \(servicesURL.path)")
 }
 
-let requiredEnv = ["OPENAI_API_KEY", "TYPESENSE_URL", "TYPESENSE_API_KEY"]
+let requiredEnv = ["OPENAI_API_KEY", "FOUNTAINSTORE_URL", "FOUNTAINSTORE_API_KEY"]
 let env = ProcessInfo.processInfo.environment
 for key in requiredEnv {
     if let value = env[key], !value.isEmpty {


### PR DESCRIPTION
## Summary
- replace Typesense env checks with FOUNTAINSTORE_URL and FOUNTAINSTORE_API_KEY
- drop Typesense service from launcher registry and docs
- update generated Typesense service to read FountainStore variables

## Testing
- `swift test --filter FountainStoreClientTests`

------
https://chatgpt.com/codex/tasks/task_b_68b83df0ab7c8333b1ab13262c01434b