### PR TITLE
Add codable tests for FountainStoreClient and ToolServer models

### DIFF
--- a/Tests/FountainStoreClientTests/ModelsCodableTests.swift
+++ b/Tests/FountainStoreClientTests/ModelsCodableTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+@testable import FountainStoreClient
+
+final class FountainStoreClientModelsCodableTests: XCTestCase {
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    func testCorpusCodable() throws {
+        let model = Corpus(id: "c1", metadata: ["owner": "me"])
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(Corpus.self, from: data)
+        XCTAssertEqual(decoded.id, "c1")
+        XCTAssertEqual(decoded.metadata["owner"], "me")
+    }
+
+    func testCorpusCreateRequestCodable() throws {
+        let model = CorpusCreateRequest(corpusId: "cid")
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(CorpusCreateRequest.self, from: data)
+        XCTAssertEqual(decoded.corpusId, "cid")
+    }
+
+    func testCorpusResponseCodable() throws {
+        let model = CorpusResponse(corpusId: "cid", message: "ok")
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(CorpusResponse.self, from: data)
+        XCTAssertEqual(decoded.corpusId, "cid")
+        XCTAssertEqual(decoded.message, "ok")
+    }
+
+    func testBaselineCodable() throws {
+        let model = Baseline(corpusId: "c", baselineId: "b", content: "base", ts: 1)
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(Baseline.self, from: data)
+        XCTAssertEqual(decoded.corpusId, "c")
+        XCTAssertEqual(decoded.baselineId, "b")
+        XCTAssertEqual(decoded.content, "base")
+        XCTAssertEqual(decoded.ts, 1)
+    }
+
+    func testReflectionCodable() throws {
+        let model = Reflection(corpusId: "c", reflectionId: "r", question: "q", content: "a", ts: 2)
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(Reflection.self, from: data)
+        XCTAssertEqual(decoded.reflectionId, "r")
+        XCTAssertEqual(decoded.question, "q")
+        XCTAssertEqual(decoded.content, "a")
+        XCTAssertEqual(decoded.ts, 2)
+    }
+
+    func testDriftCodable() throws {
+        let model = Drift(corpusId: "c", driftId: "d", content: "dr", ts: 3)
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(Drift.self, from: data)
+        XCTAssertEqual(decoded.driftId, "d")
+        XCTAssertEqual(decoded.content, "dr")
+        XCTAssertEqual(decoded.ts, 3)
+    }
+
+    func testPatternsCodable() throws {
+        let model = Patterns(corpusId: "c", patternsId: "p", content: "pat", ts: 4)
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(Patterns.self, from: data)
+        XCTAssertEqual(decoded.patternsId, "p")
+        XCTAssertEqual(decoded.content, "pat")
+        XCTAssertEqual(decoded.ts, 4)
+    }
+
+    func testRoleCodable() throws {
+        let model = Role(corpusId: "c", name: "admin", prompt: "do")
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(Role.self, from: data)
+        XCTAssertEqual(decoded.name, "admin")
+        XCTAssertEqual(decoded.prompt, "do")
+    }
+
+    func testPageCodable() throws {
+        let model = Page(corpusId: "c", pageId: "p1", url: "https://x", host: "x", title: "t")
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(Page.self, from: data)
+        XCTAssertEqual(decoded.pageId, "p1")
+        XCTAssertEqual(decoded.url, "https://x")
+        XCTAssertEqual(decoded.host, "x")
+        XCTAssertEqual(decoded.title, "t")
+    }
+
+    func testSegmentCodable() throws {
+        let model = Segment(corpusId: "c", segmentId: "s", pageId: "p", kind: "k", text: "txt")
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(Segment.self, from: data)
+        XCTAssertEqual(decoded.segmentId, "s")
+        XCTAssertEqual(decoded.pageId, "p")
+        XCTAssertEqual(decoded.kind, "k")
+        XCTAssertEqual(decoded.text, "txt")
+    }
+
+    func testEntityCodable() throws {
+        let model = Entity(corpusId: "c", entityId: "e", name: "N", type: "T")
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(Entity.self, from: data)
+        XCTAssertEqual(decoded.entityId, "e")
+        XCTAssertEqual(decoded.name, "N")
+        XCTAssertEqual(decoded.type, "T")
+    }
+
+    func testTableCodable() throws {
+        let model = Table(corpusId: "c", tableId: "t1", pageId: "p", csv: "a,b")
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(Table.self, from: data)
+        XCTAssertEqual(decoded.tableId, "t1")
+        XCTAssertEqual(decoded.pageId, "p")
+        XCTAssertEqual(decoded.csv, "a,b")
+    }
+
+    func testAnalysisRecordCodable() throws {
+        let model = AnalysisRecord(corpusId: "c", analysisId: "a", pageId: "p", summary: "s")
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(AnalysisRecord.self, from: data)
+        XCTAssertEqual(decoded.analysisId, "a")
+        XCTAssertEqual(decoded.pageId, "p")
+        XCTAssertEqual(decoded.summary, "s")
+    }
+
+    func testCapabilitiesCodable() throws {
+        let model = Capabilities(corpus: true, documents: ["upsert"], query: ["byId"], transactions: ["snapshot"], admin: ["health"], experimental: [])
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(Capabilities.self, from: data)
+        XCTAssertTrue(decoded.corpus)
+        XCTAssertEqual(decoded.documents.first, "upsert")
+        XCTAssertEqual(decoded.query.first, "byId")
+        XCTAssertEqual(decoded.transactions.first, "snapshot")
+        XCTAssertEqual(decoded.admin.first, "health")
+    }
+
+    func testFunctionModelCodable() throws {
+        let model = FunctionModel(corpusId: "c", functionId: "f", name: "fn", description: "desc", httpMethod: "GET", httpPath: "/f")
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(FunctionModel.self, from: data)
+        XCTAssertEqual(decoded.functionId, "f")
+        XCTAssertEqual(decoded.name, "fn")
+        XCTAssertEqual(decoded.description, "desc")
+        XCTAssertEqual(decoded.httpMethod, "GET")
+        XCTAssertEqual(decoded.httpPath, "/f")
+    }
+
+    func testSuccessResponseCodable() throws {
+        let model = SuccessResponse(message: "ok")
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(SuccessResponse.self, from: data)
+        XCTAssertEqual(decoded.message, "ok")
+    }
+}
+

