### PR TITLE
Validate FountainStoreClient query shapes

### DIFF
--- a/Tests/FountainStoreClientTests/FountainStoreClientTests.swift
+++ b/Tests/FountainStoreClientTests/FountainStoreClientTests.swift
@@ -49,6 +49,19 @@ final class FountainStoreClientTests: XCTestCase {
         XCTAssertEqual(metrics["query.byId"], 1)
     }
 
+    func testUnsupportedQueryShape() async throws {
+        let client = FountainStoreClient(client: MockFountainStoreClient())
+        let q = Query(mode: .byId("p1"), sort: [(field: "foo", ascending: true)])
+        do {
+            _ = try await client.query(corpusId: "c1", collection: "pages", query: q)
+            XCTFail("expected notSupported")
+        } catch PersistenceError.notSupported(let need) {
+            XCTAssertEqual(need, "query.byId.invalid")
+        }
+        let metrics = await client.capabilityRequests
+        XCTAssertEqual(metrics["query.byId.invalid"], 1)
+    }
+
     func testCollectionHelpers() async throws {
         let client = FountainStoreClient(client: MockFountainStoreClient())
         _ = try await client.createCorpus("c2")

--- a/libs/FountainStoreClient/FountainStoreClient.swift
+++ b/libs/FountainStoreClient/FountainStoreClient.swift
@@ -90,6 +90,7 @@ public actor FountainStoreClient {
     }
 
     public func query(corpusId: String, collection: String, query: Query) async throws -> QueryResponse {
+        try validateQuery(query)
         if let mode = query.mode {
             switch mode {
             case .byId: try await requireCapability("query.byId")
@@ -100,6 +101,30 @@ public actor FountainStoreClient {
         if !query.filters.isEmpty { try await requireCapability("query.filters") }
         if !query.sort.isEmpty { try await requireCapability("query.sort") }
         return try await client.query(corpusId: corpusId, collection: collection, query: query)
+    }
+
+    private func validateQuery(_ q: Query) throws {
+        if q.sort.count > 1 {
+            try requestCapability("query.sort.multi")
+        }
+        if let mode = q.mode {
+            switch mode {
+            case .byId:
+                if !q.filters.isEmpty || !q.sort.isEmpty || q.limit != nil || q.offset != nil {
+                    try requestCapability("query.byId.invalid")
+                }
+            case .byIndexEq, .prefixScan:
+                if !q.filters.isEmpty {
+                    try requestCapability("query.modeWithFilters")
+                }
+            }
+        }
+    }
+
+    private func requestCapability(_ need: String) throws -> Never {
+        capabilityCounters[need, default: 0] += 1
+        print("capability request: need=\(need)")
+        throw PersistenceError.notSupported(need: need)
     }
 
     // MARK: - Capabilities


### PR DESCRIPTION
## Summary
- validate query requests against supported shapes
- log capability requests and throw `NotSupported` for unsupported queries
- add unit test for unsupported query shape

## Testing
- `swift build --target FountainStoreClient`
- `swift test --filter FountainStoreClientTests`


------
https://chatgpt.com/codex/tasks/task_b_68b849b08cdc8333bb29a96ea18125c7