### PR TITLE
Add dashboard model and view tests

### DIFF
--- a/platform/FountainAILauncher/Package.swift
+++ b/platform/FountainAILauncher/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .testTarget(
             name: "FountainAiLauncherTests",
             dependencies: ["FountainAiLauncher"],
-            path: "Tests/FountainAiLauncherTests"
+            path: "Tests"
         )
     ]
 )

--- a/platform/FountainAILauncher/Sources/ControlPlane/ControlPlane.swift
+++ b/platform/FountainAILauncher/Sources/ControlPlane/ControlPlane.swift
@@ -87,7 +87,7 @@ public final class ControlPlane: @unchecked Sendable {
 }
 
 /// Status information returned by the control plane.
-public struct ServiceStatus: Codable, Sendable {
+public struct ServiceStatus: Codable, Sendable, Equatable {
     /// Service name.
     public let name: String
     /// Whether the process is running.

--- a/platform/FountainAILauncher/Sources/ControlPlane/UI/DashboardModel.swift
+++ b/platform/FountainAILauncher/Sources/ControlPlane/UI/DashboardModel.swift
@@ -49,4 +49,20 @@ public final class ControlPlaneUIModel: ObservableObject {
         }
     }
 }
+#else
+
+/// Lightweight dashboard representation used on platforms
+/// where the full SwiftUI implementation is unavailable.
+/// Encodes supervisor state for HTML/Markdown rendering.
+public struct DashboardModel: Codable, Equatable {
+    /// Latest service statuses reported by the control plane.
+    public var statuses: [ServiceStatus]
+    /// Accumulated log lines streamed from supervised services.
+    public var logs: [String]
+
+    public init(statuses: [ServiceStatus] = [], logs: [String] = []) {
+        self.statuses = statuses
+        self.logs = logs
+    }
+}
 #endif

--- a/platform/FountainAILauncher/Sources/ControlPlane/UI/DashboardView.swift
+++ b/platform/FountainAILauncher/Sources/ControlPlane/UI/DashboardView.swift
@@ -42,4 +42,34 @@ public struct ControlPlaneDashboardView: View {
         .padding()
     }
 }
+#else
+
+/// Minimal renderer producing HTML and Markdown output from a ``DashboardModel``.
+/// This fallback is used in environments without SwiftUI.
+public struct DashboardView {
+    public let model: DashboardModel
+
+    public init(model: DashboardModel) {
+        self.model = model
+    }
+
+    /// Render the model into a very small HTML snippet.
+    public func renderHTML() -> String {
+        let rows = model.statuses.map { status in
+            "<tr><td>\(status.name)</td><td>\(status.running)</td><td>\(status.healthy)</td></tr>"
+        }.joined()
+        let logs = model.logs.map { "<li>\($0)</li>" }.joined()
+        return "<h1>Dashboard</h1><table>\(rows)</table><ul>\(logs)</ul>"
+    }
+
+    /// Render the model into a Markdown table with logs as bullet points.
+    public func renderMarkdown() -> String {
+        var table = "| Service | Running | Healthy |\n|---|---|---|\n"
+        table += model.statuses.map { status in
+            "| \(status.name) | \(status.running) | \(status.healthy) |"
+        }.joined(separator: "\n")
+        let logs = model.logs.map { "- \($0)" }.joined(separator: "\n")
+        return "# Dashboard\n\(table)\n\(logs)"
+    }
+}
 #endif

--- a/platform/FountainAILauncher/Tests/ControlPlaneUITests.swift
+++ b/platform/FountainAILauncher/Tests/ControlPlaneUITests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import FountainAiLauncher
+
+final class ControlPlaneUITests: XCTestCase {
+    /// DashboardModel should round-trip through JSON.
+    func testDashboardModelCodable() throws {
+        let statuses = [ServiceStatus(name: "Echo", running: true, healthy: false)]
+        let model = DashboardModel(statuses: statuses, logs: ["Started"])
+        let data = try JSONEncoder().encode(model)
+        let decoded = try JSONDecoder().decode(DashboardModel.self, from: data)
+        XCTAssertEqual(decoded, model)
+    }
+
+    /// DashboardView should render model values into HTML and Markdown.
+    func testDashboardViewRendering() {
+        let statuses = [ServiceStatus(name: "Echo", running: true, healthy: false)]
+        let model = DashboardModel(statuses: statuses, logs: ["Started"])
+        let view = DashboardView(model: model)
+
+        let html = view.renderHTML()
+        let expectedHTML = "<h1>Dashboard</h1><table><tr><td>Echo</td><td>true</td><td>false</td></tr></table><ul><li>Started</li></ul>"
+        XCTAssertEqual(html, expectedHTML)
+
+        let markdown = view.renderMarkdown()
+        let expectedMarkdown = [
+            "# Dashboard",
+            "| Service | Running | Healthy |",
+            "|---|---|---|",
+            "| Echo | true | false |",
+            "- Started"
+        ].joined(separator: "\n")
+        XCTAssertEqual(markdown, expectedMarkdown)
+    }
+}


### PR DESCRIPTION
## Summary
- Add lightweight `DashboardModel` for non-SwiftUI platforms
- Add fallback `DashboardView` rendering HTML and Markdown
- Cover dashboard model JSON round-trip and view rendering in tests
- Allow `ServiceStatus` to be compared and expose tests at package root

## Testing
- `swift test` *(fails: Found unhandled resource at .build/checkouts/Teatro/assets/sine.orc)*

------
https://chatgpt.com/codex/tasks/task_b_68b939c9c6b48333a9e0859cce46a08a