### PR TITLE
feat: add corpus collection helpers

### DIFF
--- a/Tests/FountainStoreClientTests/FountainStoreClientTests.swift
+++ b/Tests/FountainStoreClientTests/FountainStoreClientTests.swift
@@ -35,5 +35,31 @@ final class FountainStoreClientTests: XCTestCase {
         XCTAssertTrue(caps.corpus)
         XCTAssertTrue(caps.documents.contains("upsert"))
     }
+
+    func testCollectionHelpers() async throws {
+        let client = FountainStoreClient(client: MockFountainStoreClient())
+        _ = try await client.createCorpus("c2")
+        let page = Page(corpusId: "c2", pageId: "p1", url: "https://ex.com", host: "ex.com", title: "Ex")
+        _ = try await client.addPage(page)
+        let segment = Segment(corpusId: "c2", segmentId: "s1", pageId: "p1", kind: "paragraph", text: "hello")
+        _ = try await client.addSegment(segment)
+        let entity = Entity(corpusId: "c2", entityId: "e1", name: "Foo", type: "PERSON")
+        _ = try await client.addEntity(entity)
+        let table = Table(corpusId: "c2", tableId: "t1", pageId: "p1", csv: "a,b\n1,2")
+        _ = try await client.addTable(table)
+        let analysis = AnalysisRecord(corpusId: "c2", analysisId: "a1", pageId: "p1", summary: "ok")
+        _ = try await client.addAnalysis(analysis)
+
+        let (_, pages) = try await client.listPages(corpusId: "c2")
+        XCTAssertEqual(pages.first?.pageId, "p1")
+        let (_, segments) = try await client.listSegments(corpusId: "c2")
+        XCTAssertEqual(segments.first?.segmentId, "s1")
+        let (_, entities) = try await client.listEntities(corpusId: "c2")
+        XCTAssertEqual(entities.first?.entityId, "e1")
+        let (_, tables) = try await client.listTables(corpusId: "c2")
+        XCTAssertEqual(tables.first?.tableId, "t1")
+        let (_, analyses) = try await client.listAnalyses(corpusId: "c2")
+        XCTAssertEqual(analyses.first?.analysisId, "a1")
+    }
 }
 

