### PR TITLE
test: cover auth claims llm

### DIFF
--- a/Tests/GatewayPluginsTests/AuthGatewayPluginTests.swift
+++ b/Tests/GatewayPluginsTests/AuthGatewayPluginTests.swift
@@ -1,6 +1,32 @@
 import XCTest
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import FountainRuntime
 import AuthGatewayPlugin
+
+private class MockURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var responseData: Data = Data()
+    nonisolated(unsafe) static var error: Error?
+    nonisolated(unsafe) static var lastRequest: URLRequest?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+    override func startLoading() {
+        Self.lastRequest = request
+        if let error = Self.error {
+            client?.urlProtocol(self, didFailWithError: error)
+            return
+        }
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.responseData)
+        client?.urlProtocolDidFinishLoading(self)
+    }
+    override func stopLoading() {}
+}
+
 final class AuthGatewayPluginTests: XCTestCase {
     func testValidateUsesLLM() async throws {
         let plugin = AuthGatewayPlugin()
@@ -9,4 +35,38 @@ final class AuthGatewayPluginTests: XCTestCase {
         let response = try await plugin.router.route(request)
         XCTAssertEqual(response?.status, 200)
     }
+
+    func testClaimsUsesLLM() async throws {
+        _ = URLProtocol.registerClass(MockURLProtocol.self)
+        defer { URLProtocol.unregisterClass(MockURLProtocol.self); MockURLProtocol.lastRequest = nil }
+        let token = "Bearer stub-token"
+        MockURLProtocol.error = nil
+        MockURLProtocol.responseData = Data("{\"ok\":true}".utf8)
+
+        let plugin = AuthGatewayPlugin()
+        let request = HTTPRequest(method: "POST", path: "/auth/claims", headers: ["Authorization": token])
+        let response = try await plugin.router.route(request)
+        XCTAssertEqual(response?.status, 200)
+
+        let last = try XCTUnwrap(MockURLProtocol.lastRequest)
+        let body = try XCTUnwrap(last.httpBody)
+        let json = try JSONSerialization.jsonObject(with: body) as? [String: String]
+        XCTAssertEqual(json?["prompt"], token)
+    }
+
+    func testLLMErrorFallsBack() async throws {
+        _ = URLProtocol.registerClass(MockURLProtocol.self)
+        defer { URLProtocol.unregisterClass(MockURLProtocol.self) }
+        MockURLProtocol.error = URLError(.badServerResponse)
+
+        let plugin = AuthGatewayPlugin()
+        let request = HTTPRequest(method: "POST", path: "/auth/claims", headers: ["Authorization": "Bearer token"])
+        let response = try await plugin.router.route(request)
+        XCTAssertEqual(response?.status, 200)
+        let body = String(data: response?.body ?? Data(), encoding: .utf8)
+        XCTAssertEqual(body, "{}")
+    }
 }
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+

--- a/libs/GatewayPlugins/AuthGatewayPlugin/AuthGatewayPlugin/Router.swift
+++ b/libs/GatewayPlugins/AuthGatewayPlugin/AuthGatewayPlugin/Router.swift
@@ -12,7 +12,7 @@ public struct Router: Sendable {
         case ("POST", "/auth/validate"):
             let body = try? JSONDecoder().decode(ValidateRequest.self, from: request.body)
             return try await handlers.authValidate(request, body: body)
-        case ("GET", "/auth/claims"):
+        case ("POST", "/auth/claims"), ("GET", "/auth/claims"):
             return try await handlers.authClaims(request, body: nil)
         default:
             return nil


### PR DESCRIPTION
## Summary
- add tests for `/auth/claims` to ensure LLM invocation and error fallback
- support POST requests for `/auth/claims` in router

## Testing
- `swift test --filter AuthGatewayPluginTests`


------
https://chatgpt.com/codex/tasks/task_b_68b91eeb09c88333b67c5d033dc0e135