### PR TITLE
Add control plane restart and shutdown tests

### DIFF
--- a/platform/FountainAILauncher/Tests/FountainAiLauncherTests/FountainAiLauncherTests.swift
+++ b/platform/FountainAILauncher/Tests/FountainAiLauncherTests/FountainAiLauncherTests.swift
@@ -4,6 +4,11 @@ import Foundation
 import FoundationNetworking
 #endif
 @testable import FountainAiLauncher
+#if canImport(Glibc)
+import Glibc
+#else
+import Darwin
+#endif
 
 final class FountainAiLauncherTests: XCTestCase {
     func testServiceLaunch() throws {
@@ -108,6 +113,51 @@ final class FountainAiLauncherTests: XCTestCase {
         request.httpMethod = "POST"
         let (_, response) = try await URLSession.shared.data(for: request)
         XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+    }
+
+    /// Restart endpoint returns 404 for unknown service.
+    func testControlPlaneRestartUnknownService() async throws {
+        let supervisor = Supervisor(launcherSignature: "test")
+        let service = Service(name: "Sleep", binaryPath: "/bin/sleep", arguments: ["10"])
+        _ = try supervisor.start(service: service)
+        let cp = ControlPlane(supervisor: supervisor, services: [service])
+        let port = try await cp.start(port: 0)
+        defer {
+            supervisor.terminateAll()
+            Task { try? await cp.stop() }
+        }
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/restart/UnknownService")!)
+        request.httpMethod = "POST"
+        let (_, response) = try await URLSession.shared.data(for: request)
+        XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 404)
+    }
+
+    /// Shutdown endpoint returns 200.
+    func testControlPlaneShutdown() async throws {
+        var fds: [Int32] = [0, 0]
+        XCTAssertEqual(pipe(&fds), 0)
+        let pid = fork()
+        if pid == 0 {
+            close(fds[0])
+            let supervisor = Supervisor(launcherSignature: "test")
+            let cp = ControlPlane(supervisor: supervisor, services: [])
+            Task {
+                let port = try await cp.start(port: 0)
+                let data = "\(port)".data(using: .utf8)!
+                _ = data.withUnsafeBytes { write(fds[1], $0.baseAddress, $0.count) }
+            }
+            dispatchMain()
+        } else {
+            close(fds[1])
+            var buffer = [UInt8](repeating: 0, count: 16)
+            let count = read(fds[0], &buffer, 16)
+            let port = Int(String(bytes: buffer[0..<Int(count)], encoding: .utf8)!.trimmingCharacters(in: .whitespacesAndNewlines))!
+            var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/shutdown")!)
+            request.httpMethod = "POST"
+            let (_, response) = try await URLSession.shared.data(for: request)
+            XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
+            waitpid(pid, nil, 0)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- test POST /restart/UnknownService returns 404
- test POST /shutdown returns 200 without crashing main process

## Testing
- `swift test --package-path platform/FountainAILauncher` *(failed: Exited with unexpected signal code 4)*

------
https://chatgpt.com/codex/tasks/task_b_68b92c9e77c88333a7286cd740a2274b