### PR TITLE
Remove embedded store path parameter

### DIFF
--- a/Tests/FountainStoreClientTests/FountainStoreClientTests.swift
+++ b/Tests/FountainStoreClientTests/FountainStoreClientTests.swift
@@ -4,14 +4,12 @@ import Foundation
 
 final class FountainStoreClientTests: XCTestCase {
     private func makeClient(caps: Capabilities? = nil) -> FountainStoreClient {
-        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         let embedded: EmbeddedFountainStoreClient
         if let c = caps {
-            embedded = EmbeddedFountainStoreClient(path: dir.path, caps: c)
+            embedded = EmbeddedFountainStoreClient(caps: c)
         } else {
-            embedded = EmbeddedFountainStoreClient(path: dir.path)
+            embedded = EmbeddedFountainStoreClient()
         }
-        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
         return FountainStoreClient(client: embedded)
     }
 

--- a/apps/BaselineAwarenessServer/main.swift
+++ b/apps/BaselineAwarenessServer/main.swift
@@ -7,13 +7,7 @@ import LauncherSignature
 verifyLauncherSignature()
 
 let corpusId = ProcessInfo.processInfo.environment["DEFAULT_CORPUS_ID"] ?? "tools-factory"
-let storePath = ProcessInfo.processInfo.environment["FOUNTAIN_STORE_PATH"] ?? "./data/fountain-store"
-do {
-    try FileManager.default.createDirectory(atPath: storePath, withIntermediateDirectories: true)
-} catch {
-    FileHandle.standardError.write(Data("[baseline-awareness] Failed to create store directory: \(error)\n".utf8))
-}
-let svc = FountainStoreClient(client: EmbeddedFountainStoreClient(path: storePath))
+let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
 Task {
     await svc.ensureCollections(corpusId: corpusId)
     let server = NIOHTTPServer(kernel: makeAwarenessKernel(service: svc))

--- a/apps/BootstrapServer/main.swift
+++ b/apps/BootstrapServer/main.swift
@@ -7,13 +7,7 @@ import LauncherSignature
 verifyLauncherSignature()
 
 let corpusId = ProcessInfo.processInfo.environment["DEFAULT_CORPUS_ID"] ?? "tools-factory"
-let storePath = ProcessInfo.processInfo.environment["FOUNTAIN_STORE_PATH"] ?? "./data/fountain-store"
-do {
-    try FileManager.default.createDirectory(atPath: storePath, withIntermediateDirectories: true)
-} catch {
-    FileHandle.standardError.write(Data("[bootstrap] Failed to create store directory: \(error)\n".utf8))
-}
-let svc = FountainStoreClient(client: EmbeddedFountainStoreClient(path: storePath))
+let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
 Task {
     await svc.ensureCollections(corpusId: corpusId)
     let server = NIOHTTPServer(kernel: makeBootstrapKernel(service: svc))

--- a/apps/FunctionCallerServer/main.swift
+++ b/apps/FunctionCallerServer/main.swift
@@ -8,13 +8,7 @@ import LauncherSignature
 verifyLauncherSignature()
 
 let corpusId = ProcessInfo.processInfo.environment["DEFAULT_CORPUS_ID"] ?? "tools-factory"
-let storePath = ProcessInfo.processInfo.environment["FOUNTAIN_STORE_PATH"] ?? "./data/fountain-store"
-do {
-    try FileManager.default.createDirectory(atPath: storePath, withIntermediateDirectories: true)
-} catch {
-    FileHandle.standardError.write(Data("[function-caller] Failed to create store directory: \(error)\n".utf8))
-}
-let svc = FountainStoreClient(client: EmbeddedFountainStoreClient(path: storePath))
+let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
 Task {
     await svc.ensureCollections(corpusId: corpusId)
     let kernel = makeFunctionCallerKernel(service: svc)

--- a/apps/PersistServer/main.swift
+++ b/apps/PersistServer/main.swift
@@ -7,13 +7,7 @@ import LauncherSignature
 verifyLauncherSignature()
 
 let corpusId = ProcessInfo.processInfo.environment["DEFAULT_CORPUS_ID"] ?? "tools-factory"
-let storePath = ProcessInfo.processInfo.environment["FOUNTAIN_STORE_PATH"] ?? "./data/fountain-store"
-do {
-    try FileManager.default.createDirectory(atPath: storePath, withIntermediateDirectories: true)
-} catch {
-    FileHandle.standardError.write(Data("[persist] Failed to create store directory: \(error)\n".utf8))
-}
-let svc = FountainStoreClient(client: EmbeddedFountainStoreClient(path: storePath))
+let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
 Task {
     await svc.ensureCollections(corpusId: corpusId)
     let kernel = makePersistKernel(service: svc)

--- a/apps/PlannerServer/main.swift
+++ b/apps/PlannerServer/main.swift
@@ -8,13 +8,7 @@ import LauncherSignature
 verifyLauncherSignature()
 
 let corpusId = ProcessInfo.processInfo.environment["DEFAULT_CORPUS_ID"] ?? "tools-factory"
-let storePath = ProcessInfo.processInfo.environment["FOUNTAIN_STORE_PATH"] ?? "./data/fountain-store"
-do {
-    try FileManager.default.createDirectory(atPath: storePath, withIntermediateDirectories: true)
-} catch {
-    FileHandle.standardError.write(Data("[planner] Failed to create store directory: \(error)\n".utf8))
-}
-let svc = FountainStoreClient(client: EmbeddedFountainStoreClient(path: storePath))
+let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
 Task {
     await svc.ensureCollections(corpusId: corpusId)
     let kernel = makePlannerKernel(service: svc)

--- a/apps/ToolsFactoryServer/main.swift
+++ b/apps/ToolsFactoryServer/main.swift
@@ -22,13 +22,7 @@ let manifest = (try? ToolManifest.load(from: manifestURL)) ?? ToolManifest(image
 let corpusId = ProcessInfo.processInfo.environment["TOOLS_FACTORY_CORPUS_ID"] ??
                ProcessInfo.processInfo.environment["DEFAULT_CORPUS_ID"] ?? "tools-factory"
 
-let storePath = ProcessInfo.processInfo.environment["FOUNTAIN_STORE_PATH"] ?? "./data/fountain-store"
-do {
-    try FileManager.default.createDirectory(atPath: storePath, withIntermediateDirectories: true)
-} catch {
-    FileHandle.standardError.write(Data("[tools-factory] Failed to create store directory: \(error)\n".utf8))
-}
-let svc = FountainStoreClient(client: EmbeddedFountainStoreClient(path: storePath))
+let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
 Task {
     await svc.ensureCollections(corpusId: corpusId)
     try? await publishFunctions(manifest: manifest, corpusId: corpusId, service: svc)


### PR DESCRIPTION
## Summary
- drop obsolete `path` argument from `EmbeddedFountainStoreClient` initializers
- simplify server entry points to use in-memory store

## Testing
- `swift test --filter FountainStoreClientTests`


------
https://chatgpt.com/codex/tasks/task_b_68b91899ff84833380296b06ec97fb34