### PR TITLE
Enable PDFiumExtractor dependency injection with mockable API

### DIFF
--- a/Tests/PDFiumExtractorTests/PDFiumExtractorTests.swift
+++ b/Tests/PDFiumExtractorTests/PDFiumExtractorTests.swift
@@ -19,5 +19,48 @@ final class PDFiumExtractorTests: XCTestCase {
         try? Data().write(to: url)
         XCTAssertThrowsError(try extractor.extractText(from: url))
     }
+
+    func testOpenFailedError() {
+        let mock = MockPDFium(openSuccess: false)
+        let extractor = PDFiumExtractor(pdfium: mock)
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("dummy.pdf")
+        XCTAssertThrowsError(try extractor.extractText(from: url, useOCR: false)) { error in
+            XCTAssertEqual(error as? PDFiumExtractorError, .openFailed)
+        }
+    }
+
+    func testSuccessfulExtraction() throws {
+        let mock = MockPDFium(openSuccess: true)
+        let extractor = PDFiumExtractor(pdfium: mock)
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("dummy.pdf")
+        let fragments = try extractor.extractText(from: url, useOCR: false)
+        XCTAssertEqual(fragments.count, 1)
+        XCTAssertEqual(fragments.first?.text, "H")
+    }
+}
+
+private final class MockPDFium: PDFiumLibrary {
+    let isAvailable = true
+    let openSuccess: Bool
+    init(openSuccess: Bool) { self.openSuccess = openSuccess }
+    func loadDocument(_ path: String, _ password: UnsafePointer<CChar>?) -> FPDFDocument? {
+        openSuccess ? FPDFDocument(bitPattern: 1) : nil
+    }
+    func closeDocument(_ document: FPDFDocument) {}
+    func getPageCount(_ document: FPDFDocument) -> Int32 { 1 }
+    func loadPage(_ document: FPDFDocument, _ pageIndex: Int32) -> FPDFPage? {
+        FPDFPage(bitPattern: 1)
+    }
+    func closePage(_ page: FPDFPage) {}
+    func textLoadPage(_ page: FPDFPage) -> FPDFTextPage? { FPDFTextPage(bitPattern: 1) }
+    func textClosePage(_ textPage: FPDFTextPage) {}
+    func textCountChars(_ textPage: FPDFTextPage) -> Int32 { 1 }
+    func textGetCharBox(_ textPage: FPDFTextPage, _ index: Int32, _ left: inout Double, _ right: inout Double, _ bottom: inout Double, _ top: inout Double) {
+        left = 0; right = 1; bottom = 0; top = 1
+    }
+    func textGetText(_ textPage: FPDFTextPage, _ startIndex: Int32, _ count: Int32, _ buffer: inout [UInt16], _ bufferSize: Int32) -> Int32 {
+        buffer[0] = Array("H".utf16)[0]
+        return 1
+    }
 }
 #endif

