### PR TITLE
Add OpenAPI fixture and endpoint test

### DIFF
--- a/Tests/ToolsFactoryServiceTests/ToolsFactoryEndpointsTests.swift
+++ b/Tests/ToolsFactoryServiceTests/ToolsFactoryEndpointsTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Foundation
 @testable import ToolsFactoryService
 @testable import FountainStoreClient
 
@@ -60,6 +61,22 @@ final class ToolsFactoryEndpointsTests: XCTestCase {
         XCTAssertEqual(resp.status, 200)
         let text = String(data: resp.body, encoding: .utf8) ?? ""
         XCTAssertTrue(text.contains("tools_factory_uptime_seconds"))
+    }
+
+    func testServesOpenAPIDocument() async throws {
+        let manifest = ToolManifest(
+            image: .init(name: "img", tarball: "t", sha256: "s", qcow2: "q", qcow2_sha256: "qs"),
+            tools: [:],
+            operations: []
+        )
+        let router = ToolsFactoryRouter(service: nil, adapters: [:], manifest: manifest)
+        let cwd = FileManager.default.currentDirectoryPath
+        let dir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        FileManager.default.changeCurrentDirectoryPath(dir.path)
+        defer { FileManager.default.changeCurrentDirectoryPath(cwd) }
+        let resp = try await router.route(.init(method: "GET", path: "/openapi.yaml"))
+        XCTAssertEqual(resp.status, 200)
+        XCTAssertEqual(resp.headers["Content-Type"], "application/yaml")
     }
 }
 

--- a/Tests/ToolsFactoryServiceTests/openapi/v1/tools-factory.yml
+++ b/Tests/ToolsFactoryServiceTests/openapi/v1/tools-factory.yml
@@ -1,0 +1,6 @@
+openapi: 3.1.0
+info:
+  title: Test Tools Factory
+  version: 1.0.0
+paths: {}
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add minimal OpenAPI spec fixture for ToolsFactory tests
- test that `/openapi.yaml` endpoint serves YAML with 200 status

## Testing
- `swift test` *(fails: AuthGatewayPluginTests.testClaimsUsesLLM : XCTUnwrap failed: expected non-nil value of type "URLRequest")*

------
https://chatgpt.com/codex/tasks/task_b_68b925e6469883339d9f81a51359ef6e