### PR TITLE
Configure embedded store path in server mains

### DIFF
--- a/apps/BaselineAwarenessServer/main.swift
+++ b/apps/BaselineAwarenessServer/main.swift
@@ -6,18 +6,24 @@ import LauncherSignature
 
 verifyLauncherSignature()
 
-// Awareness server using the shared NIOHTTPServer for consistent HTTP handling
+let corpusId = ProcessInfo.processInfo.environment["DEFAULT_CORPUS_ID"] ?? "tools-factory"
+let storePath = ProcessInfo.processInfo.environment["FOUNTAIN_STORE_PATH"] ?? "./data/fountain-store"
 do {
-    let corpusId = ProcessInfo.processInfo.environment["DEFAULT_CORPUS_ID"] ?? "tools-factory"
-    let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
-    Task { await svc.ensureCollections(corpusId: corpusId) }
-    let server = NIOHTTPServer(kernel: makeAwarenessKernel(service: svc))
-    let port: Int = 8081
-    _ = try await server.start(port: port)
-    print("baseline-awareness (NIO) listening on :\(port)")
-    dispatchMain()
+    try FileManager.default.createDirectory(atPath: storePath, withIntermediateDirectories: true)
 } catch {
-    print("Failed to start baseline-awareness: \(error)")
+    FileHandle.standardError.write(Data("[baseline-awareness] Failed to create store directory: \(error)\n".utf8))
 }
+let svc = FountainStoreClient(client: EmbeddedFountainStoreClient(path: storePath))
+Task {
+    await svc.ensureCollections(corpusId: corpusId)
+    let server = NIOHTTPServer(kernel: makeAwarenessKernel(service: svc))
+    do {
+        _ = try await server.start(port: 8081)
+        print("baseline-awareness (NIO) listening on :8081")
+    } catch {
+        FileHandle.standardError.write(Data("[baseline-awareness] Failed to start: \(error)\n".utf8))
+    }
+}
+dispatchMain()
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/apps/BootstrapServer/main.swift
+++ b/apps/BootstrapServer/main.swift
@@ -6,18 +6,24 @@ import LauncherSignature
 
 verifyLauncherSignature()
 
-// Bootstrap server using the shared NIOHTTPServer for consistent HTTP handling
+let corpusId = ProcessInfo.processInfo.environment["DEFAULT_CORPUS_ID"] ?? "tools-factory"
+let storePath = ProcessInfo.processInfo.environment["FOUNTAIN_STORE_PATH"] ?? "./data/fountain-store"
 do {
-    let corpusId = ProcessInfo.processInfo.environment["DEFAULT_CORPUS_ID"] ?? "tools-factory"
-    let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
-    Task { await svc.ensureCollections(corpusId: corpusId) }
-    let server = NIOHTTPServer(kernel: makeBootstrapKernel(service: svc))
-    let port: Int = 8082
-    _ = try await server.start(port: port)
-    print("bootstrap (NIO) listening on :\(port)")
-    dispatchMain()
+    try FileManager.default.createDirectory(atPath: storePath, withIntermediateDirectories: true)
 } catch {
-    print("Failed to start bootstrap: \(error)")
+    FileHandle.standardError.write(Data("[bootstrap] Failed to create store directory: \(error)\n".utf8))
 }
+let svc = FountainStoreClient(client: EmbeddedFountainStoreClient(path: storePath))
+Task {
+    await svc.ensureCollections(corpusId: corpusId)
+    let server = NIOHTTPServer(kernel: makeBootstrapKernel(service: svc))
+    do {
+        _ = try await server.start(port: 8082)
+        print("bootstrap (NIO) listening on :8082")
+    } catch {
+        FileHandle.standardError.write(Data("[bootstrap] Failed to start: \(error)\n".utf8))
+    }
+}
+dispatchMain()
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/apps/FunctionCallerServer/main.swift
+++ b/apps/FunctionCallerServer/main.swift
@@ -8,7 +8,13 @@ import LauncherSignature
 verifyLauncherSignature()
 
 let corpusId = ProcessInfo.processInfo.environment["DEFAULT_CORPUS_ID"] ?? "tools-factory"