--- a/libs/PDFiumExtractor/PDFiumExtractor/PDFiumExtractor.swift
+++ b/libs/PDFiumExtractor/PDFiumExtractor/PDFiumExtractor.swift
@@ -32,40 +32,44 @@ public enum PDFiumExtractorError: Error {
 }
 
 public final class PDFiumExtractor {
-    public init() {}
+    private let pdfium: PDFiumLibrary
+    public init(pdfium: PDFiumLibrary = DefaultPDFiumLibrary()) {
+        self.pdfium = pdfium
+    }
     public func extractText(from url: URL, useOCR: Bool = true) throws -> [PDFTextFragment] {
-#if canImport(PDFium)
+        guard pdfium.isAvailable else {
+            throw PDFiumExtractorError.unsupportedPlatform
+        }
         var fragments: [PDFTextFragment] = []
-        guard let document = FPDF_LoadDocument(url.path, nil) else {
+        guard let document = pdfium.loadDocument(url.path, nil) else {
             throw PDFiumExtractorError.openFailed
         }
-        defer { FPDF_CloseDocument(document) }
-        let pageCount = FPDF_GetPageCount(document)
+        defer { pdfium.closeDocument(document) }
+        let pageCount = pdfium.getPageCount(document)
         for pageIndex in 0..<pageCount {
-            guard let page = FPDF_LoadPage(document, pageIndex) else { continue }
-            defer { FPDF_ClosePage(page) }
-            guard let textPage = FPDFText_LoadPage(page) else { continue }
-            defer { FPDFText_ClosePage(textPage) }
-            let charCount = FPDFText_CountChars(textPage)
+            guard let page = pdfium.loadPage(document, pageIndex) else { continue }
+            defer { pdfium.closePage(page) }
+            guard let textPage = pdfium.textLoadPage(page) else { continue }
+            defer { pdfium.textClosePage(textPage) }
+            let charCount = pdfium.textCountChars(textPage)
             for i in 0..<charCount {
                 var left: Double = 0, right: Double = 0, bottom: Double = 0, top: Double = 0
-                FPDFText_GetCharBox(textPage, i, &left, &right, &bottom, &top)
+                pdfium.textGetCharBox(textPage, i, &left, &right, &bottom, &top)
                 var buffer = [UInt16](repeating: 0, count: 8)
-                let count = FPDFText_GetText(textPage, i, 1, &buffer, buffer.count)
+                let count = pdfium.textGetText(textPage, i, 1, &buffer, Int32(buffer.count))
                 if count > 0 {
                     let text = String(decoding: buffer[0..<Int(count)], as: UTF16.self)
                     let rect = Rect(x: left, y: bottom, width: right - left, height: top - bottom)
                     fragments.append(PDFTextFragment(text: text, frame: rect))
                 }
             }
+#if canImport(PDFium)
             if useOCR, hasTesseract {
                 fragments += ocrText(in: page)
             }
+#endif
         }
         return fragments
-#else
-        throw PDFiumExtractorError.unsupportedPlatform
-#endif
     }
 }
 

--- a/libs/PDFiumExtractor/PDFiumExtractor/PDFiumLibrary.swift
+++ b/libs/PDFiumExtractor/PDFiumExtractor/PDFiumLibrary.swift
@@ -1,0 +1,76 @@
+import Foundation
+#if canImport(PDFium)
+import PDFium
+#endif
+
+public typealias FPDFDocument = OpaquePointer
+public typealias FPDFPage = OpaquePointer
+public typealias FPDFTextPage = OpaquePointer
+
+public protocol PDFiumLibrary {
+    var isAvailable: Bool { get }
+    func loadDocument(_ path: String, _ password: UnsafePointer<CChar>?) -> FPDFDocument?
+    func closeDocument(_ document: FPDFDocument)
+    func getPageCount(_ document: FPDFDocument) -> Int32
+    func loadPage(_ document: FPDFDocument, _ pageIndex: Int32) -> FPDFPage?
+    func closePage(_ page: FPDFPage)
+    func textLoadPage(_ page: FPDFPage) -> FPDFTextPage?
+    func textClosePage(_ textPage: FPDFTextPage)
+    func textCountChars(_ textPage: FPDFTextPage) -> Int32
+    func textGetCharBox(_ textPage: FPDFTextPage, _ index: Int32, _ left: inout Double, _ right: inout Double, _ bottom: inout Double, _ top: inout Double)
+    func textGetText(_ textPage: FPDFTextPage, _ startIndex: Int32, _ count: Int32, _ buffer: inout [UInt16], _ bufferSize: Int32) -> Int32
+}
+
+#if canImport(PDFium)
+public struct DefaultPDFiumLibrary: PDFiumLibrary {
+    public init() {}
+    public var isAvailable: Bool { true }
+    public func loadDocument(_ path: String, _ password: UnsafePointer<CChar>?) -> FPDFDocument? {
+        FPDF_LoadDocument(path, password)
+    }
+    public func closeDocument(_ document: FPDFDocument) {
+        FPDF_CloseDocument(document)
+    }
+    public func getPageCount(_ document: FPDFDocument) -> Int32 {
+        FPDF_GetPageCount(document)
+    }
+    public func loadPage(_ document: FPDFDocument, _ pageIndex: Int32) -> FPDFPage? {
+        FPDF_LoadPage(document, pageIndex)
+    }
+    public func closePage(_ page: FPDFPage) {
+        FPDF_ClosePage(page)
+    }
+    public func textLoadPage(_ page: FPDFPage) -> FPDFTextPage? {
+        FPDFText_LoadPage(page)
+    }
+    public func textClosePage(_ textPage: FPDFTextPage) {
+        FPDFText_ClosePage(textPage)
+    }
+    public func textCountChars(_ textPage: FPDFTextPage) -> Int32 {
+        FPDFText_CountChars(textPage)
+    }
+    public func textGetCharBox(_ textPage: FPDFTextPage, _ index: Int32, _ left: inout Double, _ right: inout Double, _ bottom: inout Double, _ top: inout Double) {
+        FPDFText_GetCharBox(textPage, index, &left, &right, &bottom, &top)
+    }
+    public func textGetText(_ textPage: FPDFTextPage, _ startIndex: Int32, _ count: Int32, _ buffer: inout [UInt16], _ bufferSize: Int32) -> Int32 {
+        buffer.withUnsafeMutableBufferPointer { ptr in
+            FPDFText_GetText(textPage, startIndex, count, ptr.baseAddress, bufferSize)
+        }
+    }
+}
+#else
+public struct DefaultPDFiumLibrary: PDFiumLibrary {
+    public init() {}
+    public var isAvailable: Bool { false }
+    public func loadDocument(_ path: String, _ password: UnsafePointer<CChar>?) -> FPDFDocument? { nil }
+    public func closeDocument(_ document: FPDFDocument) {}
+    public func getPageCount(_ document: FPDFDocument) -> Int32 { 0 }
+    public func loadPage(_ document: FPDFDocument, _ pageIndex: Int32) -> FPDFPage? { nil }
+    public func closePage(_ page: FPDFPage) {}
+    public func textLoadPage(_ page: FPDFPage) -> FPDFTextPage? { nil }
+    public func textClosePage(_ textPage: FPDFTextPage) {}
+    public func textCountChars(_ textPage: FPDFTextPage) -> Int32 { 0 }
+    public func textGetCharBox(_ textPage: FPDFTextPage, _ index: Int32, _ left: inout Double, _ right: inout Double, _ bottom: inout Double, _ top: inout Double) {}
+    public func textGetText(_ textPage: FPDFTextPage, _ startIndex: Int32, _ count: Int32, _ buffer: inout [UInt16], _ bufferSize: Int32) -> Int32 { 0 }
+}
+#endif


### PR DESCRIPTION
## Summary
- Introduce `PDFiumLibrary` protocol and default implementation to allow mocking PDFium C APIs
- Refactor `PDFiumExtractor` to depend on `PDFiumLibrary`
- Add test double covering open failure and successful text extraction paths

## Testing
- `swift test --enable-code-coverage --filter PDFiumExtractorTests`
- `llvm-cov-19 show .build/debug/the-fountainaiPackageTests.xctest -instr-profile=.build/debug/codecov/default.profdata libs/PDFiumExtractor/PDFiumExtractor/PDFiumExtractor.swift -use-color=false | sed -n '34,80p'`


------
https://chatgpt.com/codex/tasks/task_b_68b925e4c5688333a5977b5ae9f6e817