### PR TITLE
test: expand fountain store coverage

### DIFF
--- a/.github/workflows/task-fast.yml
+++ b/.github/workflows/task-fast.yml
@@ -16,9 +16,16 @@ jobs:
             ~/.swiftpm
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: ${{ runner.os }}-spm-
-      - name: Build (Debug, fast)
-        run: swift build -c debug -Xswiftc -Onone -Xswiftc -enable-testing -Xswiftc -warnings-as-errors
-      - name: Determine impacted targets
-        run: bash Scripts/impacted-targets.sh | tee impacted-filters.txt
-      - name: Run filtered unit tests
-        run: xargs -I {} swift test --parallel --filter {} < impacted-filters.txt
+      - name: Build & Test (Tier-A)
+        run: |
+          set -e
+          bash Scripts/impacted-targets.sh | tee impacted-filters.txt
+          build_start=$(date +%s)
+          if swift build -c debug -Xswiftc -Onone -Xswiftc -enable-testing -Xswiftc -warnings-as-errors; then build=passed; else build=failed; fi
+          build_end=$(date +%s)
+          test_start=$(date +%s)
+          if xargs -I {} swift test --parallel --filter {} < impacted-filters.txt; then tests=passed; else tests=failed; fi
+          test_end=$(date +%s)
+          filters_json=$(sed 's/.*/"&"/' impacted-filters.txt | paste -sd, -)
+          echo "{ \"mode\": \"Tier-A\", \"impactedTargets\": [${filters_json}], \"build\": \"${build}\", \"tests\": \"${tests}\", \"durations\": {\"buildSec\": $((build_end-build_start)), \"testsSec\": $((test_end-test_start))}, \"capabilityRequests\": [] }"
+          if [ \"$build\" != \"passed\" ] || [ \"$tests\" != \"passed\" ]; then exit 1; fi

--- a/Tests/FountainStoreClientTests/FountainStoreClientTests.swift
+++ b/Tests/FountainStoreClientTests/FountainStoreClientTests.swift
@@ -87,5 +87,79 @@ final class FountainStoreClientTests: XCTestCase {
         let (_, analyses) = try await client.listAnalyses(corpusId: "c2")
         XCTAssertEqual(analyses.first?.analysisId, "a1")
     }
+
+    func testListCorporaAndAdminOps() async throws {
+        let client = FountainStoreClient(client: MockFountainStoreClient())
+        _ = try await client.createCorpus("cA")
+        _ = try await client.createCorpus("cB")
+        let (total, corpora) = try await client.listCorpora()
+        XCTAssertEqual(total, 2)
+        XCTAssertEqual(Set(corpora), ["cA", "cB"])
+
+        // Admin operations should succeed when capabilities are present
+        try await client.backup(corpusId: "cA")
+        try await client.compaction(corpusId: "cA")
+    }
+
+    func testExtendedCollections() async throws {
+        let client = FountainStoreClient(client: MockFountainStoreClient())
+        _ = try await client.createCorpus("c3")
+
+        let baseline = Baseline(corpusId: "c3", baselineId: "b1", content: "base")
+        _ = try await client.addBaseline(baseline)
+        let reflection = Reflection(corpusId: "c3", reflectionId: "r1", question: "q", content: "a")
+        _ = try await client.addReflection(reflection)
+        let drift = Drift(corpusId: "c3", driftId: "d1", content: "dr")
+        _ = try await client.addDrift(drift)
+        let patterns = Patterns(corpusId: "c3", patternsId: "p1", content: "pat")
+        _ = try await client.addPatterns(patterns)
+        let role = Role(corpusId: "c3", name: "admin", prompt: "do")
+        _ = try await client.addRole(role)
+        _ = try await client.seedDefaultRoles(corpusId: "c3", defaults: [Role(corpusId: "c3", name: "user", prompt: "u")])
+
+        let (_, baselines) = try await client.listBaselines(corpusId: "c3")
+        XCTAssertEqual(baselines.first?.baselineId, "b1")
+        let (_, reflections) = try await client.listReflections(corpusId: "c3")
+        XCTAssertEqual(reflections.first?.reflectionId, "r1")
+        let (_, drifts) = try await client.listDrifts(corpusId: "c3")
+        XCTAssertEqual(drifts.first?.driftId, "d1")
+        let (_, pats) = try await client.listPatterns(corpusId: "c3")
+        XCTAssertEqual(pats.first?.patternsId, "p1")
+
+        // verify roles inserted via query
+        let roleResp = try await client.query(corpusId: "c3", collection: "roles", query: Query())
+        XCTAssertEqual(roleResp.total, 2)
+    }
+
+    func testFunctionHelpers() async throws {
+        let client = FountainStoreClient(client: MockFountainStoreClient())
+        _ = try await client.createCorpus("c4")
+        let fn = FunctionModel(corpusId: "c4", functionId: "f1", name: "fn", description: "desc", httpMethod: "GET", httpPath: "/f")
+        _ = try await client.addFunction(fn)
+
+        let (totalAll, all) = try await client.listFunctions()
+        XCTAssertEqual(totalAll, 1)
+        XCTAssertEqual(all.first?.functionId, "f1")
+
+        let (totalCorpus, corpusFns) = try await client.listFunctions(corpusId: "c4")
+        XCTAssertEqual(totalCorpus, 1)
+        XCTAssertEqual(corpusFns.first?.functionId, "f1")
+
+        let details = try await client.getFunctionDetails(functionId: "f1")
+        XCTAssertEqual(details?.name, "fn")
+    }
+
+    func testSnapshotCapabilityFallback() async throws {
+        let caps = Capabilities(corpus: true, documents: ["upsert", "get", "delete"], query: ["byId"], transactions: [], admin: [], experimental: [])
+        let client = FountainStoreClient(client: MockFountainStoreClient(caps: caps))
+        do {
+            try await client.snapshot(corpusId: "c1")
+            XCTFail("expected notSupported")
+        } catch PersistenceError.notSupported(let need) {
+            XCTAssertEqual(need, "transactions.snapshot")
+        }
+        let metrics = await client.capabilityRequests
+        XCTAssertEqual(metrics["transactions.snapshot"], 1)
+    }
 }
 

