### PR TITLE
Add rate limiter tests for stats and minute reset

### DIFF
--- a/Tests/GatewayPluginsTests/RateLimiterGatewayPluginTests.swift
+++ b/Tests/GatewayPluginsTests/RateLimiterGatewayPluginTests.swift
@@ -1,13 +1,45 @@
 import XCTest
 import FountainRuntime
-import RateLimiterGatewayPlugin
+@testable import RateLimiterGatewayPlugin
 
 final class RateLimiterGatewayPluginTests: XCTestCase {
-    func testCheckUsesLLM() async throws {
-        let plugin = RateLimiterGatewayPlugin()
-        let body = try JSONEncoder().encode(RateLimitCheckRequest(routeId: "r", clientId: "c", limitPerMinute: nil))
-        let request = HTTPRequest(method: "POST", path: "/rate-limit/check", body: body)
+    struct ThrowingClient: LLMClient {
+        func call(prompt: String) async throws -> String { throw URLError(.badServerResponse) }
+    }
+
+    final class MutableDate: @unchecked Sendable {
+        var value: Date
+        init(_ value: Date) { self.value = value }
+    }
+
+    func testAllowThrottleResetAndStats() async throws {
+        let dateBox = MutableDate(Date())
+        let plugin = RateLimiterGatewayPlugin(defaultLimit: 2, client: ThrowingClient(), date: { dateBox.value })
+
+        let first = await plugin.allow(routeId: "r", clientId: "c", limitPerMinute: nil)
+        XCTAssertTrue(first)
+        let second = await plugin.allow(routeId: "r", clientId: "c", limitPerMinute: nil)
+        XCTAssertTrue(second)
+        let third = await plugin.allow(routeId: "r", clientId: "c", limitPerMinute: nil)
+        XCTAssertFalse(third)
+
+        let firstStats = await plugin.stats()
+        XCTAssertEqual(firstStats.allowed, 2)
+        XCTAssertEqual(firstStats.throttled, 1)
+
+        dateBox.value = dateBox.value.addingTimeInterval(60)
+        let fourth = await plugin.allow(routeId: "r", clientId: "c", limitPerMinute: nil)
+        XCTAssertTrue(fourth)
+
+        let secondStats = await plugin.stats()
+        XCTAssertEqual(secondStats.allowed, 3)
+        XCTAssertEqual(secondStats.throttled, 1)
+
+        let request = HTTPRequest(method: "GET", path: "/rate-limit/stats")
         let response = try await plugin.router.route(request)
         XCTAssertEqual(response?.status, 200)
+        let statsResp = try JSONDecoder().decode(RateLimitStatsResponse.self, from: response?.body ?? Data())
+        XCTAssertEqual(statsResp.allowed, 3)
+        XCTAssertEqual(statsResp.throttled, 1)
     }
 }

--- a/libs/GatewayPlugins/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin/Handlers.swift
+++ b/libs/GatewayPlugins/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin/Handlers.swift
@@ -4,16 +4,25 @@ import FoundationNetworking
 #endif
 import FountainRuntime
 
+public protocol LLMClient: Sendable {
+    func call(prompt: String) async throws -> String
+}
+
 /// Handlers for rate limiter gateway endpoints using an LLM backend.
 public actor Handlers {
-    private let client = LLMPluginClient(personaPath: "openapi/personas/rate-limiter.md")
+    private let client: LLMClient
     private let defaultLimit: Int
+    private let date: @Sendable () -> Date
     private var buckets: [String: (minute: Int, count: Int)] = [:]
     private var allowedTotal = 0
     private var throttledTotal = 0
 
-    public init(defaultLimit: Int = 60) {
+    public init(defaultLimit: Int = 60,
+                client: LLMClient? = nil,
+                date: @Sendable @escaping () -> Date = Date.init) {
         self.defaultLimit = defaultLimit
+        self.client = client ?? LLMPluginClient(personaPath: "openapi/personas/rate-limiter.md")
+        self.date = date
     }
 
     /// Returns whether the request is within its rate limit.
@@ -64,7 +73,7 @@ public actor Handlers {
 
     private func localAllow(routeId: String, clientId: String, limit: Int) -> Bool {
         let key = "\(routeId)|\(clientId)"
-        let minute = Int(Date().timeIntervalSince1970 / 60)
+        let minute = Int(date().timeIntervalSince1970 / 60)
         var bucket = buckets[key] ?? (minute: minute, count: 0)
         if bucket.minute != minute {
             bucket = (minute: minute, count: 0)
@@ -103,5 +112,7 @@ struct LLMPluginClient {
         return String(data: data, encoding: .utf8) ?? "{}"
     }
 }
+
+extension LLMPluginClient: LLMClient {}
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin.swift
+++ b/libs/GatewayPlugins/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin/RateLimiterGatewayPlugin.swift
@@ -6,8 +6,10 @@ public struct RateLimiterGatewayPlugin: Sendable {
     public let router: Router
     private let handlers: Handlers
 
-    public init(defaultLimit: Int = 60) {
-        let h = Handlers(defaultLimit: defaultLimit)
+    public init(defaultLimit: Int = 60,
+                client: LLMClient? = nil,
+                date: @Sendable @escaping () -> Date = Date.init) {
+        let h = Handlers(defaultLimit: defaultLimit, client: client, date: date)
         self.handlers = h
         self.router = Router(handlers: h)
     }


### PR DESCRIPTION
## Summary
- Add injectable LLM client and clock to `RateLimiterGatewayPlugin`
- Verify local fallback, stats endpoint, and minute counter reset in tests

## Testing
- `swift test --filter RateLimiterGatewayPluginTests`


------
https://chatgpt.com/codex/tasks/task_b_68b91ef3850483338528e4771c08f112