### PR TITLE
Handle unmapped routes and methods in ToolServer

### DIFF
--- a/Tests/ToolServerTests/ToolServerRouterTests.swift
+++ b/Tests/ToolServerTests/ToolServerRouterTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import ToolServerService
+
+final class ToolServerRouterTests: XCTestCase {
+    private func makeRouter() -> Router {
+        Router()
+    }
+
+    func testUnmappedRouteReturns404() async throws {
+        let router = makeRouter()
+        let resp = try await router.route(.init(method: "POST", path: "/unknown"))
+        XCTAssertEqual(resp.status, 404)
+        XCTAssertEqual(resp.headers["Content-Type"], "text/plain")
+        XCTAssertEqual(String(data: resp.body, encoding: .utf8), "Not Found")
+    }
+
+    func testUnsupportedMethodReturns405() async throws {
+        let router = makeRouter()
+        let resp = try await router.route(.init(method: "GET", path: "/ffmpeg"))
+        XCTAssertEqual(resp.status, 405)
+        XCTAssertEqual(resp.headers["Content-Type"], "text/plain")
+        XCTAssertEqual(resp.headers["Allow"], "POST")
+        XCTAssertEqual(String(data: resp.body, encoding: .utf8), "Method Not Allowed")
+    }
+}

--- a/libs/ToolServer/Service/HTTPServer.swift
+++ b/libs/ToolServer/Service/HTTPServer.swift
@@ -23,7 +23,10 @@ public class HTTPServer: URLProtocol {
         let strongSelf = self
         Task { @Sendable in
             do {
-                let resp = try await kernel.handle(req)
+                var resp = try await kernel.handle(req)
+                if resp.headers["Content-Length"] == nil {
+                    resp.headers["Content-Length"] = String(resp.body.count)
+                }
                 let httpResponse = HTTPURLResponse(url: url, statusCode: resp.status, httpVersion: "HTTP/1.1", headerFields: resp.headers)!
                 client?.urlProtocol(strongSelf, didReceive: httpResponse, cacheStoragePolicy: .notAllowed)
                 client?.urlProtocol(strongSelf, didLoad: resp.body)

--- a/libs/ToolServer/Service/Router.swift
+++ b/libs/ToolServer/Service/Router.swift
@@ -38,7 +38,30 @@ public struct Router {
             let body = try? decoder.decode(Index.self, from: request.body)
             return try await handlers.pdfindexvalidate(request, body: body)
         default:
-            return HTTPResponse(status: 404)
+            let paths: Set<String> = [
+                "/ffmpeg",
+                "/exiftool",
+                "/imagemagick",
+                "/pdf/scan",
+                "/pandoc",
+                "/pdf/export-matrix",
+                "/libplist",
+                "/pdf/query",
+                "/pdf/index/validate"
+            ]
+            if paths.contains(request.path) {
+                return HTTPResponse(
+                    status: 405,
+                    headers: ["Content-Type": "text/plain", "Allow": "POST"],
+                    body: Data("Method Not Allowed".utf8)
+                )
+            } else {
+                return HTTPResponse(
+                    status: 404,
+                    headers: ["Content-Type": "text/plain"],
+                    body: Data("Not Found".utf8)
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- differentiate between unknown paths and unsupported HTTP methods in Router with 404/405 plain-text responses
- ensure HTTPServer adds a `Content-Length` header when missing
- test unmapped routes and unsupported methods

## Testing
- `swift test --filter ToolServerTests --skip-build`


------
https://chatgpt.com/codex/tasks/task_b_68b932ec0dd48333865288374813c79d