### PR TITLE
chore: link service specs

### DIFF
--- a/services/BaselineAwarenessServer/openapi/baseline-awareness.yml
+++ b/services/BaselineAwarenessServer/openapi/baseline-awareness.yml
@@ -1,0 +1,1 @@
+../../../openapi/v1/baseline-awareness.yml

--- a/services/BootstrapServer/openapi/bootstrap.yml
+++ b/services/BootstrapServer/openapi/bootstrap.yml
@@ -1,0 +1,1 @@
+../../../openapi/v1/bootstrap.yml

--- a/services/FunctionCallerServer/openapi/function-caller.yml
+++ b/services/FunctionCallerServer/openapi/function-caller.yml
@@ -1,0 +1,1 @@
+../../../openapi/v1/function-caller.yml

--- a/services/GatewayServer/openapi/gateway.yml
+++ b/services/GatewayServer/openapi/gateway.yml
@@ -1,0 +1,1 @@
+../../../openapi/v1/gateway.yml

--- a/services/OpenAPICuratorService/openapi/openapi-curator.yml
+++ b/services/OpenAPICuratorService/openapi/openapi-curator.yml
@@ -1,0 +1,1 @@
+../../../openapi/v1/openapi-curator.yml

--- a/services/PersistServer/openapi/persist.yml
+++ b/services/PersistServer/openapi/persist.yml
@@ -1,0 +1,1 @@
+../../../openapi/v1/persist.yml

--- a/services/PlannerServer/openapi/planner.yml
+++ b/services/PlannerServer/openapi/planner.yml
@@ -1,0 +1,1 @@
+../../../openapi/v1/planner.yml

--- a/services/README.md
+++ b/services/README.md
@@ -1,0 +1,19 @@
+# Services
+
+Each service in this directory follows a common layout:
+
+- `README.md` referencing the service's canonical OpenAPI specification.
+- `openapi/` containing symlinks to the spec stored under the repository's top-level `openapi/` directory.
+- Source files (e.g., `main.swift`).
+
+When adding a new service:
+
+1. Add or update the spec under `openapi/v{major}/`.
+2. Create an `openapi/` subfolder in the service directory.
+3. Symlink the spec into the subfolder, e.g.:
+   ```bash
+   ln -s ../../../openapi/v1/my-service.yml services/MyService/openapi/my-service.yml
+   ```
+4. Reference the spec from the service's `README.md`.
+
+This keeps service implementations and their OpenAPI contracts discoverable and consistently organized.

--- a/services/SemanticBrowserServer/openapi/semantic-browser.yml
+++ b/services/SemanticBrowserServer/openapi/semantic-browser.yml
@@ -1,0 +1,1 @@
+../../../openapi/v1/semantic-browser.yml

--- a/services/ToolsFactoryServer/openapi/tools-factory.yml
+++ b/services/ToolsFactoryServer/openapi/tools-factory.yml
@@ -1,0 +1,1 @@
+../../../openapi/v1/tools-factory.yml


### PR DESCRIPTION
## Summary
- add `openapi` subfolders for each service with symlink back to canonical spec
- document service layout and how to link OpenAPI specs

## Testing
- `swift build -c debug`
- `swift test --skip-build --filter GatewayPersonaOrchestratorTests/testAllAllowReturnsAllow`


------
https://chatgpt.com/codex/tasks/task_b_68b9b63910548333ab09b94a125f94b7