### PR TITLE
Annotate OpenAPI specs with fountain extensions and expose truth table

### DIFF
--- a/Tests/OpenAPICuratorTests/OpenAPICuratorTests.swift
+++ b/Tests/OpenAPICuratorTests/OpenAPICuratorTests.swift
@@ -68,6 +68,19 @@ final class OpenAPICuratorTests: XCTestCase {
         XCTAssertTrue(result.report.appliedRules.contains("x-fountain.visibility=public"))
     }
 
+    func testTruthTableOutput() {
+        let spec = Spec(operations: ["op"], extensions: ["op": [
+            "x-fountain.visibility": "internal",
+            "x-fountain.reason": "example",
+            "x-fountain.allow-as-tool": "false"
+        ]])
+        let result = curate(specs: [spec], rules: Rules())
+        let entry = result.report.truthTable["op"]
+        XCTAssertEqual(entry?.visibility, "internal")
+        XCTAssertEqual(entry?.reason, "example")
+        XCTAssertEqual(entry?.allowAsTool, false)
+    }
+
     func testReviewerHookInvoked() {
         let spec = Spec(operations: ["op"])
         var reviewed = false

--- a/docs/openapi-curator-architecture.md
+++ b/docs/openapi-curator-architecture.md
@@ -362,8 +362,30 @@ POST /curate
 
   * **removes** denylisted/admin endpoints,
   * **resolves** all `operationId` conflicts per configured strategy,
-  * **emits** a valid OpenAPI 3.1 document,
-  * optionally **submits** to Tools Factory,
-  * **persists** artifacts and **exposes** metrics.
+* **emits** a valid OpenAPI 3.1 document,
+* optionally **submits** to Tools Factory,
+* **persists** artifacts and **exposes** metrics.
+
+---
+
+## 15) Truth Table Derivation
+
+During curation the Rules Engine reads each operation's vendor extensions:
+
+```
+x-fountain.visibility: public|internal
+x-fountain.allow-as-tool: true|false
+x-fountain.reason: "..."
+```
+
+It assembles them into a truth table mapping `operationId` to a structured record:
+
+```
+{
+  "authValidate": { "visibility": "public", "allowAsTool": true, "reason": "" }
+}
+```
+
+The `/truth-table` endpoint and `CuratorReport.truthTable` expose this view so clients can audit which operations become tools and why.
 
 

--- a/libs/OpenAPICurator/Sources/OpenAPICurator/Curator.swift
+++ b/libs/OpenAPICurator/Sources/OpenAPICurator/Curator.swift
@@ -18,6 +18,17 @@ public struct OpenAPI {
     }
 }
 
