### PR TITLE
feat: centralize service configs in FountainStore

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -327,7 +327,7 @@ let fullTargets: [Target] = [
     ),
     .testTarget(
         name: "OpenAPICuratorServiceIntegrationTests",
-        dependencies: ["openapi-curator-service"],
+        dependencies: ["openapi-curator-service", "FountainStoreClient"],
         path: "Tests/OpenAPICuratorServiceIntegrationTests"
     ),
     .testTarget(
@@ -376,7 +376,7 @@ let fullTargets: [Target] = [
         path: "Tests/BootstrapServerIntegrationTests"
     ),
     .testTarget(name: "ClientGeneratorTests", dependencies: ["FountainRuntime"], path: "Tests/ClientGeneratorTests"),
-    .testTarget(name: "PublishingFrontendTests", dependencies: ["PublishingFrontend"], path: "Tests/PublishingFrontendTests"),
+    .testTarget(name: "PublishingFrontendTests", dependencies: ["PublishingFrontend", "FountainStoreClient"], path: "Tests/PublishingFrontendTests"),
     .testTarget(name: "DNSTests", dependencies: ["PublishingFrontend", "FountainRuntime", .product(name: "Crypto", package: "swift-crypto"), .product(name: "NIOEmbedded", package: "swift-nio"), .product(name: "NIO", package: "swift-nio")], path: "Tests/DNSTests"),
     .testTarget(
         name: "IntegrationRuntimeTests",
@@ -389,7 +389,7 @@ let fullTargets: [Target] = [
     .testTarget(name: "MIDI2CoreTests", dependencies: ["MIDI2Core", "ResourceLoader", "flexctl"], path: "Tests/MIDI2CoreTests"),
     .testTarget(name: "MIDI2TransportsTests", dependencies: ["MIDI2Transports"], path: "Tests/MIDI2TransportsTests"),
     .testTarget(name: "FlexctlTests", dependencies: ["flexctl", "ResourceLoader"], path: "Tests/FlexctlTests"),
-    .testTarget(name: "GatewayAppTests", dependencies: ["gateway-server", "LLMGatewayPlugin", "AuthGatewayPlugin", "DestructiveGuardianGatewayPlugin", "PayloadInspectionGatewayPlugin", "BudgetBreakerGatewayPlugin", "RateLimiterGatewayPlugin", "RoleHealthCheckGatewayPlugin", "persist-server"], path: "Tests/GatewayAppTests"),
+    .testTarget(name: "GatewayAppTests", dependencies: ["gateway-server", "LLMGatewayPlugin", "AuthGatewayPlugin", "DestructiveGuardianGatewayPlugin", "PayloadInspectionGatewayPlugin", "BudgetBreakerGatewayPlugin", "RateLimiterGatewayPlugin", "RoleHealthCheckGatewayPlugin", "persist-server", "FountainStoreClient"], path: "Tests/GatewayAppTests"),
     .testTarget(name: "ToolsFactoryServiceTests", dependencies: ["ToolsFactoryService", "FountainStoreClient"], path: "Tests/ToolsFactoryServiceTests"),
     .testTarget(
         name: "ToolsmithPackageTests",

--- a/Tests/GatewayAppTests/GatewayConfigStoreTests.swift
+++ b/Tests/GatewayAppTests/GatewayConfigStoreTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import gateway_server
+import FountainStoreClient
+
+final class GatewayConfigStoreTests: XCTestCase {
+    func testLoadGatewayConfigFromStore() async throws {
+        let client = FountainStoreClient(client: EmbeddedFountainStoreClient())
+        let store = ConfigurationStore(client: client, corpusId: "test")
+        try await store.put("gateway.yml", data: Data("rateLimitPerMinute: 7".utf8))
+        let env = [
+            "FOUNTAINSTORE_URL": "embedded",
+            "FOUNTAINSTORE_API_KEY": "key",
+            "DEFAULT_CORPUS_ID": "test"
+        ]
+        let cfg = try loadGatewayConfig(store: store, environment: env)
+        XCTAssertEqual(cfg.rateLimitPerMinute, 7)
+    }
+}

--- a/Tests/GatewayAppTests/RoleGuardConfigTests.swift
+++ b/Tests/GatewayAppTests/RoleGuardConfigTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import FountainStoreClient
 @testable import gateway_server
 
 final class RoleGuardConfigTests: XCTestCase {
@@ -12,9 +13,25 @@ final class RoleGuardConfigTests: XCTestCase {
           "/bootstrap": "admin"
         """
         try yaml.write(to: file, atomically: true, encoding: .utf8)
-        let rules = loadRoleGuardRules(from: file)
+        let rules = loadRoleGuardRules(path: file)
         XCTAssertEqual(rules["/awareness"]?.roles ?? [], ["admin"])
         XCTAssertEqual(rules["/bootstrap"]?.roles ?? [], ["admin"])
     }
 }
 
+    func testLoadRoleGuardRulesFromStore() async throws {
+        let client = FountainStoreClient(client: EmbeddedFountainStoreClient())
+        let store = ConfigurationStore(client: client, corpusId: "c")
+        let yaml = """
+        rules:
+          "/admin": "root"
+        """
+        try await store.put("roleguard.yml", data: Data(yaml.utf8))
+        let env = [
+            "FOUNTAINSTORE_URL": "embedded",
+            "FOUNTAINSTORE_API_KEY": "k",
+            "DEFAULT_CORPUS_ID": "c"
+        ]
+        let rules = loadRoleGuardRules(store: store, environment: env)
+        XCTAssertEqual(rules["/admin"]?.roles ?? [], ["root"])
+    }

--- a/Tests/GatewayAppTests/RoleGuardReload304Tests.swift
+++ b/Tests/GatewayAppTests/RoleGuardReload304Tests.swift
@@ -12,7 +12,7 @@ final class RoleGuardReload304Tests: XCTestCase {
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         let file = dir.appendingPathComponent("roleguard.yml")
         try Data().write(to: file)
-        let store = RoleGuardStore(initialRules: loadRoleGuardRules(from: file), configURL: file)
+        let store = RoleGuardStore(initialRules: loadRoleGuardRules(path: file), configURL: file)
         let server = GatewayServer(plugins: [], roleGuardStore: store)
         let port = 9152
         Task { try await server.start(port: port) }

--- a/Tests/GatewayAppTests/RoleGuardReloadTests.swift
+++ b/Tests/GatewayAppTests/RoleGuardReloadTests.swift
@@ -19,7 +19,7 @@ final class RoleGuardReloadTests: XCTestCase {
         try initial.write(to: rulesFile)
 
         // Server with store pointing to temp file
-        let store = RoleGuardStore(initialRules: loadRoleGuardRules(from: rulesFile), configURL: rulesFile)
+        let store = RoleGuardStore(initialRules: loadRoleGuardRules(path: rulesFile), configURL: rulesFile)
         let server = GatewayServer(plugins: [RoleGuardPlugin(store: store)], roleGuardStore: store)
         let port = 9145
         Task { try await server.start(port: port) }

--- a/Tests/OpenAPICuratorServiceIntegrationTests/ConfigurationStoreTests.swift
+++ b/Tests/OpenAPICuratorServiceIntegrationTests/ConfigurationStoreTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import openapi_curator_service
+import FountainStoreClient
+
+final class ConfigurationStoreTests: XCTestCase {
+    func testLoadCuratorRulesFromStore() async throws {
+        let client = FountainStoreClient(client: EmbeddedFountainStoreClient())
+        let store = ConfigurationStore(client: client, corpusId: "c")
+        let yaml = """
+        renames:
+          old: new
+        """
+        try await store.put("curator.yml", data: Data(yaml.utf8))
+        let env = [
+            "FOUNTAINSTORE_URL": "embedded",
+            "FOUNTAINSTORE_API_KEY": "k",
+            "DEFAULT_CORPUS_ID": "c"
+        ]
+        let rules = loadCuratorRules(environment: env, store: store)
+        XCTAssertEqual(rules.renames["old"], "new")
+    }
+}

--- a/Tests/PublishingFrontendTests/PublishingFrontendTests.swift
+++ b/Tests/PublishingFrontendTests/PublishingFrontendTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import FountainStoreClient
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -246,3 +247,20 @@ final class PublishingFrontendTests: XCTestCase {
 }
 
 // © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+    func testLoadPublishingConfigFromStore() async throws {
+        let client = FountainStoreClient(client: EmbeddedFountainStoreClient())
+        let store = ConfigurationStore(client: client, corpusId: "p")
+        let yaml = """
+        port: 5555
+        rootPath: /srv/www
+        """
+        try await store.put("publishing.yml", data: Data(yaml.utf8))
+        let env = [
+            "FOUNTAINSTORE_URL": "embedded",
+            "FOUNTAINSTORE_API_KEY": "x",
+            "DEFAULT_CORPUS_ID": "p"
+        ]
+        let cfg = try loadPublishingConfig(store: store, environment: env)
+        XCTAssertEqual(cfg.port, 5555)
+        XCTAssertEqual(cfg.rootPath, "/srv/www")
+    }

--- a/libs/FountainStoreClient/ConfigurationStore.swift
+++ b/libs/FountainStoreClient/ConfigurationStore.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Convenience wrapper for storing configuration files inside FountainStore.
+public actor ConfigurationStore {
+    private let client: FountainStoreClient
+    private let corpusId: String
+    private let collection = "config"
+
+    public init(client: FountainStoreClient, corpusId: String) {
+        self.client = client
+        self.corpusId = corpusId
+    }
+
+    /// Reads a configuration document by name.
+    public func get(_ name: String) async throws -> Data? {
+        try await client.getDoc(corpusId: corpusId, collection: collection, id: name)
+    }
+
+    /// Writes a configuration document.
+    public func put(_ name: String, data: Data) async throws {
+        try await client.putDoc(corpusId: corpusId, collection: collection, id: name, body: data)
+    }
+
+    /// Synchronously fetches a configuration document.
+    public nonisolated func getSync(_ name: String) -> Data? {
+        let sema = DispatchSemaphore(value: 0)
+        var result: Data?
+        Task {
+            result = try? await get(name)
+            sema.signal()
+        }
+        sema.wait()
+        return result
+    }
+}
+
+public extension ConfigurationStore {
+    /// Creates a store instance from environment variables if possible.
+    /// Returns `nil` when required variables are missing.
+    static func fromEnvironment(_ env: [String: String] = ProcessInfo.processInfo.environment,
+                                client: FountainStoreClient? = nil) -> ConfigurationStore? {
+        guard env["FOUNTAINSTORE_URL"] != nil,
+              env["FOUNTAINSTORE_API_KEY"] != nil,
+              let corpus = env["DEFAULT_CORPUS_ID"] ?? env["CORPUS_ID"] else {
+            return nil
+        }
+        let svc = client ?? FountainStoreClient(client: EmbeddedFountainStoreClient())
+        return ConfigurationStore(client: svc, corpusId: corpus)
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/libs/PublishingFrontend/PublishingFrontend/PublishingFrontend.swift
+++ b/libs/PublishingFrontend/PublishingFrontend/PublishingFrontend.swift
@@ -3,6 +3,7 @@ import NIO
 import NIOHTTP1
 import FountainRuntime
 import Yams
+import FountainStoreClient
 
 /// Configuration for the ``PublishingFrontend`` server.
 public struct PublishingConfig: Codable {
@@ -64,15 +65,22 @@ public final class PublishingFrontend {
     }
 }
 
-/// Loads the publishing configuration from `Configuration/publishing.yml`.
-/// Missing `port` or `rootPath` keys fall back to the defaults `8085` and `./Public`.
-/// - Throws: If the file is missing, contains invalid YAML, or fails decoding into ``PublishingConfig``.
-/// - Returns: Parsed ``PublishingConfig`` instance.
-public func loadPublishingConfig() throws -> PublishingConfig {
-    let url = URL(fileURLWithPath: "Configuration/publishing.yml")
+/// Loads the publishing configuration from FountainStore's `config/publishing.yml`.
+/// Falls back to `Configuration/publishing.yml` when FountainStore is unavailable.
+public func loadPublishingConfig(store: ConfigurationStore? = nil,
+                                environment: [String: String] = ProcessInfo.processInfo.environment) throws -> PublishingConfig {
+    let svc = store ?? ConfigurationStore.fromEnvironment(environment)
+    if let data = svc?.getSync("publishing.yml"), let text = String(data: data, encoding: .utf8) {
+        return try decodePublishingConfig(from: text)
+    }
+    let path = environment["PUBLISHING_CONFIG_PATH"] ?? "Configuration/publishing.yml"
+    let raw = try String(contentsOfFile: path, encoding: .utf8)
+    return try decodePublishingConfig(from: raw)
+}
+
+private func decodePublishingConfig(from raw: String) throws -> PublishingConfig {
     // Strip lines that begin with a copyright footer (e.g., starting with "©")
     // to keep configuration strictly YAML-parseable.
-    let raw = try String(contentsOf: url, encoding: .utf8)
     let sanitized = raw
         .split(separator: "\n", omittingEmptySubsequences: false)
         .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("©") }

--- a/scripts/ingest-config.swift
+++ b/scripts/ingest-config.swift
@@ -1,0 +1,25 @@
+import Foundation
+import FountainStoreClient
+
+@main
+struct IngestConfig {
+    static func main() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let store = ConfigurationStore.fromEnvironment(env) else {
+            fputs("FOUNTAINSTORE_URL, FOUNTAINSTORE_API_KEY, and corpus id required\n", stderr)
+            return
+        }
+        let base = URL(fileURLWithPath: "Configuration", isDirectory: true)
+        let fm = FileManager.default
+        let items = ["gateway.yml", "curator.yml", "publishing.yml", "roleguard.yml", "routes.json"]
+        for name in items {
+            let path = base.appendingPathComponent(name)
+            if fm.fileExists(atPath: path.path), let data = try? Data(contentsOf: path) {
+                try await store.put(name, data: data)
+                print("ingested \(name)")
+            }
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/services/GatewayServer/GatewayApp/GatewayConfig.swift
+++ b/services/GatewayServer/GatewayApp/GatewayConfig.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yams
+import FountainStoreClient
 
 /// Configuration for the gateway server.
 public struct GatewayConfig: Codable {
@@ -11,11 +12,20 @@ public struct GatewayConfig: Codable {
     }
 }
 
-/// Loads gateway configuration from `Configuration/gateway.yml`.
-/// Lines beginning with a copyright symbol are ignored to keep YAML parseable.
-public func loadGatewayConfig() throws -> GatewayConfig {
-    let url = URL(fileURLWithPath: "Configuration/gateway.yml")
-    let raw = try String(contentsOf: url, encoding: .utf8)
+/// Loads gateway configuration from FountainStore's `config/gateway.yml`.
+/// Falls back to `Configuration/gateway.yml` when FountainStore is unavailable.
+public func loadGatewayConfig(store: ConfigurationStore? = nil,
+                              environment: [String: String] = ProcessInfo.processInfo.environment) throws -> GatewayConfig {
+    let svc = store ?? ConfigurationStore.fromEnvironment(environment)
+    if let data = svc?.getSync("gateway.yml"), let text = String(data: data, encoding: .utf8) {
+        return try decodeGatewayConfig(from: text)
+    }
+    let path = environment["GATEWAY_CONFIG_PATH"] ?? "Configuration/gateway.yml"
+    let raw = try String(contentsOfFile: path, encoding: .utf8)
+    return try decodeGatewayConfig(from: raw)
+}
+
+private func decodeGatewayConfig(from raw: String) throws -> GatewayConfig {
     let sanitized = raw
         .split(separator: "\n", omittingEmptySubsequences: false)
         .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("©") }

--- a/services/GatewayServer/GatewayApp/RoleGuardConfig.swift
+++ b/services/GatewayServer/GatewayApp/RoleGuardConfig.swift
@@ -1,13 +1,22 @@
 import Foundation
 import Yams
+import FountainStoreClient
 
-public func roleGuardConfigURL(environment: [String: String] = ProcessInfo.processInfo.environment) -> URL {
-    return environment["ROLE_GUARD_PATH"].map(URL.init(fileURLWithPath:)) ?? URL(fileURLWithPath: "Configuration/roleguard.yml")
+/// Loads role guard rules from FountainStore's `config/roleguard.yml`.
+/// Falls back to a local file when FountainStore is unavailable.
+public func loadRoleGuardRules(store: ConfigurationStore? = nil,
+                               path: URL? = nil,
+                               environment: [String: String] = ProcessInfo.processInfo.environment) -> [String: RoleRequirement] {
+    let svc = store ?? ConfigurationStore.fromEnvironment(environment)
+    if let data = svc?.getSync("roleguard.yml"), let text = String(data: data, encoding: .utf8) {
+        return parseRoleGuardRules(from: text)
+    }
+    let filePath = path?.path ?? (environment["ROLE_GUARD_PATH"] ?? "Configuration/roleguard.yml")
+    guard let text = try? String(contentsOfFile: filePath, encoding: .utf8) else { return [:] }
+    return parseRoleGuardRules(from: text)
 }
 
-public func loadRoleGuardRules(from path: URL? = nil, environment: [String: String] = ProcessInfo.processInfo.environment) -> [String: RoleRequirement] {
-    let url = path ?? roleGuardConfigURL(environment: environment)
-    guard FileManager.default.fileExists(atPath: url.path), let text = try? String(contentsOf: url, encoding: .utf8) else { return [:] }
+private func parseRoleGuardRules(from text: String) -> [String: RoleRequirement] {
     do {
         if let yaml = try Yams.load(yaml: text) as? [String: Any], let rawRules = yaml["rules"] as? [String: Any] {
             var result: [String: RoleRequirement] = [:]

--- a/services/GatewayServer/GatewayApp/RoleGuardStore.swift
+++ b/services/GatewayServer/GatewayApp/RoleGuardStore.swift
@@ -17,7 +17,7 @@ public actor RoleGuardStore {
     @discardableResult
     public func reload() async -> Bool {
         guard let url = configURL else { return false }
-        let newRules = loadRoleGuardRules(from: url)
+        let newRules = loadRoleGuardRules(path: url)
         guard !newRules.isEmpty else { return false }
         self.rules = newRules
         return true

--- a/services/GatewayServer/GatewayApp/main.swift
+++ b/services/GatewayServer/GatewayApp/main.swift
@@ -8,32 +8,42 @@ import RateLimiterGatewayPlugin
 import CuratorGatewayPlugin
 import LauncherSignature
 import GatewayPersonaOrchestrator
+import FountainStoreClient
 
 verifyLauncherSignature()
 // Role guard plugin in this target
 // Loaded from config if present
+let env = ProcessInfo.processInfo.environment
+let configStore = ConfigurationStore.fromEnvironment(env)
 
-let publishingConfig = try? loadPublishingConfig()
+let publishingConfig = try? loadPublishingConfig(store: configStore, environment: env)
 if publishingConfig == nil {
-    FileHandle.standardError.write(Data("[gateway] Warning: failed to load Configuration/publishing.yml; using defaults for static content.\n".utf8))
+    FileHandle.standardError.write(Data("[gateway] Warning: failed to load publishing config; using defaults for static content.\n".utf8))
 }
 
-let gatewayConfig = try? loadGatewayConfig()
+let gatewayConfig = try? loadGatewayConfig(store: configStore, environment: env)
 if gatewayConfig == nil {
-    FileHandle.standardError.write(Data("[gateway] Warning: failed to load Configuration/gateway.yml; using defaults for rate limiting.\n".utf8))
+    FileHandle.standardError.write(Data("[gateway] Warning: failed to load gateway config; using defaults for rate limiting.\n".utf8))
 }
 let rateLimiter = RateLimiterGatewayPlugin(defaultLimit: gatewayConfig?.rateLimitPerMinute ?? 60)
 let curatorPlugin = CuratorGatewayPlugin()
 let llmPlugin = LLMGatewayPlugin()
 let authPlugin = AuthGatewayPlugin()
-let routesFile = URL(fileURLWithPath: "Configuration/routes.json")
+var routesURL: URL?
+if let data = configStore?.getSync("routes.json") {
+    let tmp = FileManager.default.temporaryDirectory.appendingPathComponent("routes.json")
+    try? data.write(to: tmp)
+    routesURL = tmp
+} else {
+    let path = env["ROUTES_PATH"] ?? "Configuration/routes.json"
+    routesURL = URL(fileURLWithPath: path)
+}
 var plugins: [any GatewayPlugin] = []
-let rgURL = roleGuardConfigURL()
-let roleRules = loadRoleGuardRules(from: rgURL)
-let roleGuardStore = RoleGuardStore(initialRules: roleRules, configURL: rgURL)
+let roleRules = loadRoleGuardRules(store: configStore, environment: env)
+let roleGuardStore = RoleGuardStore(initialRules: roleRules, configURL: nil)
 Task { await RoleGuardMetrics.shared.setActiveRules(roleRules.count) }
 // Choose validator based on environment (JWKS for HS256-oct if provided; otherwise env secret)
-if let jwksURL = ProcessInfo.processInfo.environment["GATEWAY_JWKS_URL"], let provider = JWKSKeyProvider(jwksURL: jwksURL) {
+if let jwksURL = env["GATEWAY_JWKS_URL"], let provider = JWKSKeyProvider(jwksURL: jwksURL) {
     plugins.append(RoleGuardPlugin(store: roleGuardStore, validator: HMACKeyValidator(keyProvider: provider)))
 } else {
     plugins.append(RoleGuardPlugin(store: roleGuardStore, validator: HMACKeyValidator()))
@@ -51,7 +61,7 @@ let orchestrator = GatewayPersonaOrchestrator(personas: [
     DestructiveGuardianPersona()
 ])
 
-let server = GatewayServer(plugins: plugins, zoneManager: nil, routeStoreURL: routesFile, certificatePath: nil, rateLimiter: rateLimiter, roleGuardStore: roleGuardStore, personaOrchestrator: orchestrator)
+let server = GatewayServer(plugins: plugins, zoneManager: nil, routeStoreURL: routesURL, certificatePath: nil, rateLimiter: rateLimiter, roleGuardStore: roleGuardStore, personaOrchestrator: orchestrator)
 Task { @MainActor in
     try await server.start(port: 8080)
 }

--- a/services/OpenAPICuratorService/OpenAPICuratorServiceModule.swift
+++ b/services/OpenAPICuratorService/OpenAPICuratorServiceModule.swift
@@ -2,25 +2,38 @@ import Foundation
 import FountainRuntime
 import OpenAPICurator
 import Yams
+import FountainStoreClient
 import CryptoKit
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
+private let env = ProcessInfo.processInfo.environment
+private let configStore = ConfigurationStore.fromEnvironment(env)
+private let initialRules: Rules = loadCuratorRules(environment: env, store: configStore)
+let curatorRulesStore = CuratorRulesStore(initialRules: initialRules, configURL: nil)
+var curatorRulesReloader: CuratorRulesReloader?
+if configStore == nil {
+    let path = env["CURATOR_RULES_PATH"] ?? "Configuration/curator.yml"
+    let url = URL(fileURLWithPath: path)
+    curatorRulesReloader = CuratorRulesReloader(store: curatorRulesStore, url: url)
+    curatorRulesReloader?.start(interval: 2.0)
+}
 
-private let rulesPath = ProcessInfo.processInfo.environment["CURATOR_RULES_PATH"] ?? "Configuration/curator.yml"
-private let rulesURL = URL(fileURLWithPath: rulesPath)
-private let initialRules: Rules = {
-    let contents = (try? String(contentsOfFile: rulesPath)) ?? ""
+public func loadCuratorRules(environment: [String: String] = ProcessInfo.processInfo.environment,
+                             store: ConfigurationStore? = nil) -> Rules {
+    let svc = store ?? ConfigurationStore.fromEnvironment(environment)
+    if let data = svc?.getSync("curator.yml"), let text = String(data: data, encoding: .utf8) {
+        return parseRules(from: text)
+    }
+    let path = environment["CURATOR_RULES_PATH"] ?? "Configuration/curator.yml"
+    let contents = (try? String(contentsOfFile: path)) ?? ""
     return parseRules(from: contents)
-}()
-let curatorRulesStore = CuratorRulesStore(initialRules: initialRules, configURL: rulesURL)
-var curatorRulesReloader: CuratorRulesReloader? = CuratorRulesReloader(store: curatorRulesStore, url: rulesURL)
-curatorRulesReloader?.start(interval: 2.0)
+}
 
 public func metrics_metrics_get() async -> HTTPResponse {
     let uptime = Int(ProcessInfo.processInfo.systemUptime)
     let counts = await curatorMetrics.snapshot()
-    let rulesContents = (try? String(contentsOfFile: rulesPath)) ?? ""
+    let rulesContents: String = { if let data = configStore?.getSync("curator.yml") { return String(data: data, encoding: .utf8) ?? "" } else { let path = env["CURATOR_RULES_PATH"] ?? "Configuration/curator.yml"; return (try? String(contentsOfFile: path)) ?? "" } }()
     let digest = SHA256.hash(data: Data(rulesContents.utf8))
     let rulesHash = digest.prefix(8).reduce(UInt64(0)) { ($0 << 8) | UInt64($1) }
     var lines: [String] = []
@@ -208,7 +221,13 @@ public func makeOpenAPICuratorKernel() -> HTTPKernel {
                 return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: json)
 
             case ("GET", ["rules"]):
-                if let contents = try? String(contentsOfFile: rulesPath),
+                if let data = configStore?.getSync("curator.yml"),
+                   let yamlObj = try? Yams.load(yaml: String(data: data, encoding: .utf8) ?? "") {
+                    let json = try JSONSerialization.data(withJSONObject: yamlObj)
+                    return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: json)
+                }
+                let path = env["CURATOR_RULES_PATH"] ?? "Configuration/curator.yml"
+                if let contents = try? String(contentsOfFile: path),
                    let yamlObj = try? Yams.load(yaml: contents) {
                     let json = try JSONSerialization.data(withJSONObject: yamlObj)
                     return HTTPResponse(status: 200, headers: ["Content-Type": "application/json"], body: json)


### PR DESCRIPTION
## Summary
- add ConfigurationStore actor backed by FountainStoreClient
- load gateway, publishing, role guard, and curator configs from FountainStore with local fallbacks
- seed config docs with ingest-config utility

## Testing
- `swift build --target FountainStoreClient`
- `swift build --target gateway-server` *(fails: no target)*
- `swift test --filter GatewayConfigStoreTests/testLoadGatewayConfigFromStore` *(no matching tests)*


------
https://chatgpt.com/codex/tasks/task_b_68ba974865e8833399e10c62856777a8