### PR TITLE
test: add GatewayPersona orchestrator tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -446,6 +446,16 @@ let fullTargets: [Target] = [
         path: "Tests/GatewayPluginsTests"
     ),
     .testTarget(
+        name: "GatewayPersonaOrchestratorTests",
+        dependencies: [
+            "GatewayPersonaOrchestrator",
+            "FountainRuntime",
+            "SecuritySentinelGatewayPlugin",
+            "DestructiveGuardianGatewayPlugin"
+        ],
+        path: "Tests/GatewayPersonaOrchestratorTests"
+    ),
+    .testTarget(
         name: "LauncherSignatureTests",
         dependencies: ["LauncherSignature"],
         path: "Tests/LauncherSignatureTests"
@@ -643,6 +653,16 @@ let leanTargets: [Target] = [
             .product(name: "Crypto", package: "swift-crypto")
         ],
         path: "Tests/GatewayPluginsTests"
+    ),
+    .testTarget(
+        name: "GatewayPersonaOrchestratorTests",
+        dependencies: [
+            "GatewayPersonaOrchestrator",
+            "FountainRuntime",
+            "SecuritySentinelGatewayPlugin",
+            "DestructiveGuardianGatewayPlugin"
+        ],
+        path: "Tests/GatewayPersonaOrchestratorTests"
     ),
     .testTarget(
         name: "LauncherSignatureTests",

--- a/Tests/GatewayPersonaOrchestratorTests/GatewayPersonaOrchestratorTests.swift
+++ b/Tests/GatewayPersonaOrchestratorTests/GatewayPersonaOrchestratorTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+@testable import GatewayPersonaOrchestrator
+import FountainRuntime
+import SecuritySentinelGatewayPlugin
+import DestructiveGuardianGatewayPlugin
+
+final class GatewayPersonaOrchestratorTests: XCTestCase {
+    struct StubPersona: GatewayPersona {
+        let name: String
+        let verdict: GatewayPersonaVerdict
+        func evaluate(_ request: HTTPRequest) async -> GatewayPersonaVerdict { verdict }
+    }
+
+    struct StubSentinelClient: SecuritySentinelClient {
+        let action: @Sendable () throws -> SentinelDecision
+        func consult(summary: String, context: [String : (any Codable & Sendable)]?) async throws -> SentinelDecision {
+            try action()
+        }
+    }
+
+    struct StubGuardianHandler: GuardianEvaluating {
+        let action: @Sendable (HTTPRequest, GuardianEvaluateRequest?) throws -> HTTPResponse
+        func guardianEvaluate(_ request: HTTPRequest, body: GuardianEvaluateRequest?) async throws -> HTTPResponse {
+            try action(request, body)
+        }
+    }
+
+    func testDenyShortCircuitsToDeny() async {
+        let personas: [GatewayPersona] = [
+            StubPersona(name: "allow", verdict: .allow),
+            StubPersona(name: "deny", verdict: .deny(reason: "nope", persona: "deny")),
+            StubPersona(name: "escalate", verdict: .escalate(reason: "maybe", persona: "escalate"))
+        ]
+        let orchestrator = GatewayPersonaOrchestrator(personas: personas)
+        let result = await orchestrator.decide(for: HTTPRequest(method: "GET", path: "/"))
+        if case .deny(_, let p) = result {
+            XCTAssertEqual(p, "deny")
+        } else {
+            XCTFail("expected deny")
+        }
+    }
+
+    func testMixedAllowAndEscalateYieldsEscalate() async {
+        let personas: [GatewayPersona] = [
+            StubPersona(name: "esc", verdict: .escalate(reason: "maybe", persona: "esc")),
+            StubPersona(name: "allow", verdict: .allow)
+        ]
+        let orchestrator = GatewayPersonaOrchestrator(personas: personas)
+        let result = await orchestrator.decide(for: HTTPRequest(method: "GET", path: "/"))
+        if case .escalate(_, let p) = result {
+            XCTAssertEqual(p, "esc")
+        } else {
+            XCTFail("expected escalate")
+        }
+    }
+
+    func testAllAllowReturnsAllow() async {
+        let personas: [GatewayPersona] = [
+            StubPersona(name: "one", verdict: .allow),
+            StubPersona(name: "two", verdict: .allow)
+        ]
+        let orchestrator = GatewayPersonaOrchestrator(personas: personas)
+        let result = await orchestrator.decide(for: HTTPRequest(method: "GET", path: "/"))
+        if case .allow = result {
+            // success
+        } else {
+            XCTFail("expected allow")
+        }
+    }
+
+    func testSecuritySentinelPersonaBranches() async {
+        let request = HTTPRequest(method: "GET", path: "/")
+        let makeDecision: @Sendable (SentinelVerdict) -> SentinelDecision = { verdict in
+            SentinelDecision(decision: verdict,
+                             reason: "r",
+                             confidence: nil,
+                             model: nil,
+                             requestID: "id",
+                             latencyMS: 0,
+                             source: .llm,
+                             timestamp: "t")
+        }
+        var persona = SecuritySentinelPersona(client: StubSentinelClient { makeDecision(.allow) })
+        var res = await persona.evaluate(request)
+        if case .allow = res {} else { XCTFail("expected allow") }
+
+        persona = SecuritySentinelPersona(client: StubSentinelClient { makeDecision(.deny) })
+        res = await persona.evaluate(request)
+        if case .deny(_, let name) = res {
+            XCTAssertEqual(name, "SecuritySentinel")
+        } else { XCTFail("expected deny") }
+
+        persona = SecuritySentinelPersona(client: StubSentinelClient { makeDecision(.escalate) })
+        res = await persona.evaluate(request)
+        if case .escalate(_, let name) = res {
+            XCTAssertEqual(name, "SecuritySentinel")
+        } else { XCTFail("expected escalate") }
+
+        struct TestError: Error {}
+        persona = SecuritySentinelPersona(client: StubSentinelClient { throw TestError() })
+        res = await persona.evaluate(request)
+        if case .escalate(let reason, let name) = res {
+            XCTAssertEqual(name, "SecuritySentinel")
+            XCTAssertTrue(reason.contains("error"))
+        } else { XCTFail("expected escalate on error") }
+    }
+
+    func testDestructiveGuardianPersonaBranches() async {
+        let request = HTTPRequest(method: "DELETE", path: "/danger")
+        let makeResponse: @Sendable (String) -> HTTPResponse = { decision in
+            let data = try! JSONEncoder().encode(["decision": decision])
+            return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: data)
+        }
+
+        var persona = DestructiveGuardianPersona(handler: StubGuardianHandler { _, _ in makeResponse("allow") })
+        var res = await persona.evaluate(request)
+        if case .allow = res {} else { XCTFail("expected allow") }
+
+        persona = DestructiveGuardianPersona(handler: StubGuardianHandler { _, _ in makeResponse("deny") })
+        res = await persona.evaluate(request)
+        if case .deny(_, let name) = res {
+            XCTAssertEqual(name, "DestructiveGuardian")
+        } else { XCTFail("expected deny") }
+
+        persona = DestructiveGuardianPersona(handler: StubGuardianHandler { _, _ in HTTPResponse(status: 200, body: Data("oops".utf8)) })
+        res = await persona.evaluate(request)
+        if case .escalate(let reason, let name) = res {
+            XCTAssertEqual(name, "DestructiveGuardian")
+            XCTAssertTrue(reason.contains("invalid"))
+        } else { XCTFail("expected escalate") }
+
+        struct TestError: Error {}
+        persona = DestructiveGuardianPersona(handler: StubGuardianHandler { _, _ in throw TestError() })
+        res = await persona.evaluate(request)
+        if case .escalate(let reason, let name) = res {
+            XCTAssertEqual(name, "DestructiveGuardian")
+            XCTAssertTrue(reason.contains("error"))
+        } else { XCTFail("expected escalate on error") }
+    }
+}
+