+public struct Truth: Codable, Equatable {
+    public let visibility: String
+    public let allowAsTool: Bool
+    public let reason: String
+    public init(visibility: String, allowAsTool: Bool, reason: String) {
+        self.visibility = visibility
+        self.allowAsTool = allowAsTool
+        self.reason = reason
+    }
+}
+
 public struct Rules {
     public let renames: [String: String]
     public let allowlist: [String]
@@ -33,19 +44,21 @@ public struct CuratorReport {
     public let appliedRules: [String]
     public let collisions: [String]
     public let diff: [String]
-    public init(appliedRules: [String], collisions: [String], diff: [String]) {
+    public let truthTable: [String: Truth]
+    public init(appliedRules: [String], collisions: [String], diff: [String], truthTable: [String: Truth]) {
         self.appliedRules = appliedRules
         self.collisions = collisions
         self.diff = diff
+        self.truthTable = truthTable
     }
 }
 
 public func curate(specs: [Spec], rules: Rules) -> (spec: OpenAPI, report: CuratorReport) {
     let parsed = Parser.parse(specs)
     let normalized = Resolver.normalize(parsed)
-    let (ruled, applied) = RulesEngine.apply(rules, to: normalized)
+    let (ruled, applied, truth) = RulesEngine.apply(rules, to: normalized)
     let diff = normalized.operations.filter { !ruled.operations.contains($0) }
     let (deduped, collisions) = CollisionResolver.resolve(ruled)
-    let report = ReportBuilder.build(appliedRules: applied, collisions: collisions, diff: diff)
+    let report = ReportBuilder.build(appliedRules: applied, collisions: collisions, diff: diff, truthTable: truth)
     return (deduped, report)
 }

--- a/libs/OpenAPICurator/Sources/OpenAPICurator/ReportBuilder.swift
+++ b/libs/OpenAPICurator/Sources/OpenAPICurator/ReportBuilder.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum ReportBuilder {
-    static func build(appliedRules: [String], collisions: [String], diff: [String]) -> CuratorReport {
-        CuratorReport(appliedRules: appliedRules, collisions: collisions, diff: diff)
+    static func build(appliedRules: [String], collisions: [String], diff: [String], truthTable: [String: Truth]) -> CuratorReport {
+        CuratorReport(appliedRules: appliedRules, collisions: collisions, diff: diff, truthTable: truthTable)
     }
 }

--- a/libs/OpenAPICurator/Sources/OpenAPICurator/RulesEngine.swift
+++ b/libs/OpenAPICurator/Sources/OpenAPICurator/RulesEngine.swift
@@ -1,10 +1,11 @@
 import Foundation
 
 enum RulesEngine {
-    static func apply(_ rules: Rules, to api: OpenAPI) -> (OpenAPI, [String]) {
+    static func apply(_ rules: Rules, to api: OpenAPI) -> (OpenAPI, [String], [String: Truth]) {
         var operations = api.operations
         var exts = api.extensions
         var applied: [String] = []
+        var truth: [String: Truth] = [:]
         for (index, op) in operations.enumerated() {
             if let newName = rules.renames[op] {
                 operations[index] = newName
@@ -12,6 +13,10 @@ enum RulesEngine {
                 applied.append("\(op)->\(newName)")
             }
             if let opExts = exts[operations[index]] {
+                let vis = opExts["x-fountain.visibility"] ?? ""
+                let reason = opExts["x-fountain.reason"] ?? ""
+                let allow = (opExts["x-fountain.allow-as-tool"]?.lowercased() == "true")
+                truth[operations[index]] = Truth(visibility: vis, allowAsTool: allow, reason: reason)
                 for (key, value) in opExts where key.hasPrefix("x-fountain.") {
                     applied.append("\(key)=\(value)")
                 }
@@ -27,6 +32,6 @@ enum RulesEngine {
             applied.append(contentsOf: removed.map { "deny:\($0)" })
             operations = operations.filter { !denied.contains($0) }
         }
-        return (OpenAPI(operations: operations, extensions: exts), applied)
+        return (OpenAPI(operations: operations, extensions: exts), applied, truth)
     }
 }

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -3,6 +3,8 @@
 Versioned service definitions live here. Each YAML file describes a FountainAI service interface.
 Persona definitions for Gateway plugins live in `personas/` and are referenced via `x-persona` in the specs.
 
+- Every operation includes `x-fountain.visibility`, `x-fountain.reason`, and `x-fountain.allow-as-tool` extensions for curation.
+
 For a repository-wide index of OpenAPI coverage, see [../OPENAPI_COVERAGE.md](../OPENAPI_COVERAGE.md).
 
 | Service | Version | Owner | Spec |
@@ -26,7 +28,7 @@ For a repository-wide index of OpenAPI coverage, see [../OPENAPI_COVERAGE.md](..
 | Destructive Guardian Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/destructive-guardian-gateway.yml](v1/destructive-guardian-gateway.yml) |
 | Security Sentinel Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/security-sentinel-gateway.yml](v1/security-sentinel-gateway.yml) |
 | Tool Server | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/tool-server.yml](v1/tool-server.yml) |
-| OpenAPI Curator Service | 1.0.1 | Contexter alias Benedikt Eickhoff | [v1/openapi-curator.yml](v1/openapi-curator.yml) |
+| OpenAPI Curator Service | 1.0.2 | Contexter alias Benedikt Eickhoff | [v1/openapi-curator.yml](v1/openapi-curator.yml) |
 
 
 ## Gateway Plugins

--- a/openapi/v1/auth-gateway.yml
+++ b/openapi/v1/auth-gateway.yml
@@ -15,6 +15,9 @@ paths:
       summary: Validate Access Token
       description: Verifies a bearer token and returns its role when valid.
       operationId: authValidate
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -35,6 +38,9 @@ paths:
       summary: Retrieve Claims
       description: Returns claims associated with the supplied bearer token.
       operationId: authClaims
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - in: header
           name: Authorization

--- a/openapi/v1/baseline-awareness.yml
+++ b/openapi/v1/baseline-awareness.yml
@@ -13,6 +13,9 @@ paths:
     get:
       summary: Health
       operationId: health_health_get
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Successful Response
@@ -25,6 +28,9 @@ paths:
       summary: Initialize a new corpus
       description: Creates a new corpus with the given corpus ID.
       operationId: initializeCorpus
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -45,6 +51,9 @@ paths:
       summary: Add Baseline
       description: Adds a baseline text to the corpus.
       operationId: addBaseline
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -65,6 +74,9 @@ paths:
       summary: Add Drift
       description: Adds a drift document to the corpus.
       operationId: addDrift
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -85,6 +97,9 @@ paths:
       summary: Add Patterns
       description: Adds narrative patterns to the corpus.
       operationId: addPatterns
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -105,6 +120,9 @@ paths:
       summary: Add Reflection
       description: Adds a reflection item to the corpus.
       operationId: addReflection
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -125,6 +143,9 @@ paths:
       summary: List Reflections
       description: Lists all reflections in the specified corpus.
       operationId: listReflections
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: corpus_id
           in: path
@@ -146,6 +167,9 @@ paths:
       summary: List History
       description: Lists the change history of the specified corpus.
       operationId: listHistory
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: corpus_id
           in: path
@@ -167,6 +191,9 @@ paths:
       summary: Summarize History
       description: Provides a semantic summary of the corpus history.
       operationId: summarizeHistory
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: corpus_id
           in: path
@@ -191,6 +218,9 @@ paths:
       description: >
         Retrieve the timeline of all semantic entries for the given corpus.
       operationId: listHistoryAnalytics
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: corpus_id
           in: query
@@ -214,6 +244,9 @@ paths:
       description: >
         Construct and return the semantic arc based on the corpus history.
       operationId: readSemanticArc
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: corpus_id
           in: query
@@ -233,6 +266,9 @@ paths:
     get:
       summary: Stream History Analytics
       operationId: streamHistoryAnalytics
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       description: Stream historical analytics of the corpus.
       responses:
         '200':
@@ -248,6 +284,9 @@ paths:
       summary: Metrics
       description: Endpoint that serves Prometheus metrics.
       operationId: metrics_metrics_get
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Successful Response

--- a/openapi/v1/bootstrap.yml
+++ b/openapi/v1/bootstrap.yml
@@ -16,6 +16,9 @@ paths:
         1) Creates empty corpus via `/corpus-init` on Awareness.
         2) Seeds default GPT roles via `/bootstrap/roles/seed`.
       operationId: bootstrapInitializeCorpus
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -43,6 +46,9 @@ paths:
       description: >
         Populates an existing corpus with the five default GPT role prompts.
       operationId: bootstrapSeedRoles
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -80,6 +86,9 @@ paths:
         All of that—live streaming, persistence of each slice, and background
         analytics—happens in one concise call.
       operationId: bootstrapAddBaseline
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -106,6 +115,9 @@ paths:
         Populates the specified corpus with five GPT role prompts.
         Prerequisite: call `/corpus-init` first.
       operationId: seedRoles
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -130,6 +142,9 @@ paths:
       summary: Metrics
       description: Endpoint that serves Prometheus metrics.
       operationId: metrics_metrics_get
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Successful Response

--- a/openapi/v1/budget-breaker-gateway.yml
+++ b/openapi/v1/budget-breaker-gateway.yml
@@ -17,6 +17,9 @@ paths:
       summary: Check budget
       description: Checks and consumes budget for a client.
       operationId: budgetCheck
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -43,6 +46,9 @@ paths:
       summary: Health check
       description: Reports plugin health status.
       operationId: budgetHealth
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Health status

--- a/openapi/v1/destructive-guardian-gateway.yml
+++ b/openapi/v1/destructive-guardian-gateway.yml
@@ -17,6 +17,9 @@ paths:
       summary: Evaluate request
       description: Evaluates a request and returns an allow or deny decision.
       operationId: guardianEvaluate
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:

--- a/openapi/v1/dns.yml
+++ b/openapi/v1/dns.yml
@@ -12,6 +12,9 @@ paths:
     get:
       summary: List Zones
       operationId: listZones
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Successful Response
@@ -22,6 +25,9 @@ paths:
     post:
       summary: Create Zone
       operationId: createZone
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -46,6 +52,9 @@ paths:
     delete:
       summary: Delete Zone
       operationId: deleteZone
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '204':
           description: Zone Deleted
@@ -60,6 +69,9 @@ paths:
     get:
       summary: List Records
       operationId: listRecords
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Successful Response
@@ -70,6 +82,9 @@ paths:
     post:
       summary: Create Record
       operationId: createRecord
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -100,6 +115,9 @@ paths:
     put:
       summary: Update Record
       operationId: updateRecord
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -116,6 +134,9 @@ paths:
     delete:
       summary: Delete Record
       operationId: deleteRecord
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '204':
           description: Record Deleted

--- a/openapi/v1/function-caller.yml
+++ b/openapi/v1/function-caller.yml
@@ -15,6 +15,9 @@ paths:
     get:
       summary: List Registered Functions
       operationId: list_functions
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       description: >
         Retrieve a paginated list of all registered functions available for
         invocation.
@@ -59,6 +62,9 @@ paths:
     get:
       summary: Get Function Details
       operationId: get_function_details
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       description: >
         Retrieve detailed metadata about a registered function by its ID.
       parameters:
@@ -84,6 +90,9 @@ paths:
     post:
       summary: Invoke a Registered Function
       operationId: invoke_function
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       description: |
         Invoke the specified function with the given input parameters.
         The service will perform the corresponding HTTP call and
@@ -133,6 +142,9 @@ paths:
       summary: Metrics
       description: Endpoint that serves Prometheus metrics.
       operationId: metrics_metrics_get
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Successful Response

--- a/openapi/v1/gateway.yml
+++ b/openapi/v1/gateway.yml
@@ -14,6 +14,9 @@ paths:
       summary: Health
       description: Returns 200 if the gateway is running.
       operationId: gatewayHealth
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Successful Response
@@ -26,6 +29,9 @@ paths:
       summary: Metrics
       description: Endpoint that serves runtime metrics encoded as JSON.
       operationId: gatewayMetrics
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Successful Response
@@ -44,6 +50,9 @@ paths:
         Verify client credentials and issue a JWT used for accessing
         protected routes.
       operationId: issueAuthToken
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -69,6 +78,9 @@ paths:
       summary: Certificate Info
       description: Returns metadata about the active TLS certificate.
       operationId: certificateInfo
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Successful Response
@@ -83,6 +95,9 @@ paths:
       summary: Trigger certificate renewal
       description: Manually invoke the renewal process for the TLS certificate.
       operationId: renewCertificate
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '202':
           description: Renewal triggered
@@ -97,6 +112,9 @@ paths:
       summary: List Configured Routes
       description: Returns all routing definitions active in the gateway.
       operationId: listRoutes
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Successful Response
@@ -111,6 +129,9 @@ paths:
     post:
       summary: Add a new route
       operationId: createRoute
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -136,6 +157,9 @@ paths:
     put:
       summary: Update an existing route
       operationId: updateRoute
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: routeId
           in: path
@@ -167,6 +191,9 @@ paths:
     delete:
       summary: Delete a route
       operationId: deleteRoute
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: routeId
           in: path

--- a/openapi/v1/openapi-curator.yml
+++ b/openapi/v1/openapi-curator.yml
@@ -2,7 +2,7 @@
 openapi: 3.1.0
 info:
   title: OpenAPI Curator Service
-  version: 1.0.1
+  version: 1.0.2
 paths:
   /curate:
     post:
@@ -10,6 +10,9 @@ paths:
         - Curator
       summary: Curate one or more OpenAPI documents
       operationId: curate
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -33,6 +36,9 @@ paths:
         - Curator
       summary: Validate specs without curating
       operationId: validate
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -50,12 +56,41 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '500':
           $ref: '#/components/responses/InternalError'
+  /truth-table:
+    post:
+      tags:
+        - Curator
+      summary: Export truth table for specs
+      operationId: truth_table
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CurateRequest'
+      responses:
+        '200':
+          description: Truth table
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TruthTable'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
   /rules:
     get:
       tags:
         - Rules
       summary: Get active curation rules
       operationId: get_rules
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Rules YAML as JSON
@@ -70,6 +105,9 @@ paths:
         - Rules
       summary: Replace curation rules
       operationId: put_rules
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -89,6 +127,9 @@ paths:
         - History
       summary: List curated snapshots for a corpus
       operationId: history
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - in: query
           name: corpusId
@@ -116,6 +157,9 @@ paths:
       summary: Metrics
       description: Endpoint that serves Prometheus metrics.
       operationId: metrics_metrics_get
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Metrics response
@@ -219,6 +263,23 @@ components:
         message:
           type: string
           example: Invalid spec provided
+    TruthEntry:
+      type: object
+      required:
+        - visibility
+        - allowAsTool
+        - reason
+      properties:
+        visibility:
+          type: string
+        allowAsTool:
+          type: boolean
+        reason:
+          type: string
+    TruthTable:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/TruthEntry'
   responses:
     BadRequest:
       description: Invalid request

--- a/openapi/v1/payload-inspection-gateway.yml
+++ b/openapi/v1/payload-inspection-gateway.yml
@@ -16,6 +16,9 @@ paths:
       summary: Inspect payload
       description: Sanitizes payloads or reports violations.
       operationId: inspectPayload
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:

--- a/openapi/v1/persist.yml
+++ b/openapi/v1/persist.yml
@@ -16,6 +16,9 @@ paths:
     get:
       summary: Get supported capabilities
       operationId: capabilities
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Capability flags for the persistence service.
@@ -32,6 +35,9 @@ paths:
         available in the persistence layer.
         Useful for clients to discover existing corpora.
       operationId: listCorpora
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: limit
           in: query
@@ -73,6 +79,9 @@ paths:
         Initialize a new corpus that will act as a semantic container for
         baselines, reflections, and other artifacts. Corpus IDs must be unique.
       operationId: createCorpus
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         description: Corpus creation request payload including unique corpusId.
         required: true
@@ -97,6 +106,9 @@ paths:
         Retrieve baseline snapshots stored for the given corpus.
         Useful for examining historical semantic state.
       operationId: listBaselines
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: corpusId
           in: path
@@ -141,6 +153,9 @@ paths:
         capture semantic state or data snapshots relevant for drift
         analysis or reflection.
       operationId: addBaseline
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: corpusId
           in: path
@@ -171,6 +186,9 @@ paths:
     get:
       summary: List functions in a corpus, supports pagination
       operationId: listFunctionsInCorpus
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: corpusId
           in: path
@@ -216,6 +234,9 @@ paths:
     post:
       summary: Add a function to a corpus
       operationId: addFunction
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: corpusId
           in: path
@@ -247,6 +268,9 @@ paths:
         Reflections often include question and answer content useful for
         semantic reasoning and planning.
       operationId: addReflection
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: corpusId
           in: path
@@ -278,6 +302,9 @@ paths:
         Retrieve reflections stored in the given corpus with pagination. Useful
         for browsing semantic insights or planning data over time.
       operationId: listReflections
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: corpusId
           in: path
@@ -323,6 +350,9 @@ paths:
         Retrieve a paginated list of all registered callable functions known to
         the persistence layer for orchestration and invocation.
       operationId: listFunctions
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: limit
           in: query
@@ -367,6 +397,9 @@ paths:
         Retrieve detailed metadata for a registered function by its
         identifier.
       operationId: getFunctionDetails
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: functionId
           in: path
@@ -389,6 +422,9 @@ paths:
       summary: Metrics
       description: Endpoint that serves Prometheus metrics.
       operationId: metrics_metrics_get
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Successful Response

--- a/openapi/v1/planner.yml
+++ b/openapi/v1/planner.yml
@@ -17,6 +17,9 @@ paths:
       description: >
         Accepts a high-level user objective and returns a step-by-step plan.
       operationId: planner_reason
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -45,6 +48,9 @@ paths:
         Takes a plan (function-call list) and runs each step,
         returning results.
       operationId: planner_execute
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -72,6 +78,9 @@ paths:
       description: >
         Returns the names/IDs of all corpora that the planner knows about.
       operationId: planner_list_corpora
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Successful Response
@@ -89,6 +98,9 @@ paths:
       summary: Fetch reflection history
       description: Retrieve all stored reflections for a given corpus ID.
       operationId: get_reflection_history
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: corpus_id
           in: path
@@ -117,6 +129,9 @@ paths:
         Retrieve the semantic arc for a given corpus ID (curated summary,
         insights, etc.).
       operationId: get_semantic_arc
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: corpus_id
           in: path
@@ -145,6 +160,9 @@ paths:
       summary: Add a new reflection
       description: Send a message to be reflected on and appended to the corpus.
       operationId: post_reflection
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -169,6 +187,9 @@ paths:
       summary: Metrics
       description: Endpoint that serves Prometheus metrics.
       operationId: metrics_metrics_get
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Successful Response

--- a/openapi/v1/rate-limiter-gateway.yml
+++ b/openapi/v1/rate-limiter-gateway.yml
@@ -16,6 +16,9 @@ paths:
       summary: Check rate limit
       description: Checks and consumes a rate limit token.
       operationId: rateLimitCheck
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -41,6 +44,9 @@ paths:
         - RateLimiter
       summary: Retrieve rate limiter statistics
       operationId: rateLimitStats
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Aggregated allowed/throttled counts

--- a/openapi/v1/role-health-check-gateway.yml
+++ b/openapi/v1/role-health-check-gateway.yml
@@ -19,6 +19,9 @@ paths:
       summary: Enqueue Role Health-Check Reflection
       description: Enqueues the health-check reflection in the corpus.
       operationId: roleHealthCheckReflect
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -45,6 +48,9 @@ paths:
       summary: Promote Role Health-Check Reflection
       description: Promotes the latest health-check reflection to a role.
       operationId: roleHealthCheckPromote
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:

--- a/openapi/v1/security-sentinel-gateway.yml
+++ b/openapi/v1/security-sentinel-gateway.yml
@@ -16,6 +16,9 @@ paths:
       summary: Consult Security Sentinel
       description: Sends a summary of a potentially destructive operation for a decision.
       operationId: sentinelConsult
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:

--- a/openapi/v1/semantic-browser.yml
+++ b/openapi/v1/semantic-browser.yml
@@ -37,6 +37,9 @@ paths:
   /v1/browse:
     post:
       operationId: browseAndDissect
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       tags: [Browse]
       summary: Navigate to a URL, snapshot the rendered page, optionally analyze and index in a single call.
       description: >
@@ -70,6 +73,9 @@ paths:
   /v1/snapshot:
     post:
       operationId: snapshotOnly
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       tags: [Browse]
       summary: Navigate and return only the Snapshot (no semantic analysis).
       requestBody:
@@ -90,6 +96,9 @@ paths:
   /v1/analyze:
     post:
       operationId: analyzeSnapshot
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       tags: [Analyze]
       summary: Run semantic dissection on a Snapshot (inline or by reference).
       requestBody:
@@ -114,6 +123,9 @@ paths:
   /v1/index:
     post:
       operationId: indexAnalysis
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       tags: [Index]
       summary: Persist Analysis-derived artifacts (page/segments/entities/tables/analyses) into FountainStore collections under a corpus.
       requestBody:
@@ -133,6 +145,9 @@ paths:
   /v1/pages:
     get:
       operationId: queryPages
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       tags: [Query]
       summary: Search previously persisted pages in FountainStore.
       parameters:
@@ -178,6 +193,9 @@ paths:
   /v1/pages/{id}:
     get:
       operationId: getPage
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       tags: [Query]
       summary: Fetch a single indexed page document by ID.
       parameters:
@@ -198,6 +216,9 @@ paths:
   /v1/segments:
     get:
       operationId: querySegments
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       tags: [Query]
       summary: Search segments (headings/paragraphs/code/captions/tables).
       parameters:
@@ -235,6 +256,9 @@ paths:
   /v1/entities:
     get:
       operationId: queryEntities
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       tags: [Query]
       summary: Search canonicalized entities.
       parameters:
@@ -267,6 +291,9 @@ paths:
   /v1/export:
     get:
       operationId: exportArtifacts
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       tags: [Export]
       summary: Export artifacts for a page/analysis.
       parameters:
@@ -294,6 +321,9 @@ paths:
   /v1/health:
     get:
       operationId: health
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       tags: [Admin]
       summary: Liveness and readiness probe.
       responses:

--- a/openapi/v1/tool-server.yml
+++ b/openapi/v1/tool-server.yml
@@ -6,6 +6,9 @@ paths:
   /imagemagick:
     post:
       operationId: runImageMagick
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -23,6 +26,9 @@ paths:
   /ffmpeg:
     post:
       operationId: runFFmpeg
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -34,6 +40,9 @@ paths:
   /exiftool:
     post:
       operationId: runExifTool
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -45,6 +54,9 @@ paths:
   /pandoc:
     post:
       operationId: runPandoc
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -56,6 +68,9 @@ paths:
   /libplist:
     post:
       operationId: runLibPlist
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -67,6 +82,9 @@ paths:
   /pdf/scan:
     post:
       operationId: pdfScan
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       summary: Scan one or more PDFs into a semantic index
       requestBody:
         required: true
@@ -84,6 +102,9 @@ paths:
   /pdf/index/validate:
     post:
       operationId: pdfIndexValidate
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       summary: Validate an index structure
       requestBody:
         required: true
@@ -101,6 +122,9 @@ paths:
   /pdf/query:
     post:
       operationId: pdfQuery
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       summary: Query an index by keyword
       requestBody:
         required: true
@@ -118,6 +142,9 @@ paths:
   /pdf/export-matrix:
     post:
       operationId: pdfExportMatrix
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       summary: Export a Midi2Swift-friendly matrix skeleton from an index
       requestBody:
         required: true

--- a/openapi/v1/tools-factory.yml
+++ b/openapi/v1/tools-factory.yml
@@ -14,6 +14,9 @@ paths:
     get:
       summary: List Registered Tools
       operationId: list_tools
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       description: Retrieve a paginated list of registered tools.
       parameters:
         - name: page
@@ -45,6 +48,9 @@ paths:
     post:
       summary: Register Tools from OpenAPI
       operationId: register_openapi
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       description: |
         Store a collection of tool definitions provided via an OpenAPI
         document. Each operationId is mapped to a callable function.
@@ -75,6 +81,9 @@ paths:
       summary: Metrics
       description: Endpoint that serves Prometheus metrics.
       operationId: metrics_metrics_get
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         '200':
           description: Successful Response

--- a/openapi/v2/llm-gateway.yml
+++ b/openapi/v2/llm-gateway.yml
@@ -12,6 +12,9 @@ paths:
       summary: Metrics
       description: Endpoint that serves Prometheus metrics.
       operationId: metrics_metrics_get
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       responses:
         "200":
           description: Successful Response
@@ -28,6 +31,9 @@ paths:
         Receives the user's objective, loads available tools,
         and delegates reasoning to GPT.
       operationId: chatWithObjective
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       requestBody:
         required: true
         content:
@@ -58,6 +64,9 @@ paths:
     get:
       summary: Fetch stored Chain-of-Thought
       operationId: getChatCoT
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
       parameters:
         - name: id
           in: path

--- a/services/OpenAPICuratorService/OpenAPICuratorServiceModule.swift
+++ b/services/OpenAPICuratorService/OpenAPICuratorServiceModule.swift
@@ -159,6 +159,27 @@ public func makeOpenAPICuratorKernel() -> HTTPKernel {
                 ]
                 let json = try JSONSerialization.data(withJSONObject: respObj)
                 return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: json)
+            case ("POST", ["truth-table"]):
+                let obj = try JSONSerialization.jsonObject(with: req.body) as? [String: Any] ?? [:]
+                let rawSpecs = obj["specs"] as? [Any] ?? []
+                var specs: [Spec] = []
+                for item in rawSpecs {
+                    if let s = item as? String {
+                        let url = URL(string: s).flatMap { $0.scheme != nil ? $0 : nil } ?? URL(fileURLWithPath: s)
+                        let data = (try? Data(contentsOf: url)) ?? Data()
+                        let text = String(data: data, encoding: .utf8) ?? ""
+                        let ops = extractOperationIds(from: text)
+                        specs.append(Spec(operations: ops))
+                    } else if let dict = item as? [String: Any], let ops = dict["operations"] as? [String] {
+                        specs.append(Spec(operations: ops))
+                    }
+                }
+                let rules = await curatorRulesStore.rules
+                let result = OpenAPICuratorKit.run(specs: specs, rules: rules)
+                let banned: Set<String> = ["metrics_metrics_get", "register_openapi", "list_tools"]
+                let table = result.report.truthTable.filter { !banned.contains($0.key) }
+                let json = try JSONEncoder().encode(table)
+                return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: json)
 
             case ("POST", ["validate"]):
                 let obj = try JSONSerialization.jsonObject(with: req.body) as? [String: Any] ?? [:]


### PR DESCRIPTION
## Summary
- add `x-fountain.*` visibility, reason, and allow-as-tool extensions across OpenAPI specs
- parse extensions into a truth table and expose via /truth-table endpoint
- document truth table derivation and cover with new tests

## Testing
- `python3 scripts/validate_openapi.py`
- `swift test` *(fails: TokenValidationTests.testJWKSKeyProvider, TokenValidationTests.testOAuth2Validator)*
- `swift test --filter OpenAPICuratorTests`


------
https://chatgpt.com/codex/tasks/task_b_68ba8a5aa57c83339e1b3e3ccc1fb179