### PR TITLE
Add MIME type resolution tests

### DIFF
--- a/Tests/PublishingFrontendTests/PublishingFrontendTests.swift
+++ b/Tests/PublishingFrontendTests/PublishingFrontendTests.swift
@@ -189,6 +189,25 @@ final class PublishingFrontendTests: XCTestCase {
         try await frontend.stop()
     }
 
+    /// Ensures ``mimeType(forPath:)`` returns expected values for common extensions
+    func testMimeTypeResolvesCommonExtensions() {
+        let cases: [(String, String)] = [
+            ("/tmp/file.css", "text/css"),
+            ("/tmp/file.js", "application/javascript"),
+            ("/tmp/file.json", "application/json"),
+            ("/tmp/file.svg", "image/svg+xml"),
+            ("/tmp/file.png", "image/png"),
+            ("/tmp/file.jpg", "image/jpeg"),
+            ("/tmp/file.gif", "image/gif"),
+            ("/tmp/file.txt", "text/plain"),
+            ("/tmp/file.unknown", "application/octet-stream")
+        ]
+
+        for (path, expected) in cases {
+            XCTAssertEqual(mimeType(forPath: path), expected)
+        }
+    }
+
     @MainActor
     /// Serves files within nested subdirectories.
     func testServerServesNestedFile() async throws {

--- a/libs/PublishingFrontend/PublishingFrontend/PublishingFrontend.swift
+++ b/libs/PublishingFrontend/PublishingFrontend/PublishingFrontend.swift
@@ -85,7 +85,7 @@ public func loadPublishingConfig() throws -> PublishingConfig {
 }
 
 // Basic content-type resolution for common static assets.
-private func mimeType(forPath path: String) -> String {
+func mimeType(forPath path: String) -> String {
     switch URL(fileURLWithPath: path).pathExtension.lowercased() {
     case "html", "htm": return "text/html"
     case "css": return "text/css"


### PR DESCRIPTION
## Summary
- expose `mimeType(forPath:)` for testing
- add parameterized tests covering common file extensions and an unknown fallback

## Testing
- `swift build --target PublishingFrontend`
- `swift test --filter PublishingFrontendTests` *(no tests run; target omitted in lean build)*
- `FULL_TESTS=1 swift test --filter PublishingFrontendTests.PublishingFrontendTests/testMimeTypeResolvesCommonExtensions` *(fails: no such module 'CryptoKit')*

------
https://chatgpt.com/codex/tasks/task_b_68b92caa65748333a86ca0ce256a7ba3