### PR TITLE
Add supervisor and health monitor tests

### DIFF
--- a/platform/FountainAILauncher/Package.swift
+++ b/platform/FountainAILauncher/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .testTarget(
             name: "FountainAiLauncherTests",
             dependencies: ["FountainAiLauncher"],
-            path: "Tests/FountainAiLauncherTests"
+            path: "Tests"
         )
     ]
 )

--- a/platform/FountainAILauncher/Sources/Supervisor/HealthMonitor.swift
+++ b/platform/FountainAILauncher/Sources/Supervisor/HealthMonitor.swift
@@ -3,9 +3,16 @@ import Foundation
 import FoundationNetworking
 #endif
 
+/// Minimal interface required for supervising services.
+public protocol SupervisorProtocol: AnyObject, Sendable {
+    func restart(service: Service)
+}
+
+extension Supervisor: SupervisorProtocol {}
+
 /// Periodically probes service health endpoints and restarts failing services.
 public final class HealthMonitor {
-    private let supervisor: Supervisor
+    private let supervisor: SupervisorProtocol
     private var timer: DispatchSourceTimer?
     private let interval: TimeInterval
 
@@ -13,7 +20,7 @@ public final class HealthMonitor {
     /// - Parameters:
     ///   - supervisor: Supervisor used for restarting services.
     ///   - interval: Time between health checks in seconds.
-    public init(supervisor: Supervisor, interval: TimeInterval = 5) {
+    public init(supervisor: SupervisorProtocol, interval: TimeInterval = 5) {
         self.supervisor = supervisor
         self.interval = interval
     }

--- a/platform/FountainAILauncher/Tests/HealthMonitorTests.swift
+++ b/platform/FountainAILauncher/Tests/HealthMonitorTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+import Foundation
+@testable import FountainAiLauncher
+
+final class HealthMonitorTests: XCTestCase {
+    final class MockSupervisor: SupervisorProtocol, @unchecked Sendable {
+        var restarted: [String] = []
+        var onRestart: ((Service) -> Void)?
+        func restart(service: Service) {
+            restarted.append(service.name)
+            onRestart?(service)
+        }
+    }
+
+    func testStartMonitoringTriggersRestartOnFailure() {
+        let mock = MockSupervisor()
+        let exp = expectation(description: "restart")
+        mock.onRestart = { _ in exp.fulfill() }
+        var monitor: HealthMonitor? = HealthMonitor(supervisor: mock, interval: 0.1)
+        let failing = Service(name: "Failing", binaryPath: "/bin/echo", port: 65535, healthPath: "/health", shouldRestart: true)
+        monitor?.startMonitoring(services: [failing])
+        wait(for: [exp], timeout: 1.0)
+        monitor = nil
+    }
+
+    func testServicesWithoutPortOrPathAreIgnored() {
+        let mock = MockSupervisor()
+        let exp = expectation(description: "no restart")
+        exp.isInverted = true
+        mock.onRestart = { _ in exp.fulfill() }
+        var monitor: HealthMonitor? = HealthMonitor(supervisor: mock, interval: 0.1)
+        let noPort = Service(name: "NoPort", binaryPath: "/bin/echo", healthPath: "/health", shouldRestart: true)
+        let noPath = Service(name: "NoPath", binaryPath: "/bin/echo", port: 65535, shouldRestart: true)
+        monitor?.startMonitoring(services: [noPort, noPath])
+        wait(for: [exp], timeout: 0.5)
+        XCTAssertTrue(mock.restarted.isEmpty)
+        monitor = nil
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/platform/FountainAILauncher/Tests/SupervisorTests.swift
+++ b/platform/FountainAILauncher/Tests/SupervisorTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+import Foundation
+@testable import FountainAiLauncher
+#if canImport(Glibc)
+import Glibc
+#else
+import Darwin
+#endif
+
+final class SupervisorTests: XCTestCase {
+    func testStartRegistersProcess() throws {
+        let supervisor = Supervisor(launcherSignature: "test")
+        let service = Service(name: "Sleep", binaryPath: "/bin/sleep", arguments: ["5"])
+        let process = try supervisor.start(service: service)
+        defer { supervisor.terminateAll() }
+        XCTAssertTrue(process.isRunning)
+        XCTAssertTrue(supervisor.isRunning(serviceName: service.name))
+    }
+
+    func testRestartReplacesProcess() throws {
+        let supervisor = Supervisor(launcherSignature: "test")
+        let service = Service(name: "Sleep", binaryPath: "/bin/sleep", arguments: ["5"])
+        let process = try supervisor.start(service: service)
+        XCTAssertTrue(process.isRunning)
+        supervisor.restart(service: service)
+        sleep(1)
+        XCTAssertFalse(process.isRunning)
+        XCTAssertTrue(supervisor.isRunning(serviceName: service.name))
+        supervisor.terminateAll()
+    }
+
+    func testTerminateAllClearsProcesses() throws {
+        let supervisor = Supervisor(launcherSignature: "test")
+        let service1 = Service(name: "Sleep1", binaryPath: "/bin/sleep", arguments: ["5"])
+        let service2 = Service(name: "Sleep2", binaryPath: "/bin/sleep", arguments: ["5"])
+        _ = try supervisor.start(service: service1)
+        _ = try supervisor.start(service: service2)
+        XCTAssertTrue(supervisor.isRunning(serviceName: service1.name))
+        XCTAssertTrue(supervisor.isRunning(serviceName: service2.name))
+        supervisor.terminateAll()
+        sleep(1)
+        XCTAssertFalse(supervisor.isRunning(serviceName: service1.name))
+        XCTAssertFalse(supervisor.isRunning(serviceName: service2.name))
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- allow HealthMonitor to work with a protocol-based supervisor for testing
- cover Supervisor start, restart, and terminateAll behavior
- verify HealthMonitor restart logic and ignoring uncheckable services

## Testing
- `swift test --package-path platform/FountainAILauncher --filter SupervisorTests`
- `swift test --package-path platform/FountainAILauncher --filter HealthMonitorTests`


------
https://chatgpt.com/codex/tasks/task_b_68b939c1f244833392b17ae6656a36ec