### PR TITLE
feat: enhance curator service spec

### DIFF
--- a/openapi/README.md
+++ b/openapi/README.md
@@ -26,7 +26,7 @@ For a repository-wide index of OpenAPI coverage, see [../OPENAPI_COVERAGE.md](..
 | Destructive Guardian Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/destructive-guardian-gateway.yml](v1/destructive-guardian-gateway.yml) |
 | Security Sentinel Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/security-sentinel-gateway.yml](v1/security-sentinel-gateway.yml) |
 | Tool Server | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/tool-server.yml](v1/tool-server.yml) |
-| OpenAPI Curator Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/openapi-curator.yml](v1/openapi-curator.yml) |
+| OpenAPI Curator Service | 1.0.1 | Contexter alias Benedikt Eickhoff | [v1/openapi-curator.yml](v1/openapi-curator.yml) |
 
 
 ## Gateway Plugins

--- a/openapi/v1/openapi-curator.yml
+++ b/openapi/v1/openapi-curator.yml
@@ -2,10 +2,12 @@
 openapi: 3.1.0
 info:
   title: OpenAPI Curator Service
-  version: 1.0.0
+  version: 1.0.1
 paths:
   /curate:
     post:
+      tags:
+        - Curator
       summary: Curate one or more OpenAPI documents
       operationId: curate
       requestBody:
@@ -13,66 +15,22 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                corpusId:
-                  type: string
-                specs:
-                  type: array
-                  items:
-                    oneOf:
-                      - type: object
-                        additionalProperties: true
-                      - type: string
-                submitToToolsFactory:
-                  type: boolean
-                  default: false
-              required:
-                - specs
+              $ref: '#/components/schemas/CurateRequest'
       responses:
-        "200":
+        '200':
           description: Curated spec and report
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  curatedOpenAPI:
-                    type: object
-                    additionalProperties: true
-                  report:
-                    type: object
-                    properties:
-                      removed:
-                        type: array
-                        items:
-                          type: string
-                      renamed:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            from:
-                              type: string
-                            to:
-                              type: string
-                      collisions:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            operationId:
-                              type: string
-                            services:
-                              type: array
-                              items:
-                                type: string
-                      warnings:
-                        type: array
-                        items:
-                          type: string
+                $ref: '#/components/schemas/CurateResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
   /validate:
     post:
+      tags:
+        - Curator
       summary: Validate specs without curating
       operationId: validate
       requestBody:
@@ -80,28 +38,36 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                specs:
-                  type: array
-                  items:
-                    oneOf:
-                      - type: object
-                        additionalProperties: true
-                      - type: string
-              required:
-                - specs
+              $ref: '#/components/schemas/ValidateRequest'
       responses:
-        "200":
+        '200':
           description: Validation report
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationReport'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
   /rules:
     get:
+      tags:
+        - Rules
       summary: Get active curation rules
       operationId: get_rules
       responses:
-        "200":
+        '200':
           description: Rules YAML as JSON
+          content:
+            application/json:
+              schema:
+                type: object
+        '500':
+          $ref: '#/components/responses/InternalError'
     put:
+      tags:
+        - Rules
       summary: Replace curation rules
       operationId: put_rules
       requestBody:
@@ -109,18 +75,18 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                rules:
-                  type: object
-                  additionalProperties: true
-              required:
-                - rules
+              $ref: '#/components/schemas/RulesDocument'
       responses:
-        "204":
+        '204':
           description: Rules replaced
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
   /history:
     get:
+      tags:
+        - History
       summary: List curated snapshots for a corpus
       operationId: history
       parameters:
@@ -128,15 +94,143 @@ paths:
           name: corpusId
           schema:
             type: string
+            example: tools-factory
+          description: Filter snapshots for this corpus
       responses:
-        "200":
+        '200':
           description: List of snapshots
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
   /metrics:
     get:
+      tags:
+        - Metrics
       summary: Metrics
       description: Endpoint that serves Prometheus metrics.
       operationId: metrics_metrics_get
       responses:
-        "200":
+        '200':
           description: Metrics response
+        '500':
+          $ref: '#/components/responses/InternalError'
+components:
+  schemas:
+    CurateRequest:
+      type: object
+      required:
+        - specs
+      properties:
+        corpusId:
+          type: string
+          description: Corpus identifier used for snapshot history
+          example: tools-factory
+        specs:
+          type: array
+          description: OpenAPI documents or URIs to curate
+          items:
+            oneOf:
+              - type: object
+                additionalProperties: true
+              - type: string
+                description: URI to spec
+                example: file://openapi/v1/baseline-awareness.yml
+        submitToToolsFactory:
+          type: boolean
+          description: Submit curated result to Tools Factory
+          default: false
+    CurateResponse:
+      type: object
+      properties:
+        curatedOpenAPI:
+          type: object
+          additionalProperties: true
+          description: Curated OpenAPI document
+        report:
+          $ref: '#/components/schemas/ValidationReport'
+    ValidateRequest:
+      type: object
+      required:
+        - specs
+      properties:
+        specs:
+          type: array
+          description: OpenAPI documents or URIs to validate
+          items:
+            oneOf:
+              - type: object
+                additionalProperties: true
+              - type: string
+                description: URI to spec
+    ValidationReport:
+      type: object
+      properties:
+        removed:
+          type: array
+          items:
+            type: string
+          description: Endpoints removed during curation
+        renamed:
+          type: array
+          items:
+            type: object
+            properties:
+              from:
+                type: string
+              to:
+                type: string
+          description: Endpoints renamed during curation
+        collisions:
+          type: array
+          items:
+            type: object
+            properties:
+              operationId:
+                type: string
+              services:
+                type: array
+                items:
+                  type: string
+          description: Conflicting operation IDs across services
+        warnings:
+          type: array
+          items:
+            type: string
+          description: Non-fatal warnings detected
+    RulesDocument:
+      type: object
+      required:
+        - rules
+      properties:
+        rules:
+          type: object
+          additionalProperties: true
+          description: Rules configuration used during curation
+    Error:
+      type: object
+      properties:
+        message:
+          type: string
+          example: Invalid spec provided
+  responses:
+    BadRequest:
+      description: Invalid request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    InternalError:
+      description: Unexpected server error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+


### PR DESCRIPTION
## Summary
- add tags and shared components to OpenAPI Curator service spec
- define error schemas and reference 4xx/5xx responses
- bump spec version to 1.0.1

## Testing
- `python3 scripts/validate_openapi.py`

------
https://chatgpt.com/codex/tasks/task_b_68ba711d3034833393ec7111a1d23194