### PR TITLE
refactor: resolve DNS test warnings

### DIFF
--- a/Tests/DNSTests/DNSEngineTests.swift
+++ b/Tests/DNSTests/DNSEngineTests.swift
@@ -275,14 +275,14 @@ final class DNSEngineTests: XCTestCase {
     }
 
     func testTypeNameUnknown() {
-        var query = makeQuery(name: "example.com", type: 99)
+        let query = makeQuery(name: "example.com", type: 99)
         var copy = query
         let parser = DNSParser(buffer: &copy)
         XCTAssertEqual(parser?.typeName, "UNKNOWN")
     }
 
     func testMakeResponseInvalidARecordReturnsNil() {
-        var query = makeQuery(name: "bad.com", type: 1)
+        let query = makeQuery(name: "bad.com", type: 1)
         var parserBuf = query
         let parser = DNSParser(buffer: &parserBuf)!
         let record = DNSEngine.Record(name: "bad.com", type: "A", value: "1.2.3")

--- a/Tests/DNSTests/DNSHandlerTests.swift
+++ b/Tests/DNSTests/DNSHandlerTests.swift
@@ -23,7 +23,7 @@ final class DNSHandlerTests: XCTestCase {
         return buf
     }
 
-    final class RecordingHandler: ChannelOutboundHandler {
+    final class RecordingHandler: ChannelOutboundHandler, @unchecked Sendable {
         typealias OutboundIn = ByteBuffer
         typealias OutboundOut = ByteBuffer
         var writeCount = 0
@@ -41,7 +41,7 @@ final class DNSHandlerTests: XCTestCase {
         try channel.pipeline.addHandlers(recorder, handler).wait()
 
         let query = makeQuery(name: "example.com", type: 1)
-        channel.pipeline.fireChannelRead(NIOAny(query))
+        channel.pipeline.fireChannelRead(query)
         channel.embeddedEventLoop.run()
 
         XCTAssertEqual(recorder.writeCount, 1)
@@ -53,8 +53,8 @@ final class DNSHandlerTests: XCTestCase {
     func testChannelReadCompleteFlushesWrites() throws {
         let engine = DNSEngine(records: [.init(name: "example.com", type: "A", value: "1.2.3.4")])
         let channel = EmbeddedChannel(handler: DNSHandler(engine: engine))
-        var query = makeQuery(name: "example.com", type: 1)
-        channel.pipeline.fireChannelRead(NIOAny(query))
+        let query = makeQuery(name: "example.com", type: 1)
+        channel.pipeline.fireChannelRead(query)
         let preFlush: ByteBuffer? = try channel.readOutbound()
         XCTAssertNil(preFlush)
         channel.pipeline.fireChannelReadComplete()


### PR DESCRIPTION
## Summary
- mark DNS test `RecordingHandler` unchecked Sendable and use direct `fireChannelRead`
- convert test queries to constants to avoid mutation warnings

## Testing
- `swift test --filter DNS` *(fails: build aborted after extended dependency build)*

------
https://chatgpt.com/codex/tasks/task_b_68b9bbd67a008333bc80357194ec488a