### PR TITLE
feat: add FountainStore capability negotiation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -63,7 +63,8 @@ let fullTargets: [Target] = [
             "Yams",
             .product(name: "Crypto", package: "swift-crypto"),
             .product(name: "Logging", package: "swift-log"),
-            .product(name: "Atomics", package: "swift-atomics")
+            .product(name: "Atomics", package: "swift-atomics"),
+            "FountainStoreClient"
         ],
         path: "libs/FountainRuntime",
         exclude: ["DNS/README.md"]
@@ -417,7 +418,7 @@ let fullTargets: [Target] = [
     ),
     .testTarget(
         name: "FountainRuntimeTests",
-        dependencies: ["FountainRuntime", .product(name: "NIOHTTP1", package: "swift-nio")],
+        dependencies: ["FountainRuntime", "FountainStoreClient", .product(name: "NIOHTTP1", package: "swift-nio")],
         path: "Tests/FountainRuntimeTests"
     ),
     .testTarget(
@@ -467,7 +468,8 @@ let leanTargets: [Target] = [
             "Yams",
             .product(name: "Crypto", package: "swift-crypto"),
             .product(name: "Logging", package: "swift-log"),
-            .product(name: "Atomics", package: "swift-atomics")
+            .product(name: "Atomics", package: "swift-atomics"),
+            "FountainStoreClient"
         ],
         path: "libs/FountainRuntime",
         exclude: ["DNS/README.md"]
@@ -599,7 +601,7 @@ let leanTargets: [Target] = [
     ),
     .testTarget(
         name: "FountainRuntimeTests",
-        dependencies: ["FountainRuntime", .product(name: "NIOHTTP1", package: "swift-nio")],
+        dependencies: ["FountainRuntime", "FountainStoreClient", .product(name: "NIOHTTP1", package: "swift-nio")],
         path: "Tests/FountainRuntimeTests"
     ),
     .testTarget(

--- a/Tests/FountainRuntimeTests/FountainRuntimeTests.swift
+++ b/Tests/FountainRuntimeTests/FountainRuntimeTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import Foundation
 import FountainRuntime
 import NIOHTTP1
+import FountainStoreClient
 
 final class FountainRuntimeTests: XCTestCase {
     func testHTTPRequestInitialization() {
@@ -25,5 +26,14 @@ final class FountainRuntimeTests: XCTestCase {
         } catch {
             // expected error
         }
+    }
+
+    func testHTTPKernelMapsCapabilityError() async throws {
+        let kernel = HTTPKernel { _ in throw PersistenceError.notSupported(need: "query.fullText") }
+        let resp = try await kernel.handle(HTTPRequest(method: "GET", path: "/"))
+        XCTAssertEqual(resp.status, 400)
+        let body = try JSONDecoder().decode([String: String].self, from: resp.body)
+        XCTAssertEqual(body["need"], "query.fullText")
+        XCTAssertEqual(body["error"], "not-supported")
     }
 }

--- a/Tests/FountainStoreClientTests/FountainStoreClientTests.swift
+++ b/Tests/FountainStoreClientTests/FountainStoreClientTests.swift
@@ -36,6 +36,19 @@ final class FountainStoreClientTests: XCTestCase {
         XCTAssertTrue(caps.documents.contains("upsert"))
     }
 
+    func testMissingCapability() async throws {
+        let caps = Capabilities(corpus: true, documents: ["upsert", "get", "delete"], query: [], transactions: [], admin: [], experimental: [])
+        let client = FountainStoreClient(client: MockFountainStoreClient(caps: caps))
+        do {
+            _ = try await client.query(corpusId: "c1", collection: "pages", query: Query(mode: .byId("p1")))
+            XCTFail("expected notSupported")
+        } catch PersistenceError.notSupported(let need) {
+            XCTAssertEqual(need, "query.byId")
+        }
+        let metrics = await client.capabilityRequests
+        XCTAssertEqual(metrics["query.byId"], 1)
+    }
+
     func testCollectionHelpers() async throws {
         let client = FountainStoreClient(client: MockFountainStoreClient())
         _ = try await client.createCorpus("c2")

--- a/libs/FountainRuntime/IntegrationRuntime/HTTPKernel.swift
+++ b/libs/FountainRuntime/IntegrationRuntime/HTTPKernel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import FountainStoreClient
 
 /// Minimal async HTTP router used by lightweight servers.
 public struct HTTPKernel: @unchecked Sendable {
@@ -15,7 +16,12 @@ public struct HTTPKernel: @unchecked Sendable {
     /// - Parameter request: Incoming request object.
     /// - Throws: Rethrows any error produced by the routing closure.
     public func handle(_ request: HTTPRequest) async throws -> HTTPResponse {
-        try await router(request)
+        do {
+            return try await router(request)
+        } catch PersistenceError.notSupported(let need) {
+            let body = (try? JSONEncoder().encode(["error": "not-supported", "need": need])) ?? Data()
+            return HTTPResponse(status: 400, headers: ["Content-Type": "application/json"], body: body)
+        }
     }
 }
 

--- a/libs/FountainStoreClient/ClientAbstraction.swift
+++ b/libs/FountainStoreClient/ClientAbstraction.swift
@@ -27,8 +27,18 @@ public final class MockFountainStoreClient: FountainStoreClientProtocol, @unchec
     private struct StoredCorpus { var metadata: [String: String]; var collections: [String: [String: Data]] }
     private var corpora: [String: StoredCorpus] = [:]
     private var snapshots: [String: StoredCorpus] = [:]
+    private let caps: Capabilities
 
-    public init() {}
+    public init(caps: Capabilities = Capabilities(
+        corpus: true,
+        documents: ["upsert", "get", "delete"],
+        query: ["byId", "byIndexEq", "prefixScan", "filters", "sort"],
+        transactions: ["snapshot", "restore"],
+        admin: ["health", "backup", "compaction", "metrics"],
+        experimental: []
+    )) {
+        self.caps = caps
+    }
 
     // MARK: - Corpus
     public func createCorpus(id: String, metadata: [String: String]) async throws {
@@ -135,16 +145,7 @@ public final class MockFountainStoreClient: FountainStoreClientProtocol, @unchec
     }
 
     // MARK: - Capabilities
-    public func capabilities() async throws -> Capabilities {
-        Capabilities(
-            corpus: true,
-            documents: ["upsert", "get", "delete"],
-            query: ["byId", "byIndexEq", "prefixScan", "filters", "sort"],
-            transactions: ["snapshot", "restore"],
-            admin: ["health", "backup", "compaction", "metrics"],
-            experimental: []
-        )
-    }
+    public func capabilities() async throws -> Capabilities { caps }
 
     // MARK: - Admin
     public func snapshot(corpusId: String) async throws {

--- a/libs/FountainStoreClient/FountainStoreClient.swift
+++ b/libs/FountainStoreClient/FountainStoreClient.swift
@@ -2,17 +2,54 @@ import Foundation
 
 public enum PersistenceError: Error, Equatable {
     case invalidData
+    case notSupported(need: String)
 }
 
 public actor FountainStoreClient {
     private let client: FountainStoreClientProtocol
+    private var caps: Capabilities?
+    private var capabilityCounters: [String: Int] = [:]
 
     public init(client: FountainStoreClientProtocol) {
         self.client = client
+        Task { try? await self.loadCapabilities() }
+    }
+
+    public var capabilityRequests: [String: Int] { capabilityCounters }
+
+    private func loadCapabilities() async throws -> Capabilities {
+        if let c = caps { return c }
+        let fetched = try await client.capabilities()
+        caps = fetched
+        return fetched
+    }
+
+    private func hasCapability(_ c: Capabilities, need: String) -> Bool {
+        let parts = need.split(separator: ".")
+        if parts.count == 1 { return parts[0] == "corpus" ? c.corpus : false }
+        guard parts.count == 2 else { return false }
+        let group = parts[0], op = parts[1]
+        switch group {
+        case "documents": return c.documents.contains(String(op))
+        case "query": return c.query.contains(String(op))
+        case "transactions": return c.transactions.contains(String(op))
+        case "admin": return c.admin.contains(String(op))
+        case "experimental": return c.experimental.contains(String(op))
+        default: return false
+        }
+    }
+
+    private func requireCapability(_ need: String) async throws {
+        let c = try await loadCapabilities()
+        if hasCapability(c, need: need) { return }
+        capabilityCounters[need, default: 0] += 1
+        print("capability request: need=\(need)")
+        throw PersistenceError.notSupported(need: need)
     }
 
     // MARK: - Corpus
     public func createCorpus(_ id: String, metadata: [String: String] = [:]) async throws -> CorpusResponse {
+        try await requireCapability("corpus")
         try await client.createCorpus(id: id, metadata: metadata)
         return CorpusResponse(corpusId: id, message: "created")
     }
@@ -22,44 +59,72 @@ public actor FountainStoreClient {
     }
 
     public func getCorpus(_ id: String) async throws -> Corpus? {
-        try await client.getCorpus(id: id)
+        try await requireCapability("corpus")
+        return try await client.getCorpus(id: id)
     }
 
     public func deleteCorpus(_ id: String) async throws {
+        try await requireCapability("corpus")
         try await client.deleteCorpus(id: id)
     }
 
     public func listCorpora(limit: Int = 50, offset: Int = 0) async throws -> (total: Int, corpora: [String]) {
-        try await client.listCorpora(limit: limit, offset: offset)
+        try await requireCapability("corpus")
+        return try await client.listCorpora(limit: limit, offset: offset)
     }
 
     // MARK: - Documents
     public func putDoc(corpusId: String, collection: String, id: String, body: Data) async throws {
+        try await requireCapability("documents.upsert")
         try await client.putDoc(corpusId: corpusId, collection: collection, id: id, body: body)
     }
 
     public func getDoc(corpusId: String, collection: String, id: String) async throws -> Data? {
-        try await client.getDoc(corpusId: corpusId, collection: collection, id: id)
+        try await requireCapability("documents.get")
+        return try await client.getDoc(corpusId: corpusId, collection: collection, id: id)
     }
 
     public func deleteDoc(corpusId: String, collection: String, id: String) async throws {
+        try await requireCapability("documents.delete")
         try await client.deleteDoc(corpusId: corpusId, collection: collection, id: id)
     }
 
     public func query(corpusId: String, collection: String, query: Query) async throws -> QueryResponse {
-        try await client.query(corpusId: corpusId, collection: collection, query: query)
+        if let mode = query.mode {
+            switch mode {
+            case .byId: try await requireCapability("query.byId")
+            case .byIndexEq: try await requireCapability("query.byIndexEq")
+            case .prefixScan: try await requireCapability("query.prefixScan")
+            }
+        }
+        if !query.filters.isEmpty { try await requireCapability("query.filters") }
+        if !query.sort.isEmpty { try await requireCapability("query.sort") }
+        return try await client.query(corpusId: corpusId, collection: collection, query: query)
     }
 
     // MARK: - Capabilities
-    public func capabilities() async throws -> Capabilities {
-        try await client.capabilities()
-    }
+    public func capabilities() async throws -> Capabilities { try await loadCapabilities() }
 
     // MARK: - Admin
-    public func snapshot(corpusId: String) async throws { try await client.snapshot(corpusId: corpusId) }
-    public func restore(corpusId: String) async throws { try await client.restore(corpusId: corpusId) }
-    public func backup(corpusId: String) async throws { try await client.backup(corpusId: corpusId) }
-    public func compaction(corpusId: String) async throws { try await client.compaction(corpusId: corpusId) }
+    public func snapshot(corpusId: String) async throws {
+        try await requireCapability("transactions.snapshot")
+        try await client.snapshot(corpusId: corpusId)
+    }
+
+    public func restore(corpusId: String) async throws {
+        try await requireCapability("transactions.restore")
+        try await client.restore(corpusId: corpusId)
+    }
+
+    public func backup(corpusId: String) async throws {
+        try await requireCapability("admin.backup")
+        try await client.backup(corpusId: corpusId)
+    }
+
+    public func compaction(corpusId: String) async throws {
+        try await requireCapability("admin.compaction")
+        try await client.compaction(corpusId: corpusId)
+    }
 
     // MARK: - Convenience Helpers
     public func addPage(_ page: Page) async throws -> SuccessResponse {


### PR DESCRIPTION
## Summary
- implement capability checks and metrics in FountainStoreClient
- surface NotSupported needs as HTTP 400 responses
- cover capability negotiation with tests

## Testing
- `swift test --filter FountainStoreClientTests`
- `swift test --filter FountainRuntimeTests`


------
https://chatgpt.com/codex/tasks/task_b_68b845a454c483338de3d281b94981ea