### PR TITLE
fix: add plugin dependencies for GatewayPluginsTests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -453,6 +453,10 @@ let fullTargets: [Target] = [
             "AuthGatewayPlugin",
             "PayloadInspectionGatewayPlugin",
             "BudgetBreakerGatewayPlugin",
+            "LLMGatewayPlugin",
+            "RoleHealthCheckGatewayPlugin",
+            "SecuritySentinelGatewayPlugin",
+            "DestructiveGuardianGatewayPlugin",
             "FountainRuntime",
             .product(name: "Crypto", package: "swift-crypto")
         ],
@@ -663,6 +667,10 @@ let leanTargets: [Target] = [
             "AuthGatewayPlugin",
             "PayloadInspectionGatewayPlugin",
             "BudgetBreakerGatewayPlugin",
+            "LLMGatewayPlugin",
+            "RoleHealthCheckGatewayPlugin",
+            "SecuritySentinelGatewayPlugin",
+            "DestructiveGuardianGatewayPlugin",
             "FountainRuntime",
             .product(name: "Crypto", package: "swift-crypto")
         ],


### PR DESCRIPTION
## Summary
- add missing gateway plugin modules to GatewayPluginsTests dependencies so test target links correctly

## Testing
- `swift test --filter GatewayPlugin`


------
https://chatgpt.com/codex/tasks/task_b_68b97bdf6a848333a5c5efd35f8fbbf8