### PR TITLE
feat: expose persistence capabilities endpoint

### DIFF
--- a/Tests/PersistServerTests/PersistServerTests.swift
+++ b/Tests/PersistServerTests/PersistServerTests.swift
@@ -139,6 +139,22 @@ final class PersistServerTests: XCTestCase {
         try await server.stop()
     }
 
+    func testCapabilitiesEndpoint() async throws {
+        let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
+        await svc.ensureCollections()
+        let kernel = makePersistKernel(service: svc)
+        let server = NIOHTTPServer(kernel: kernel)
+        let port = try await server.start(port: 0)
+
+        let (data, resp) = try await URLSession.shared.data(from: URL(string: "http://127.0.0.1:\(port)/capabilities")!)
+        XCTAssertEqual((resp as? HTTPURLResponse)?.statusCode, 200)
+        let caps = try JSONDecoder().decode(Capabilities.self, from: data)
+        XCTAssertTrue(caps.corpus)
+        XCTAssertTrue(caps.documents.contains("upsert"))
+
+        try await server.stop()
+    }
+
     func testMetricsEndpoint() async throws {
         let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
         await svc.ensureCollections()

--- a/apps/PersistServer/PersistServerModule.swift
+++ b/apps/PersistServer/PersistServerModule.swift
@@ -27,6 +27,11 @@ public func makePersistKernel(service svc: FountainStoreClient) -> HTTPKernel {
             case ("GET", ["metrics"]):
                 return await metrics_metrics_get()
 
+            case ("GET", ["capabilities"]):
+                let caps = try await svc.capabilities()
+                let json = try JSONEncoder().encode(caps)
+                return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: json)
+
             case ("GET", ["corpora"]):
                 let qp = queryParams(from: req.path)
                 let limit = min(max(Int(qp["limit"] ?? "50") ?? 50, 1), 200)

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -12,7 +12,7 @@ Persona definitions for Gateway plugins live in `personas/` and are referenced v
 | Function Caller Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/function-caller.yml](v1/function-caller.yml) |
 | Gateway | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/gateway.yml](v1/gateway.yml) |
 | LLM Gateway | 2.0.0 | Contexter alias Benedikt Eickhoff | [v2/llm-gateway.yml](v2/llm-gateway.yml) |
-| Persistence Service | 1.0.1 | Contexter alias Benedikt Eickhoff | [v1/persist.yml](v1/persist.yml) |
+| Persistence Service | 1.0.2 | Contexter alias Benedikt Eickhoff | [v1/persist.yml](v1/persist.yml) |
 | Planner Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/planner.yml](v1/planner.yml) |
 | Planner Service (legacy alias) | 1.0.0 | Contexter alias Benedikt Eickhoff | [v0/planner.yml](v0/planner.yml) |
 | Role Health Check Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/role-health-check-gateway.yml](v1/role-health-check-gateway.yml) |

--- a/openapi/v1/persist.yml
+++ b/openapi/v1/persist.yml
@@ -7,11 +7,22 @@ info:
     semantic artifacts (baselines, drifts, reflections, functions, history).
     Collection schemas for pages, segments, entities, tables, and analyses are
     described in [docs/fountainstore-collections.md](../../docs/fountainstore-collections.md).
-  version: 1.0.1
+  version: 1.0.2
 x-persona: ../personas/persist.md
 servers:
   - url: http://persist.fountain.coach/api/v1
 paths:
+  /capabilities:
+    get:
+      summary: Get supported capabilities
+      operationId: capabilities
+      responses:
+        '200':
+          description: Capability flags for the persistence service.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Capabilities'
 
   /corpora:
     get:
@@ -388,6 +399,32 @@ paths:
 
 components:
   schemas:
+    Capabilities:
+      type: object
+      properties:
+        corpus:
+          type: boolean
+        documents:
+          type: array
+          items:
+            type: string
+        query:
+          type: array
+          items:
+            type: string
+        transactions:
+          type: array
+          items:
+            type: string
+        admin:
+          type: array
+          items:
+            type: string
+        experimental:
+          type: array
+          items:
+            type: string
+
     BaseEntity:
       type: object
       required:


### PR DESCRIPTION
## Summary
- expose capabilities via GET /capabilities in Persist server
- document capabilities path and schema in persist OpenAPI spec
- cover new endpoint with unit test

## Testing
- `python3 scripts/validate_openapi.py`
- `python3 scripts/opid_handler_audit.py`
- `swift build`
- `swift test --filter PersistServerTests` *(failed: no matching tests)*
- `FULL_TESTS=1 swift test --filter PersistServerTests/testCapabilitiesEndpoint` *(failed: emit-module command failed)*
- `swift test` *(failed: 18 tests failed)*

------
https://chatgpt.com/codex/tasks/task_b_68b897ed5f348333a754f87d201baeab