### PR TITLE
docs: add openapi coverage index

### DIFF
--- a/OPENAPI_COVERAGE.md
+++ b/OPENAPI_COVERAGE.md
@@ -1,0 +1,45 @@
+# OpenAPI Coverage Index
+
+This index tracks which FountainAI components expose OpenAPI specifications. Update this file whenever a new service or tool is added to keep coverage consistent.
+
+## Services with OpenAPI Specs
+
+| Service | OpenAPI Spec |
+| --- | --- |
+| Baseline Awareness Service | [openapi/v1/baseline-awareness.yml](openapi/v1/baseline-awareness.yml) |
+| Bootstrap Service | [openapi/v1/bootstrap.yml](openapi/v1/bootstrap.yml) |
+| DNS API | [openapi/v1/dns.yml](openapi/v1/dns.yml) |
+| Function Caller Service | [openapi/v1/function-caller.yml](openapi/v1/function-caller.yml) |
+| Gateway Service | [openapi/v1/gateway.yml](openapi/v1/gateway.yml) |
+| LLM Gateway Plugin | [openapi/v2/llm-gateway.yml](openapi/v2/llm-gateway.yml) |
+| OpenAPI Curator Service | [openapi/v1/openapi-curator.yml](openapi/v1/openapi-curator.yml) |
+| Persistence Service | [openapi/v1/persist.yml](openapi/v1/persist.yml) |
+| Planner Service | [openapi/v1/planner.yml](openapi/v1/planner.yml) |
+| Planner Service (legacy) | [openapi/v0/planner.yml](openapi/v0/planner.yml) |
+| Semantic Browser & Dissector API | [openapi/v1/semantic-browser.yml](openapi/v1/semantic-browser.yml) |
+| Tools Factory Service | [openapi/v1/tools-factory.yml](openapi/v1/tools-factory.yml) |
+| Tool Server | [openapi/v1/tool-server.yml](openapi/v1/tool-server.yml) |
+
+## Gateway Plugins
+
+| Plugin | OpenAPI Spec |
+| --- | --- |
+| Auth Gateway Plugin | [openapi/v1/auth-gateway.yml](openapi/v1/auth-gateway.yml) |
+| Budget Breaker Gateway Plugin | [openapi/v1/budget-breaker-gateway.yml](openapi/v1/budget-breaker-gateway.yml) |
+| Destructive Guardian Gateway Plugin | [openapi/v1/destructive-guardian-gateway.yml](openapi/v1/destructive-guardian-gateway.yml) |
+| Payload Inspection Gateway Plugin | [openapi/v1/payload-inspection-gateway.yml](openapi/v1/payload-inspection-gateway.yml) |
+| Rate Limiter Gateway Plugin | [openapi/v1/rate-limiter-gateway.yml](openapi/v1/rate-limiter-gateway.yml) |
+| Role Health Check Gateway Plugin | [openapi/v1/role-health-check-gateway.yml](openapi/v1/role-health-check-gateway.yml) |
+| Security Sentinel Gateway Plugin | [openapi/v1/security-sentinel-gateway.yml](openapi/v1/security-sentinel-gateway.yml) |
+
+## Utilities and CLIs without OpenAPI Coverage
+
+| Tool/CLI | Rationale |
+| --- | --- |
+| ClientgenService | Generates client code; exposes no HTTP API. |
+| Flexctl | Internal command-line utility; no network surface. |
+| OpenAPICuratorCLI | CLI wrapper around the curator service; spec covers the service instead. |
+| PublishingFrontendCLI | Local publishing helper; not a network service. |
+| SSEClient | Example client for Server-Sent Events; no endpoints to document. |
+
+Keep this index current as the project evolves.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FountainAI Playbill
 
+See [OPENAPI_COVERAGE.md](OPENAPI_COVERAGE.md) for a catalog of services, specs, and tools lacking OpenAPI coverage.
+
 Imagine FountainAI as a bustling theatre. Every user request is a script handed to the stage door, where the `gateway` decides whether the show can begin. The [Gateway API](openapi/v1/gateway.yml) and its [Swift stage crew](services/GatewayServer/GatewayApp) set the scene.
 
 The first actor to read the script is the [Auth Gateway](openapi/personas/auth.md), following the cues in [its contract](openapi/v1/auth-gateway.yml) and the lines in [AuthGatewayPlugin+GatewayPlugin.swift](services/GatewayServer/GatewayApp/AuthGatewayPlugin+GatewayPlugin.swift). If the ticket is valid, the curtain lifts for the next gatekeeper, the [Rate Limiter](openapi/personas/rate-limiter.md), who keeps count using [rate-limiter-gateway.yml](openapi/v1/rate-limiter-gateway.yml) and [RateLimiterGatewayPlugin+GatewayPlugin.swift](services/GatewayServer/GatewayApp/RateLimiterGatewayPlugin+GatewayPlugin.swift).

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -3,6 +3,8 @@
 Versioned service definitions live here. Each YAML file describes a FountainAI service interface.
 Persona definitions for Gateway plugins live in `personas/` and are referenced via `x-persona` in the specs.
 
+For a repository-wide index of OpenAPI coverage, see [../OPENAPI_COVERAGE.md](../OPENAPI_COVERAGE.md).
+
 | Service | Version | Owner | Spec |
 | --- | --- | --- | --- |
 | Auth Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/auth-gateway.yml](v1/auth-gateway.yml) |


### PR DESCRIPTION
## Summary
- document OpenAPI coverage across services and utilities
- cross-link coverage index from repo and OpenAPI READMEs

## Testing
- `swift test` *(fails: AuthGatewayPluginTests.testClaimsUsesLLM: expected non-nil value of type "URLRequest")*
- `python3 scripts/validate_openapi.py`

------
https://chatgpt.com/codex/tasks/task_b_68b9b33f6bf083338c8922ae5972370b