### PR TITLE
Add SSE and metrics tests for AwarenessService

### DIFF
--- a/Tests/AwarenessServiceTests/AwarenessServiceTests.swift
+++ b/Tests/AwarenessServiceTests/AwarenessServiceTests.swift
@@ -63,6 +63,21 @@ final class AwarenessServiceTests: XCTestCase {
             XCTAssertNotNil(first["phase"]) ; XCTAssertNotNil(first["weight"]) ; XCTAssertNotNil(first["pct"])
         }
     }
+
+    func testStreamHistoryAnalyticsSSE() async throws {
+        let router = makeRouter()
+        let resp = try await router.route(.init(method: "GET", path: "/corpus/history/stream?sse=1"))
+        XCTAssertEqual(resp.status, 200)
+        XCTAssertEqual(resp.headers["Content-Type"], "text/event-stream")
+    }
+
+    func testMetricsUptime() async throws {
+        let router = makeRouter()
+        let resp = try await router.route(.init(method: "GET", path: "/metrics"))
+        XCTAssertEqual(resp.status, 200)
+        let text = String(decoding: resp.body, as: UTF8.self)
+        XCTAssertTrue(text.starts(with: "awareness_uptime_seconds"))
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add coverage for history streaming with SSE
- verify metrics endpoint reports uptime

## Testing
- `swift test --enable-code-coverage --skip-build` *(fails: AuthGatewayPluginTests.testClaimsUsesLLM)*

------
https://chatgpt.com/codex/tasks/task_b_68b925e84d208333b046b07d3b98557c