### PR TITLE
test: cover FunctionCaller error paths

### DIFF
--- a/Tests/FunctionCallerServiceTests/FunctionCallerServiceTests.swift
+++ b/Tests/FunctionCallerServiceTests/FunctionCallerServiceTests.swift
@@ -38,6 +38,64 @@ final class FunctionCallerServiceTests: XCTestCase {
         let obj = try JSONSerialization.jsonObject(with: invokeResp.body) as? [String: String]
         XCTAssertEqual(obj?["foo"], "bar")
     }
+
+    func testGetFunctionDetailsNotFound() async throws {
+        let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
+        let router = FunctionCallerRouter(persistence: svc)
+        let resp = try await router.route(.init(method: "GET", path: "/functions/missing"))
+        XCTAssertEqual(resp.status, 404)
+        let err = try JSONDecoder().decode(ErrorResponse.self, from: resp.body)
+        XCTAssertEqual(err.error_code, "not_found")
+    }
+
+    func testInvokeFunctionMissing() async throws {
+        let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
+        let router = FunctionCallerRouter(persistence: svc)
+        let resp = try await router.route(.init(method: "POST", path: "/functions/nope/invoke"))
+        XCTAssertEqual(resp.status, 404)
+        let err = try JSONDecoder().decode(ErrorResponse.self, from: resp.body)
+        XCTAssertEqual(err.error_code, "not_found")
+    }
+
+    func testInvokeFunctionError() async throws {
+        let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
+        let fn = FunctionModel(
+            corpusId: "c1",
+            functionId: "boom",
+            name: "Boom",
+            description: "desc",
+            httpMethod: "GET",
+            httpPath: "http://127.0.0.1:1/boom"
+        )
+        _ = try await svc.addFunction(fn)
+        let router = FunctionCallerRouter(persistence: svc)
+        let resp = try await router.route(.init(method: "POST", path: "/functions/boom/invoke"))
+        XCTAssertEqual(resp.status, 500)
+        let err = try JSONDecoder().decode(ErrorResponse.self, from: resp.body)
+        XCTAssertEqual(err.error_code, "invoke_error")
+    }
+
+    func testMetricsEndpoint() async throws {
+        let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
+        let router = FunctionCallerRouter(persistence: svc)
+        let resp = try await router.route(.init(method: "GET", path: "/metrics"))
+        XCTAssertEqual(resp.status, 200)
+        let text = String(data: resp.body, encoding: .utf8) ?? ""
+        XCTAssertTrue(text.contains("function_caller_requests_total"))
+    }
+
+    func testRouteNotFoundReturns404() async throws {
+        let svc = FountainStoreClient(client: EmbeddedFountainStoreClient())
+        let router = FunctionCallerRouter(persistence: svc)
+        let resp = try await router.route(.init(method: "GET", path: "/nope"))
+        XCTAssertEqual(resp.status, 404)
+    }
+
+    func testParseQuery() {
+        let params = FunctionCallerRouter.parseQuery("a=1&b=two")
+        XCTAssertEqual(params["a"], "1")
+        XCTAssertEqual(params["b"], "two")
+    }
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- extend FunctionCallerService tests for missing functions, invocation failures, metrics endpoint, and query parsing

## Testing
- `FULL_TESTS=1 swift build --target FunctionCallerServiceTests -c debug`
- `FULL_TESTS=1 swift test --skip-build --filter FunctionCallerServiceTests.FunctionCallerServiceTests/testGetFunctionDetailsNotFound` *(no tests discovered)*

------
https://chatgpt.com/codex/tasks/task_b_68b9c58b44d08333910cfde8f5867790