### PR TITLE
test(queryparams): cover query param helper

### DIFF
--- a/Tests/AwarenessServiceTests/QueryParamsTests.swift
+++ b/Tests/AwarenessServiceTests/QueryParamsTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import AwarenessService
+
+final class QueryParamsTests: XCTestCase {
+    func testNoQueryReturnsEmptyDictionary() {
+        let result = AwarenessRouter.queryParams(from: "/path")
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testMultipleParametersParsedCorrectly() {
+        let result = AwarenessRouter.queryParams(from: "/path?a=1&b=2")
+        XCTAssertEqual(result["a"], "1")
+        XCTAssertEqual(result["b"], "2")
+        XCTAssertEqual(result.count, 2)
+    }
+
+    func testEmptyValuesAreIgnored() {
+        let result = AwarenessRouter.queryParams(from: "/path?a=&b=2&c")
+        XCTAssertNil(result["a"])
+        XCTAssertEqual(result["b"], "2")
+        XCTAssertNil(result["c"])
+        XCTAssertEqual(result.count, 1)
+    }
+}

--- a/libs/AwarenessService/AwarenessService.swift
+++ b/libs/AwarenessService/AwarenessService.swift
@@ -198,7 +198,7 @@ extension AwarenessRouter {
         var out: [String: String] = [:]
         for pair in query.split(separator: "&") {
             let parts = pair.split(separator: "=", maxSplits: 1).map(String.init)
-            if parts.count == 2 { out[parts[0]] = parts[1] }
+            if parts.count == 2, !parts[1].isEmpty { out[parts[0]] = parts[1] }
         }
         return out
     }


### PR DESCRIPTION
## Summary
- add tests for AwarenessService query parameter parsing
- ignore empty query values

## Testing
- `swift test --filter AwarenessServiceTests.QueryParamsTests/testNoQueryReturnsEmptyDictionary --enable-code-coverage` *(no tests matched)*

------
https://chatgpt.com/codex/tasks/task_b_68b925e9eb848333942165db0b3ec2be