--- a/Tests/SemanticBrowserTests/SemanticBrowserIndexTests.swift
+++ b/Tests/SemanticBrowserTests/SemanticBrowserIndexTests.swift
@@ -40,6 +40,47 @@ final class SemanticBrowserIndexTests: XCTestCase {
 
         try await server.stop()
     }
+
+    func testIndexWritesToBackend() async throws {
+        final class RecordingBackend: SemanticMemoryService.Backend, @unchecked Sendable {
+            var pages: [SemanticMemoryService.PageDoc] = []
+            var segments: [SemanticMemoryService.SegmentDoc] = []
+            var entities: [SemanticMemoryService.EntityDoc] = []
+            func upsert(page: SemanticMemoryService.PageDoc) { pages.append(page) }
+            func upsert(segment: SemanticMemoryService.SegmentDoc) { segments.append(segment) }
+            func upsert(entity: SemanticMemoryService.EntityDoc) { entities.append(entity) }
+            func searchPages(q: String?, host: String?, lang: String?, limit: Int, offset: Int) -> (Int, [SemanticMemoryService.PageDoc]) { (0, []) }
+            func searchSegments(q: String?, kind: String?, entity: String?, limit: Int, offset: Int) -> (Int, [SemanticMemoryService.SegmentDoc]) { (0, []) }
+            func searchEntities(q: String?, type: String?, limit: Int, offset: Int) -> (Int, [SemanticMemoryService.EntityDoc]) { (0, []) }
+        }
+        let backend = RecordingBackend()
+        let svc = SemanticMemoryService(backend: backend)
+        let kernel = makeSemanticKernel(service: svc)
+        let server = NIOHTTPServer(kernel: kernel)
+        let port = try await server.start(port: 0)
+
+        let payload: [String: Any] = [
+            "analysis": [
+                "page": ["id": "p1", "url": "https://ex.com/1", "host": "ex.com", "title": "One"],
+                "segments": [["id": "s1", "pageId": "p1", "kind": "paragraph", "text": "hello"]],
+                "entities": [["id": "e1", "name": "Foo", "type": "PERSON"]]
+            ]
+        ]
+        var req = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/index")!)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONSerialization.data(withJSONObject: payload)
+        _ = try await URLSession.shared.data(for: req)
+
+        let stored = backend.pages.first?.id
+        XCTAssertEqual(stored, "p1")
+        let segStored = backend.segments.first?.id
+        XCTAssertEqual(segStored, "s1")
+        let entStored = backend.entities.first?.id
+        XCTAssertEqual(entStored, "e1")
+
+        try await server.stop()
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- cover all FountainStoreClient methods including admin and collection helpers
- verify Semantic Browser indexing writes through backend collections
- add capability fallback test and lean Tier-A CI summary

## Testing
- `swift test --filter FountainStoreClientTests`


------
https://chatgpt.com/codex/tasks/task_b_68b851bab40883338f577a15caff6d4f