-let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
+let storePath = ProcessInfo.processInfo.environment["FOUNTAIN_STORE_PATH"] ?? "./data/fountain-store"
+do {
+    try FileManager.default.createDirectory(atPath: storePath, withIntermediateDirectories: true)
+} catch {
+    FileHandle.standardError.write(Data("[function-caller] Failed to create store directory: \(error)\n".utf8))
+}
+let svc = FountainStoreClient(client: EmbeddedFountainStoreClient(path: storePath))
 Task {
     await svc.ensureCollections(corpusId: corpusId)
     let kernel = makeFunctionCallerKernel(service: svc)

--- a/apps/PersistServer/main.swift
+++ b/apps/PersistServer/main.swift
@@ -7,7 +7,13 @@ import LauncherSignature
 verifyLauncherSignature()
 
 let corpusId = ProcessInfo.processInfo.environment["DEFAULT_CORPUS_ID"] ?? "tools-factory"
-let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
+let storePath = ProcessInfo.processInfo.environment["FOUNTAIN_STORE_PATH"] ?? "./data/fountain-store"
+do {
+    try FileManager.default.createDirectory(atPath: storePath, withIntermediateDirectories: true)
+} catch {
+    FileHandle.standardError.write(Data("[persist] Failed to create store directory: \(error)\n".utf8))
+}
+let svc = FountainStoreClient(client: EmbeddedFountainStoreClient(path: storePath))
 Task {
     await svc.ensureCollections(corpusId: corpusId)
     let kernel = makePersistKernel(service: svc)

--- a/apps/PlannerServer/main.swift
+++ b/apps/PlannerServer/main.swift
@@ -8,7 +8,13 @@ import LauncherSignature
 verifyLauncherSignature()
 
 let corpusId = ProcessInfo.processInfo.environment["DEFAULT_CORPUS_ID"] ?? "tools-factory"
-let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
+let storePath = ProcessInfo.processInfo.environment["FOUNTAIN_STORE_PATH"] ?? "./data/fountain-store"
+do {
+    try FileManager.default.createDirectory(atPath: storePath, withIntermediateDirectories: true)
+} catch {
+    FileHandle.standardError.write(Data("[planner] Failed to create store directory: \(error)\n".utf8))
+}
+let svc = FountainStoreClient(client: EmbeddedFountainStoreClient(path: storePath))
 Task {
     await svc.ensureCollections(corpusId: corpusId)
     let kernel = makePlannerKernel(service: svc)

--- a/apps/ToolsFactoryServer/main.swift
+++ b/apps/ToolsFactoryServer/main.swift
@@ -22,17 +22,25 @@ let manifest = (try? ToolManifest.load(from: manifestURL)) ?? ToolManifest(image
 let corpusId = ProcessInfo.processInfo.environment["TOOLS_FACTORY_CORPUS_ID"] ??
                ProcessInfo.processInfo.environment["DEFAULT_CORPUS_ID"] ?? "tools-factory"
 
+let storePath = ProcessInfo.processInfo.environment["FOUNTAIN_STORE_PATH"] ?? "./data/fountain-store"
 do {
-    let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
-    Task { await svc.ensureCollections(corpusId: corpusId); try? await publishFunctions(manifest: manifest, corpusId: corpusId, service: svc) }
+    try FileManager.default.createDirectory(atPath: storePath, withIntermediateDirectories: true)
+} catch {
+    FileHandle.standardError.write(Data("[tools-factory] Failed to create store directory: \(error)\n".utf8))
+}
+let svc = FountainStoreClient(client: EmbeddedFountainStoreClient(path: storePath))
+Task {
+    await svc.ensureCollections(corpusId: corpusId)
+    try? await publishFunctions(manifest: manifest, corpusId: corpusId, service: svc)
     let kernel = makeToolsFactoryKernel(service: svc, adapters: adapters, manifest: manifest)
     let server = NIOHTTPServer(kernel: kernel)
-    let port: Int = 8080
-    _ = try await server.start(port: port)
-    print("tools-factory (NIO) listening on :\(port)")
-    dispatchMain()
-} catch {
-    print("Failed to start tools-factory: \(error)")
+    do {
+        _ = try await server.start(port: 8080)
+        print("tools-factory (NIO) listening on :8080")
+    } catch {
+        FileHandle.standardError.write(Data("[tools-factory] Failed to start: \(error)\n".utf8))
+    }
 }
+dispatchMain()
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- make server entrypoints use `EmbeddedFountainStoreClient` with configurable `FOUNTAIN_STORE_PATH`
- create storage directory on startup and invoke `ensureCollections` after initialization

## Testing
- `swift test` *(failed: 18 failures)*

------
https://chatgpt.com/codex/tasks/task_b_68b875bf97988333a0f1ddb36dc2bd5c