--- a/libs/GatewayPersonaOrchestrator/GatewayPersonaOrchestrator/GatewayPersonaOrchestrator.swift
+++ b/libs/GatewayPersonaOrchestrator/GatewayPersonaOrchestrator/GatewayPersonaOrchestrator.swift
@@ -95,19 +95,30 @@ public struct SecuritySentinelPersona: GatewayPersona {
     }
 }
 
+/// Abstraction over types capable of performing destructive guardian evaluations.
+public protocol GuardianEvaluating: Sendable {
+    func guardianEvaluate(_ request: HTTPRequest, body: GuardianEvaluateRequest?) async throws -> HTTPResponse
+}
+
+extension Handlers: GuardianEvaluating {}
+
 /// Persona enforcing destructive operation policies.
 public struct DestructiveGuardianPersona: GatewayPersona {
-    private let handlers: Handlers
+    private let handler: any GuardianEvaluating
     public var name: String { "DestructiveGuardian" }
 
     public init(sensitivePaths: [String] = ["/"],
                 privilegedTokens: [String] = [],
                 auditURL: URL = URL(fileURLWithPath: "logs/guardian.log")) {
-        self.handlers = Handlers(
+        self.handler = Handlers(
             sensitivePaths: sensitivePaths,
             privilegedTokens: Set(privilegedTokens),
             auditURL: auditURL
         )
+    }
+
+    public init(handler: any GuardianEvaluating) {
+        self.handler = handler
     }
 
     public func evaluate(_ request: HTTPRequest) async -> GatewayPersonaVerdict {
@@ -116,7 +127,7 @@ public struct DestructiveGuardianPersona: GatewayPersona {
                                            manualApproval: false,
                                            serviceToken: nil)
         do {
-            let resp = try await handlers.guardianEvaluate(request, body: body)
+            let resp = try await handler.guardianEvaluate(request, body: body)
             if let decision = try? JSONDecoder().decode(GuardianEvaluateResponse.self, from: resp.body) {
                 if decision.decision.lowercased() == "allow" {
                     return .allow


### PR DESCRIPTION
## Summary
- expand DestructiveGuardianPersona with injectable guardian evaluator
- add GatewayPersonaOrchestrator test target and cover deny/allow/escalate flows

## Testing
- `swift test --filter GatewayPersonaOrchestratorTests`


------
https://chatgpt.com/codex/tasks/task_b_68b91ee33f908333a5d6c575374c8ac7