--- a/docs/fountainstore-collections.md
+++ b/docs/fountainstore-collections.md
@@ -1,0 +1,38 @@
+# FountainStore Corpus Collections
+
+All persisted artifacts live under `/corpora/{corpusId}/collections/{name}`.
+The following collections are used across FountainAI services:
+
+## pages
+- `corpusId` – owning corpus
+- `pageId` – unique page identifier
+- `url` – canonical page URL
+- `host` – host component of the URL
+- `title` – page title
+
+## segments
+- `corpusId` – owning corpus
+- `segmentId` – unique segment identifier
+- `pageId` – parent page reference
+- `kind` – semantic segment kind (e.g., paragraph, heading)
+- `text` – segment content
+
+## entities
+- `corpusId` – owning corpus
+- `entityId` – unique entity identifier
+- `name` – entity surface form
+- `type` – entity category label
+
+## tables
+- `corpusId` – owning corpus
+- `tableId` – unique table identifier
+- `pageId` – parent page reference
+- `csv` – table serialized as CSV
+
+## analyses
+- `corpusId` – owning corpus
+- `analysisId` – unique analysis identifier
+- `pageId` – related page reference
+- `summary` – short description of the analysis
+
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/FountainStoreClient/FountainStoreClient.swift
+++ b/libs/FountainStoreClient/FountainStoreClient.swift
@@ -62,6 +62,71 @@ public actor FountainStoreClient {
     public func compaction(corpusId: String) async throws { try await client.compaction(corpusId: corpusId) }
 
     // MARK: - Convenience Helpers
+    public func addPage(_ page: Page) async throws -> SuccessResponse {
+        let payload = try JSONEncoder().encode(page)
+        try await putDoc(corpusId: page.corpusId, collection: "pages", id: page.pageId, body: payload)
+        return SuccessResponse(message: "ok")
+    }
+
+    public func listPages(corpusId: String, limit: Int = 50, offset: Int = 0) async throws -> (total: Int, pages: [Page]) {
+        let q = Query(filters: ["corpusId": corpusId], limit: limit, offset: offset)
+        let resp = try await query(corpusId: corpusId, collection: "pages", query: q)
+        let list = try resp.documents.map { try JSONDecoder().decode(Page.self, from: $0) }
+        return (resp.total, list)
+    }
+
+    public func addSegment(_ segment: Segment) async throws -> SuccessResponse {
+        let payload = try JSONEncoder().encode(segment)
+        try await putDoc(corpusId: segment.corpusId, collection: "segments", id: segment.segmentId, body: payload)
+        return SuccessResponse(message: "ok")
+    }
+
+    public func listSegments(corpusId: String, limit: Int = 50, offset: Int = 0) async throws -> (total: Int, segments: [Segment]) {
+        let q = Query(filters: ["corpusId": corpusId], limit: limit, offset: offset)
+        let resp = try await query(corpusId: corpusId, collection: "segments", query: q)
+        let list = try resp.documents.map { try JSONDecoder().decode(Segment.self, from: $0) }
+        return (resp.total, list)
+    }
+
+    public func addEntity(_ entity: Entity) async throws -> SuccessResponse {
+        let payload = try JSONEncoder().encode(entity)
+        try await putDoc(corpusId: entity.corpusId, collection: "entities", id: entity.entityId, body: payload)
+        return SuccessResponse(message: "ok")
+    }
+
+    public func listEntities(corpusId: String, limit: Int = 50, offset: Int = 0) async throws -> (total: Int, entities: [Entity]) {
+        let q = Query(filters: ["corpusId": corpusId], limit: limit, offset: offset)
+        let resp = try await query(corpusId: corpusId, collection: "entities", query: q)
+        let list = try resp.documents.map { try JSONDecoder().decode(Entity.self, from: $0) }
+        return (resp.total, list)
+    }
+
+    public func addTable(_ table: Table) async throws -> SuccessResponse {
+        let payload = try JSONEncoder().encode(table)
+        try await putDoc(corpusId: table.corpusId, collection: "tables", id: table.tableId, body: payload)
+        return SuccessResponse(message: "ok")
+    }
+
+    public func listTables(corpusId: String, limit: Int = 50, offset: Int = 0) async throws -> (total: Int, tables: [Table]) {
+        let q = Query(filters: ["corpusId": corpusId], limit: limit, offset: offset)
+        let resp = try await query(corpusId: corpusId, collection: "tables", query: q)
+        let list = try resp.documents.map { try JSONDecoder().decode(Table.self, from: $0) }
+        return (resp.total, list)
+    }
+
+    public func addAnalysis(_ analysis: AnalysisRecord) async throws -> SuccessResponse {
+        let payload = try JSONEncoder().encode(analysis)
+        try await putDoc(corpusId: analysis.corpusId, collection: "analyses", id: analysis.analysisId, body: payload)
+        return SuccessResponse(message: "ok")
+    }
+
+    public func listAnalyses(corpusId: String, limit: Int = 50, offset: Int = 0) async throws -> (total: Int, analyses: [AnalysisRecord]) {
+        let q = Query(filters: ["corpusId": corpusId], limit: limit, offset: offset)
+        let resp = try await query(corpusId: corpusId, collection: "analyses", query: q)
+        let list = try resp.documents.map { try JSONDecoder().decode(AnalysisRecord.self, from: $0) }
+        return (resp.total, list)
+    }
+
     public func addBaseline(_ baseline: Baseline) async throws -> SuccessResponse {
         let payload = try JSONEncoder().encode(baseline)
         try await putDoc(corpusId: baseline.corpusId, collection: "baselines", id: baseline.baselineId, body: payload)

--- a/libs/FountainStoreClient/Models.swift
+++ b/libs/FountainStoreClient/Models.swift
@@ -88,6 +88,80 @@ public struct Role: Codable, Sendable {
     }
 }
 
+public struct Page: Codable, Sendable {
+    public let corpusId: String
+    public let pageId: String
+    public let url: String
+    public let host: String
+    public let title: String
+
+    public init(corpusId: String, pageId: String, url: String, host: String, title: String) {
+        self.corpusId = corpusId
+        self.pageId = pageId
+        self.url = url
+        self.host = host
+        self.title = title
+    }
+}
+
+public struct Segment: Codable, Sendable {
+    public let corpusId: String
+    public let segmentId: String
+    public let pageId: String
+    public let kind: String
+    public let text: String
+
+    public init(corpusId: String, segmentId: String, pageId: String, kind: String, text: String) {
+        self.corpusId = corpusId
+        self.segmentId = segmentId
+        self.pageId = pageId
+        self.kind = kind
+        self.text = text
+    }
+}
+
+public struct Entity: Codable, Sendable {
+    public let corpusId: String
+    public let entityId: String
+    public let name: String
+    public let type: String
+
+    public init(corpusId: String, entityId: String, name: String, type: String) {
+        self.corpusId = corpusId
+        self.entityId = entityId
+        self.name = name
+        self.type = type
+    }
+}
+
+public struct Table: Codable, Sendable {
+    public let corpusId: String
+    public let tableId: String
+    public let pageId: String
+    public let csv: String
+
+    public init(corpusId: String, tableId: String, pageId: String, csv: String) {
+        self.corpusId = corpusId
+        self.tableId = tableId
+        self.pageId = pageId
+        self.csv = csv
+    }
+}
+
+public struct AnalysisRecord: Codable, Sendable {
+    public let corpusId: String
+    public let analysisId: String
+    public let pageId: String
+    public let summary: String
+
+    public init(corpusId: String, analysisId: String, pageId: String, summary: String) {
+        self.corpusId = corpusId
+        self.analysisId = analysisId
+        self.pageId = pageId
+        self.summary = summary
+    }
+}
+
 public struct Query: Sendable {
     public enum Mode: Sendable {
         case byId(String)

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -12,11 +12,11 @@ Persona definitions for Gateway plugins live in `personas/` and are referenced v
 | Function Caller Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/function-caller.yml](v1/function-caller.yml) |
 | Gateway | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/gateway.yml](v1/gateway.yml) |
 | LLM Gateway | 2.0.0 | Contexter alias Benedikt Eickhoff | [v2/llm-gateway.yml](v2/llm-gateway.yml) |
-| Persistence Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/persist.yml](v1/persist.yml) |
+| Persistence Service | 1.0.1 | Contexter alias Benedikt Eickhoff | [v1/persist.yml](v1/persist.yml) |
 | Planner Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/planner.yml](v1/planner.yml) |
 | Planner Service (legacy alias) | 1.0.0 | Contexter alias Benedikt Eickhoff | [v0/planner.yml](v0/planner.yml) |
 | Role Health Check Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/role-health-check-gateway.yml](v1/role-health-check-gateway.yml) |
