### PR TITLE
Inject exit closure for launcher signature

### DIFF
--- a/Tests/LauncherSignatureTests/LauncherSignatureTests.swift
+++ b/Tests/LauncherSignatureTests/LauncherSignatureTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Foundation
 @testable import LauncherSignature
 
 final class LauncherSignatureTests: XCTestCase {
@@ -23,5 +24,28 @@ final class LauncherSignatureTests: XCTestCase {
     func testInvalidSignatureFailsValidation() {
         setenv("LAUNCHER_SIGNATURE", "bogus", 1)
         XCTAssertFalse(isLauncherSignatureValid())
+    }
+
+    func testVerifyLauncherSignatureFailsWithInvalidEnv() {
+        setenv("LAUNCHER_SIGNATURE", "bogus", 1)
+        var status: Int32?
+        let mockExit: (Int32) -> Void = { code in status = code }
+
+        let pipe = Pipe()
+        let fd = dup(STDERR_FILENO)
+        dup2(pipe.fileHandleForWriting.fileDescriptor, STDERR_FILENO)
+
+        verifyLauncherSignature(exit: mockExit)
+
+        fflush(nil)
+        dup2(fd, STDERR_FILENO)
+        pipe.fileHandleForWriting.closeFile()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8) ?? ""
+
+        XCTAssertEqual(status, 1)
+        XCTAssertTrue(output.contains("Missing or invalid launcher signature"))
+
+        unsetenv("LAUNCHER_SIGNATURE")
     }
 }

--- a/libs/LauncherSignature/Verifier.swift
+++ b/libs/LauncherSignature/Verifier.swift
@@ -9,9 +9,12 @@ func isLauncherSignatureValid(
     return runtimeSig == embeddedLauncherSignature
 }
 
-public func verifyLauncherSignature() {
+public func verifyLauncherSignature(
+    exit: (Int32) -> Void = { Foundation.exit($0) }
+) {
     guard isLauncherSignatureValid() else {
         FileHandle.standardError.write(Data("Missing or invalid launcher signature\n".utf8))
         exit(1)
+        return
     }
 }


### PR DESCRIPTION
## Summary
- Allow launcher signature verification to inject a custom exit handler
- Cover failure path by capturing stderr and exit code in tests

## Testing
- `swift test --filter LauncherSignatureTests`

------
https://chatgpt.com/codex/tasks/task_b_68b925e2db208333b424aa5799e0b773