### PR TITLE
Document Golden Rule in system docs

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -10,8 +10,8 @@ This file is the **canonical manifest** at the repo root that Codex follows when
 ---
 
 ## 1) Golden Rule
-> **Everything is persisted under a corpus.**  
-> All FountainAI services write/read through FountainStore into a corpus tree. The corpus structure is authoritative and defined by Bootstrapping and Baseline Awareness. No dual APIs, no detached indexers, no semantic browser persistence outside the semantic memory engine.
+> **Everything—including configuration—is persisted under a corpus.**
+> All FountainAI services and their configs read/write through FountainStore into a corpus tree. The corpus structure is authoritative and defined by Bootstrapping and Baseline Awareness. No dual APIs, no detached indexers, and no standalone configuration files outside the semantic memory engine.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,10 @@
 
 FountainAI organizes its Swift packages into modular layers.
 
+## Golden Rule
+
+All persistent data—including configuration—must reside in a FountainStore corpus. Services load and persist state through the corpus tree instead of local files, keeping deployments consistent and auditable.
+
 ## Architecture
 
 - [Sources/FountainCodex/Parser/SpecLoader.swift](../Sources/FountainCodex/Parser/SpecLoader.swift#L1-L33) // loads OpenAPI specs and normalizes JSON or YAML


### PR DESCRIPTION
## Summary
- clarify Golden Rule in `agent.md` that configuration must live in corpora
- add Golden Rule section to architecture docs detailing corpus-first persistence

## Testing
- `bash scripts/run-tests.sh` *(fails: extension declares a conformance of imported type 'Truth' to imported protocol 'Sendable')*

------
https://chatgpt.com/codex/tasks/task_b_68ba9681209883339527266967eca776