-| Semantic Browser & Dissector API | 0.2.0 | Contexter alias Benedikt Eickhoff | [v1/semantic-browser.yml](v1/semantic-browser.yml) |
+| Semantic Browser & Dissector API | 0.2.1 | Contexter alias Benedikt Eickhoff | [v1/semantic-browser.yml](v1/semantic-browser.yml) |
 | Tools Factory Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/tools-factory.yml](v1/tools-factory.yml) |
 | Rate Limiter Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/rate-limiter-gateway.yml](v1/rate-limiter-gateway.yml) |
 | Payload Inspection Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/payload-inspection-gateway.yml](v1/payload-inspection-gateway.yml) |

--- a/openapi/v1/persist.yml
+++ b/openapi/v1/persist.yml
@@ -5,7 +5,9 @@ info:
   description: >
     Persistence and semantic indexing API for FountainAI corpora and related
     semantic artifacts (baselines, drifts, reflections, functions, history).
-  version: 1.0.0
+    Collection schemas for pages, segments, entities, tables, and analyses are
+    described in [docs/fountainstore-collections.md](../../docs/fountainstore-collections.md).
+  version: 1.0.1
 x-persona: ../personas/persist.md
 servers:
   - url: http://persist.fountain.coach/api/v1

--- a/openapi/v1/semantic-browser.yml
+++ b/openapi/v1/semantic-browser.yml
@@ -1,11 +1,12 @@
 openapi: 3.1.0
 info:
   title: Semantic Browser & Dissector API
-  version: 0.2.0
+  version: 0.2.1
   summary: >
     A Swift-only, JS-capable semantic browser that (1) renders a page, (2) snapshots network+DOM,
     (3) semantically dissects rendered content into blocks/entities/claims/tables with span-level citations,
     and (4) optionally persists artifacts into FountainStore under a corpus defined by Bootstrapping and Baseline Awareness.
+    See [docs/fountainstore-collections.md](../../docs/fountainstore-collections.md) for collection schemas.
   contact:
     name: FountainAI
     url: https://fountain.coach
@@ -114,7 +115,7 @@ paths:
     post:
       operationId: indexAnalysis
       tags: [Index]
-      summary: Persist Analysis-derived artifacts (page/segments/entities/tables) into FountainStore under a corpus.
+      summary: Persist Analysis-derived artifacts (page/segments/entities/tables/analyses) into FountainStore collections under a corpus.
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## Summary
- add typed models and helpers for pages, segments, entities, tables, and analyses collections
- document FountainStore corpus collections and reference them from persistence and semantic browser specs
- expand FountainStore client tests for collection helpers

## Testing
- `swift test --filter FountainStoreClientTests`
- `FULL_TESTS=1 swift run openapi-curator-cli --spec openapi/v1/persist.yml --corpus persist` *(fails: 'async' call in a function that does not support concurrency)*
- `FULL_TESTS=1 swift run openapi-curator-cli --spec openapi/v1/semantic-browser.yml --corpus sb` *(fails: 'async' call in a function that does not support concurrency)*

------
https://chatgpt.com/codex/tasks/task_b_68b8416aa5fc83338759bf8581404576