### PR TITLE
Add tests for missing ToolServer routes and unknown path handling

### DIFF
--- a/Tests/ToolServerTests/ToolServerHandlersTests.swift
+++ b/Tests/ToolServerTests/ToolServerHandlersTests.swift
@@ -21,6 +21,47 @@ final class ToolServerHandlersTests: XCTestCase {
         XCTAssertEqual(String(data: resp.body, encoding: .utf8), "ok")
     }
 
+    func testRunExifToolReturnsOutput() async throws {
+        let h = Handlers(exifToolAdapter: MockAdapter(data: Data("ok".utf8), code: 0, tool: "exiftool"))
+        let router = Router(handlers: h)
+        let req = ToolRequest(args: ["-version"], request_id: "r1")
+        let body = try JSONEncoder().encode(req)
+        let resp = try await router.route(.init(method: "POST", path: "/exiftool", body: body))
+        XCTAssertEqual(resp.status, 200)
+        XCTAssertEqual(String(data: resp.body, encoding: .utf8), "ok")
+    }
+
+    func testRunImageMagickReturnsOutput() async throws {
+        let h = Handlers(imageMagickAdapter: MockAdapter(data: Data("img".utf8), code: 0, tool: "imagemagick"))
+        let router = Router(handlers: h)
+        let req = ToolRequest(args: ["-version"], request_id: "r1")
+        let body = try JSONEncoder().encode(req)
+        let resp = try await router.route(.init(method: "POST", path: "/imagemagick", body: body))
+        XCTAssertEqual(resp.status, 200)
+        XCTAssertEqual(String(data: resp.body, encoding: .utf8), "img")
+        XCTAssertEqual(resp.headers["Content-Type"], "application/octet-stream")
+    }
+
+    func testRunPandocReturnsOutput() async throws {
+        let h = Handlers(pandocAdapter: MockAdapter(data: Data("ok".utf8), code: 0, tool: "pandoc"))
+        let router = Router(handlers: h)
+        let req = ToolRequest(args: ["-v"], request_id: "r1")
+        let body = try JSONEncoder().encode(req)
+        let resp = try await router.route(.init(method: "POST", path: "/pandoc", body: body))
+        XCTAssertEqual(resp.status, 200)
+        XCTAssertEqual(String(data: resp.body, encoding: .utf8), "ok")
+    }
+
+    func testRunLibPlistReturnsOutput() async throws {
+        let h = Handlers(libPlistAdapter: MockAdapter(data: Data("plist".utf8), code: 0, tool: "libplist"))
+        let router = Router(handlers: h)
+        let req = ToolRequest(args: ["--help"], request_id: "r1")
+        let body = try JSONEncoder().encode(req)
+        let resp = try await router.route(.init(method: "POST", path: "/libplist", body: body))
+        XCTAssertEqual(resp.status, 200)
+        XCTAssertEqual(String(data: resp.body, encoding: .utf8), "plist")
+    }
+
     func testPdfScanReturnsIndex() async throws {
         let idx = Index(documents: [["id": "d1"]])
         let data = try JSONEncoder().encode(idx)
@@ -58,6 +99,22 @@ final class ToolServerHandlersTests: XCTestCase {
         XCTAssertEqual(resp.status, 200)
         let out = try JSONDecoder().decode(Matrix.self, from: resp.body)
         XCTAssertEqual(out.schemaVersion, "1")
+    }
+
+    func testPdfIndexValidateReturnsValidation() async throws {
+        let router = Router(handlers: Handlers())
+        let idx = Index(documents: [["id": "d1"]])
+        let body = try JSONEncoder().encode(idx)
+        let resp = try await router.route(.init(method: "POST", path: "/pdf/index/validate", body: body))
+        XCTAssertEqual(resp.status, 200)
+        let out = try JSONDecoder().decode(ValidationResult.self, from: resp.body)
+        XCTAssertTrue(out.ok)
+    }
+
+    func testUnknownPathReturns404() async throws {
+        let router = Router(handlers: Handlers())
+        let resp = try await router.route(.init(method: "GET", path: "/unknown"))
+        XCTAssertEqual(resp.status, 404)
     }
 
     func testOpenAPISpecLoads() throws {


### PR DESCRIPTION
## Summary
- add coverage for `/exiftool`, `/imagemagick`, `/pandoc`, and `/libplist` routes
- test `/pdf/index/validate` and router behavior for unknown paths

## Testing
- `swift test --filter ToolServerHandlersTests`


------
https://chatgpt.com/codex/tasks/task_b_68b92ca44a8c8333bdb943d51043d970