### PR TITLE
feat: add curator gateway plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,7 @@ let fullProducts: [Product] = [
     .executable(name: "openapi-curator-cli", targets: ["openapi-curator-cli"]),
     .executable(name: "openapi-curator-service", targets: ["openapi-curator-service"]),
     .library(name: "GatewayPersonaOrchestrator", targets: ["GatewayPersonaOrchestrator"]),
+    .library(name: "CuratorGatewayPlugin", targets: ["CuratorGatewayPlugin"]),
     .executable(name: "semantic-browser-server", targets: ["semantic-browser-server"])]
 
 let leanProducts: [Product] = [
@@ -42,6 +43,7 @@ let leanProducts: [Product] = [
     .library(name: "DestructiveGuardianGatewayPlugin", targets: ["DestructiveGuardianGatewayPlugin"]),
     .library(name: "RoleHealthCheckGatewayPlugin", targets: ["RoleHealthCheckGatewayPlugin"]),
     .library(name: "SecuritySentinelGatewayPlugin", targets: ["SecuritySentinelGatewayPlugin"]),
+    .library(name: "CuratorGatewayPlugin", targets: ["CuratorGatewayPlugin"]),
     .library(name: "GatewayPersonaOrchestrator", targets: ["GatewayPersonaOrchestrator"]),
     .executable(name: "semantic-browser-server", targets: ["semantic-browser-server"])
 ]
@@ -119,6 +121,7 @@ let fullTargets: [Target] = [
             "PublishingFrontend",
             "LLMGatewayPlugin",
             "AuthGatewayPlugin",
+            "CuratorGatewayPlugin",
             "RateLimiterGatewayPlugin",
             "BudgetBreakerGatewayPlugin",
             "PayloadInspectionGatewayPlugin",
@@ -178,6 +181,11 @@ let fullTargets: [Target] = [
             .product(name: "Logging", package: "swift-log")
         ],
         path: "libs/GatewayPlugins/SecuritySentinelGatewayPlugin",
+    ),
+    .target(
+        name: "CuratorGatewayPlugin",
+        dependencies: ["FountainRuntime", "OpenAPICurator"],
+        path: "libs/GatewayPlugins/CuratorGatewayPlugin",
     ),
     .target(
         name: "GatewayPersonaOrchestrator",
@@ -470,6 +478,7 @@ let fullTargets: [Target] = [
             "RoleHealthCheckGatewayPlugin",
             "SecuritySentinelGatewayPlugin",
             "DestructiveGuardianGatewayPlugin",
+            "CuratorGatewayPlugin",
             "FountainRuntime",
             .product(name: "Crypto", package: "swift-crypto")
         ],
@@ -558,6 +567,7 @@ let leanTargets: [Target] = [
             "PublishingFrontend",
             "LLMGatewayPlugin",
             "AuthGatewayPlugin",
+            "CuratorGatewayPlugin",
             "RateLimiterGatewayPlugin",
             "BudgetBreakerGatewayPlugin",
             "PayloadInspectionGatewayPlugin",
@@ -617,6 +627,11 @@ let leanTargets: [Target] = [
             .product(name: "Logging", package: "swift-log")
         ],
         path: "libs/GatewayPlugins/SecuritySentinelGatewayPlugin"
+    ),
+    .target(
+        name: "CuratorGatewayPlugin",
+        dependencies: ["FountainRuntime", "OpenAPICurator"],
+        path: "libs/GatewayPlugins/CuratorGatewayPlugin"
     ),
     .target(
         name: "GatewayPersonaOrchestrator",
@@ -701,6 +716,7 @@ let leanTargets: [Target] = [
             "RoleHealthCheckGatewayPlugin",
             "SecuritySentinelGatewayPlugin",
             "DestructiveGuardianGatewayPlugin",
+            "CuratorGatewayPlugin",
             "FountainRuntime",
             .product(name: "Crypto", package: "swift-crypto")
         ],

--- a/Tests/GatewayPluginsTests/CuratorGatewayPluginTests.swift
+++ b/Tests/GatewayPluginsTests/CuratorGatewayPluginTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+import FountainRuntime
+@testable import CuratorGatewayPlugin
+
+final class CuratorGatewayPluginTests: XCTestCase {
+    func testAllowedOperationPasses() async throws {
+        let table = ["op.allowed": CuratorGatewayPlugin.Truth(visibility: "public", allowAsTool: true, reason: "ok")]
+        let plugin = CuratorGatewayPlugin(fetcher: { table })
+        let req = HTTPRequest(method: "GET", path: "/", headers: ["X-Operation-ID": "op.allowed"])
+        let prepared = try await plugin.prepare(req)
+        let resp = HTTPResponse(status: 200)
+        let out = try await plugin.respond(resp, for: prepared)
+        XCTAssertEqual(out.status, 200)
+        XCTAssertEqual(out.headers["X-Curator-Evidence"], "ok")
+    }
+
+    func testBannedOperationBlocked() async throws {
+        let table = ["op.allowed": CuratorGatewayPlugin.Truth(visibility: "public", allowAsTool: true, reason: "ok")]
+        let plugin = CuratorGatewayPlugin(fetcher: { table })
+        let req = HTTPRequest(method: "GET", path: "/", headers: ["X-Operation-ID": "op.blocked"])
+        let prepared = try await plugin.prepare(req)
+        let resp = HTTPResponse(status: 200)
+        let out = try await plugin.respond(resp, for: prepared)
+        XCTAssertEqual(out.status, 403)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/docs/Q&A/what-functionality-does-the-fountainai-gateway-implement-to-provide-a-safe-llm-environment.md
+++ b/docs/Q&A/what-functionality-does-the-fountainai-gateway-implement-to-provide-a-safe-llm-environment.md
@@ -8,6 +8,8 @@ FountainAI Gateway is a SwiftNIO-based HTTP gateway that centralizes HTTPS termi
 ## Security and safety controls
 Authentication and authorization rely on signed JWTs and configurable validators. RoleGuard enforces path-based scopes, while rate limiting, payload inspection, destructive-operation gating, budget breakers, and a Security Sentinel offer defense-in-depth. Comprehensive metrics surface unauthorized access, allowances, and plugin-specific events.
 
+Requests are additionally validated against a curator-provided truth table; see [gateway evidence checks](../gateway/README.md#curatorgatewayplugin) for details.
+
 ## Operational features
 TLS certificates can auto-renew or be manually triggered. Routes are stored on disk with CRUD APIs, DNS zones can be managed through an optional ZoneManager (see [How does DNS work in FountainAI?](./how-does-dns-work-in-fountainai.md)), and RoleGuard rules hot-reload via an admin endpoint. Additional plugins can be added to extend gateway behavior.
 

--- a/docs/gateway/README.md
+++ b/docs/gateway/README.md
@@ -34,6 +34,10 @@ Define a `GATEWAY_CRED_<CLIENT_ID>` variable for each client allowed to request 
 ### Entry Point
 [`main.swift`](main.swift) constructs a `GatewayServer` with `LoggingPlugin` and `PublishingFrontendPlugin` and starts listening on port 8080. Passing `--dns` additionally launches a DNS server backed by `ZoneManager`. See [DNS subsystem docs](../FountainCodex/DNS/README.md) for zone management and server details.
 
+## Evidence-based Reasoning
+
+`CuratorGatewayPlugin` loads a truth table from the OpenAPI Curator service describing operations and their supporting evidence. Incoming requests declare an operation identifier which is validated against this table. Operations lacking evidence are blocked, while approved responses are annotated with the curator's rationale.
+
 ## Plugin Index
 
 The gateway composes middleware plugins to augment request handling. Each plugin is documented below.
@@ -70,6 +74,9 @@ Applies per-user request budgets with circuit breakers and health-triggered load
 
 - `rateLimit` – Optional requests-per-minute quota on route definitions.
 - Exceeding the quota returns HTTP `429` and increments throttling metrics.
+
+### CuratorGatewayPlugin
+Validates requests against a curator-provided truth table. Responses for allowed operations include the curator's evidence, while unknown operations are blocked.
 
 ---
 © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/GatewayPlugins/CuratorGatewayPlugin/CuratorGatewayPlugin/CuratorGatewayPlugin.swift
+++ b/libs/GatewayPlugins/CuratorGatewayPlugin/CuratorGatewayPlugin/CuratorGatewayPlugin.swift
@@ -1,0 +1,80 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import FountainRuntime
+import OpenAPICurator
+
+extension OpenAPICurator.Truth: @unchecked Sendable {}
+
+/// Gateway plugin that consults the curator service for evidence-based operation gating.
+public struct CuratorGatewayPlugin: Sendable {
+    public typealias Truth = OpenAPICurator.Truth
+    public typealias TruthTable = [String: Truth]
+
+    private let fetchTable: @Sendable () async throws -> TruthTable
+    private let cache = TruthTableCache()
+
+    /// Create a plugin pointing at the given curator service URL.
+    /// - Parameter curatorURL: Base URL of the curator service.
+    public init(curatorURL: URL = URL(string: "http://curator.fountain.coach/api/v1")!) {
+        self.fetchTable = {
+            var req = URLRequest(url: curatorURL.appendingPathComponent("truth-table"))
+            req.httpMethod = "POST"
+            req.addValue("application/json", forHTTPHeaderField: "Content-Type")
+            req.httpBody = Data("{}".utf8)
+            let (data, _) = try await URLSession.shared.data(for: req)
+            let table = try JSONDecoder().decode(TruthTable.self, from: data)
+            return table
+        }
+    }
+
+    /// Create a plugin with a custom fetcher, used mainly for tests.
+    public init(fetcher: @escaping @Sendable () async throws -> TruthTable) {
+        self.fetchTable = fetcher
+    }
+
+    /// Loads the curator truth table on first request.
+    public func prepare(_ request: HTTPRequest) async throws -> HTTPRequest {
+        try await cache.loadIfNeeded(fetcher: fetchTable)
+        return request
+    }
+
+    /// Returns whether an operation has curator evidence.
+    public func allowed(operation: String) async -> Bool {
+        if let truth = await cache.lookup(operation) {
+            return !truth.reason.isEmpty
+        }
+        return false
+    }
+
+    /// Annotates responses with curator evidence or rejects when missing.
+    public func respond(_ response: HTTPResponse, for request: HTTPRequest) async throws -> HTTPResponse {
+        guard let op = request.headers["X-Operation-ID"], !op.isEmpty else { return response }
+        if let truth = await cache.lookup(op) {
+            var resp = response
+            resp.headers["X-Curator-Evidence"] = truth.reason
+            return resp
+        }
+        return HTTPResponse(status: 403,
+                            headers: ["Content-Type": "application/json"],
+                            body: Data("{\"error\":\"operation lacks evidence\"}".utf8))
+    }
+}
+
+/// Actor-backed cache for curator truth table.
+actor TruthTableCache {
+    private var table: CuratorGatewayPlugin.TruthTable = [:]
+
+    func loadIfNeeded(fetcher: @Sendable () async throws -> CuratorGatewayPlugin.TruthTable) async throws {
+        if table.isEmpty {
+            table = try await fetcher()
+        }
+    }
+
+    func lookup(_ op: String) -> CuratorGatewayPlugin.Truth? {
+        table[op]
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -29,6 +29,7 @@ For a repository-wide index of OpenAPI coverage, see [../OPENAPI_COVERAGE.md](..
 | Security Sentinel Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/security-sentinel-gateway.yml](v1/security-sentinel-gateway.yml) |
 | Tool Server | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/tool-server.yml](v1/tool-server.yml) |
 | OpenAPI Curator Service | 1.0.2 | Contexter alias Benedikt Eickhoff | [v1/openapi-curator.yml](v1/openapi-curator.yml) |
+| Curator Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/curator-gateway.yml](v1/curator-gateway.yml) |
 
 
 ## Gateway Plugins
@@ -42,6 +43,7 @@ For a repository-wide index of OpenAPI coverage, see [../OPENAPI_COVERAGE.md](..
 | Budget Breaker Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/budget-breaker-gateway.yml](v1/budget-breaker-gateway.yml) |
 | Destructive Guardian Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/destructive-guardian-gateway.yml](v1/destructive-guardian-gateway.yml) |
 | Security Sentinel Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/security-sentinel-gateway.yml](v1/security-sentinel-gateway.yml) |
+| Curator Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/curator-gateway.yml](v1/curator-gateway.yml) |
 
 ## Persistence/FountainStore
 

--- a/openapi/v1/curator-gateway.yml
+++ b/openapi/v1/curator-gateway.yml
@@ -1,0 +1,94 @@
+---
+openapi: 3.1.0
+info:
+  title: Curator Gateway Plugin
+  description: >
+    Evidence-based operation gating for FountainAI gateway.
+  version: 1.0.0
+servers:
+  - url: http://curator-gateway.fountain.coach/api/v1
+paths:
+  /curator/check:
+    post:
+      tags:
+        - Curator
+      summary: Check operation evidence
+      description: Checks whether an operation is allowed with curator-provided evidence.
+      operationId: curatorCheck
+      x-fountain.visibility: public
+      x-fountain.reason: ""
+      x-fountain.allow-as-tool: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CuratorCheckRequest'
+      responses:
+        '200':
+          description: Allowance decision
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CuratorCheckResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+components:
+  schemas:
+    CuratorCheckRequest:
+      title: CuratorCheckRequest
+      type: object
+      required:
+        - operationId
+      properties:
+        operationId:
+          type: string
+          title: Operationid
+    CuratorCheckResponse:
+      title: CuratorCheckResponse
+      type: object
+      required:
+        - allowed
+      properties:
+        allowed:
+          type: boolean
+          title: Allowed
+        evidence:
+          type: string
+          title: Evidence
+          nullable: true
+    HTTPValidationError:
+      title: HTTPValidationError
+      type: object
+      properties:
+        detail:
+          type: array
+          title: Detail
+          items:
+            $ref: '#/components/schemas/ValidationError'
+    ValidationError:
+      title: ValidationError
+      type: object
+      required:
+        - loc
+        - msg
+        - type
+      properties:
+        loc:
+          type: array
+          title: Location
+          items:
+            anyOf:
+              - type: string
+              - type: integer
+        msg:
+          type: string
+          title: Message
+        type:
+          type: string
+          title: Error Type
+© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/services/GatewayServer/GatewayApp/CuratorGatewayPlugin+GatewayPlugin.swift
+++ b/services/GatewayServer/GatewayApp/CuratorGatewayPlugin+GatewayPlugin.swift
@@ -1,0 +1,5 @@
+import CuratorGatewayPlugin
+
+extension CuratorGatewayPlugin: GatewayPlugin {}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/services/GatewayServer/GatewayApp/main.swift
+++ b/services/GatewayServer/GatewayApp/main.swift
@@ -5,6 +5,7 @@ import FountainRuntime
 import LLMGatewayPlugin
 import AuthGatewayPlugin
 import RateLimiterGatewayPlugin
+import CuratorGatewayPlugin
 import LauncherSignature
 import GatewayPersonaOrchestrator
 
@@ -22,6 +23,7 @@ if gatewayConfig == nil {
     FileHandle.standardError.write(Data("[gateway] Warning: failed to load Configuration/gateway.yml; using defaults for rate limiting.\n".utf8))
 }
 let rateLimiter = RateLimiterGatewayPlugin(defaultLimit: gatewayConfig?.rateLimitPerMinute ?? 60)
+let curatorPlugin = CuratorGatewayPlugin()
 let llmPlugin = LLMGatewayPlugin()
 let authPlugin = AuthGatewayPlugin()
 let routesFile = URL(fileURLWithPath: "Configuration/routes.json")
@@ -38,6 +40,7 @@ if let jwksURL = ProcessInfo.processInfo.environment["GATEWAY_JWKS_URL"], let pr
 }
 plugins.append(contentsOf: [
     authPlugin as any GatewayPlugin,
+    curatorPlugin as any GatewayPlugin,
     llmPlugin as any GatewayPlugin,
     rateLimiter as any GatewayPlugin,
     LoggingPlugin() as any GatewayPlugin,


### PR DESCRIPTION
## Summary
- gate requests via new CuratorGatewayPlugin backed by curator truth tables
- register plugin in Gateway server and document evidence-based reasoning
- add OpenAPI spec and tests for curator-based request validation

## Testing
- `swift run openapi-curator-cli --spec openapi/v1/curator-gateway.yml` *(fails: 'async' call in a function that does not support concurrency)*
- `swift build`
- `swift test` *(fails: TokenValidationTests.testJWKSKeyProvider, TokenValidationTests.testOAuth2Validator)*

------
https://chatgpt.com/codex/tasks/task_b_68ba906f701c83338ffe4d37119ca22c