--- a/Tests/ToolServerTests/ToolServerModelsTests.swift
+++ b/Tests/ToolServerTests/ToolServerModelsTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import ToolServerService
+
+final class ToolServerModelsTests: XCTestCase {
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    func testBitFieldCodable() throws {
+        let model = BitField(bits: [1,2], name: "flags")
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(BitField.self, from: data)
+        XCTAssertEqual(decoded.bits, [1,2])
+        XCTAssertEqual(decoded.name, "flags")
+    }
+
+    func testEnumCaseCodable() throws {
+        let model = EnumCase(name: "foo", value: 1)
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(EnumCase.self, from: data)
+        XCTAssertEqual(decoded.name, "foo")
+        XCTAssertEqual(decoded.value, 1)
+    }
+
+    func testEnumSpecCodable() throws {
+        let model = EnumSpec(cases: [EnumCase(name: "a", value: 0)], field: "f")
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(EnumSpec.self, from: data)
+        XCTAssertEqual(decoded.cases.first?.name, "a")
+        XCTAssertEqual(decoded.field, "f")
+    }
+
+    func testExportMatrixRequestCodable() throws {
+        let model = ExportMatrixRequest(bitfields: true, enums: true, index: Index(documents: [["id": "1"]]), ranges: false)
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(ExportMatrixRequest.self, from: data)
+        XCTAssertTrue(decoded.bitfields)
+        XCTAssertTrue(decoded.enums)
+        XCTAssertEqual(decoded.index.documents.first?["id"], "1")
+        XCTAssertFalse(decoded.ranges)
+    }
+
+    func testIndexCodable() throws {
+        let model = Index(documents: [["id": "x"], ["id": "y"]])
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(Index.self, from: data)
+        XCTAssertEqual(decoded.documents.count, 2)
+        XCTAssertEqual(decoded.documents.first?["id"], "x")
+    }
+
+    func testMatrixCodable() throws {
+        let bf = BitField(bits: [0], name: "b")
+        let enumSpec = EnumSpec(cases: [EnumCase(name: "c", value: 1)], field: "f")
+        let entry = MatrixEntry(page: 1, text: "t", x: 0, y: 1)
+        let range = RangeSpec(field: "f", max: 10, min: 0)
+        let model = Matrix(bitfields: [bf], enums: [enumSpec], messages: [entry], ranges: [range], schemaVersion: "1", terms: [entry])
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(Matrix.self, from: data)
+        XCTAssertEqual(decoded.schemaVersion, "1")
+        XCTAssertEqual(decoded.bitfields.first?.name, "b")
+        XCTAssertEqual(decoded.enums.first?.field, "f")
+        XCTAssertEqual(decoded.messages.first?.page, 1)
+        XCTAssertEqual(decoded.ranges.first?.max, 10)
+        XCTAssertEqual(decoded.terms.first?.text, "t")
+    }
+
+    func testMatrixEntryCodable() throws {
+        let model = MatrixEntry(page: 2, text: "x", x: 3, y: 4)
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(MatrixEntry.self, from: data)
+        XCTAssertEqual(decoded.page, 2)
+        XCTAssertEqual(decoded.text, "x")
+        XCTAssertEqual(decoded.x, 3)
+        XCTAssertEqual(decoded.y, 4)
+    }
+
+    func testQueryRequestCodable() throws {
+        let model = QueryRequest(index: Index(documents: []), pageRange: "1-2", q: "foo")
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(QueryRequest.self, from: data)
+        XCTAssertEqual(decoded.pageRange, "1-2")
+        XCTAssertEqual(decoded.q, "foo")
+    }
+
+    func testQueryResponseCodable() throws {
+        let model = QueryResponse(hits: [["docId": "d1"]])
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(QueryResponse.self, from: data)
+        XCTAssertEqual(decoded.hits.first?["docId"], "d1")
+    }
+
+    func testRangeSpecCodable() throws {
+        let model = RangeSpec(field: "f", max: 5, min: 1)
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(RangeSpec.self, from: data)
+        XCTAssertEqual(decoded.field, "f")
+        XCTAssertEqual(decoded.max, 5)
+        XCTAssertEqual(decoded.min, 1)
+    }
+
+    func testScanRequestCodable() throws {
+        let model = ScanRequest(includeText: true, inputs: ["a"], sha256: true)
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(ScanRequest.self, from: data)
+        XCTAssertTrue(decoded.includeText)
+        XCTAssertEqual(decoded.inputs, ["a"])
+        XCTAssertTrue(decoded.sha256)
+    }
+
+    func testToolRequestCodable() throws {
+        let model = ToolRequest(args: ["-v"], request_id: "r1")
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(ToolRequest.self, from: data)
+        XCTAssertEqual(decoded.args, ["-v"])
+        XCTAssertEqual(decoded.request_id, "r1")
+    }
+
+    func testValidationResultCodable() throws {
+        let model = ValidationResult(issues: ["a"], ok: true)
+        let data = try encoder.encode(model)
+        let decoded = try decoder.decode(ValidationResult.self, from: data)
+        XCTAssertEqual(decoded.issues, ["a"])
+        XCTAssertTrue(decoded.ok)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add round-trip codable tests for FountainStoreClient data models
- cover ToolServer service models with encoding and decoding tests

## Testing
- `swift test --filter FountainStoreClientModelsCodableTests` *(fails: build exceeded time)*
- `swift test --filter ToolServerModelsTests` *(fails: build exceeded time)*

------
https://chatgpt.com/codex/tasks/task_b_68b9bd5ed4d883338468db679e92b235