### PR TITLE
Fix DNS metrics test and OAuth2 mock handling

### DIFF
--- a/Tests/DNSTests/DNSEngineTests.swift
+++ b/Tests/DNSTests/DNSEngineTests.swift
@@ -179,7 +179,7 @@ final class DNSEngineTests: XCTestCase {
         buf.writeInteger(UInt16(0x1234), as: UInt16.self)
         let engine = DNSEngine(records: [])
         XCTAssertNil(engine.handleQuery(buffer: &buf))
-        await Task.yield()
+        _ = await DNSMetrics.shared.wait(forQueries: 1)
         let text = await DNSMetrics.shared.exposition()
         XCTAssertTrue(text.contains("dns_queries_type_invalid_total 1"))
         XCTAssertTrue(text.contains("dns_misses_total 1"))

--- a/Tests/TokenValidationTests/TokenValidationTests.swift
+++ b/Tests/TokenValidationTests/TokenValidationTests.swift
@@ -150,7 +150,22 @@ private class MockURLProtocol: URLProtocol {
             client?.urlProtocol(self, didFailWithError: URLError(.badURL))
             return
         }
-        let (status, data) = handler(request)
+        var req = request
+        if req.httpBody == nil, let stream = req.httpBodyStream {
+            stream.open()
+            defer { stream.close() }
+            var data = Data()
+            let bufferSize = 1024
+            let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+            defer { buffer.deallocate() }
+            while stream.hasBytesAvailable {
+                let read = stream.read(buffer, maxLength: bufferSize)
+                if read <= 0 { break }
+                data.append(buffer, count: read)
+            }
+            req.httpBody = data
+        }
+        let (status, data) = handler(req)
         let response = HTTPURLResponse(url: url, statusCode: status, httpVersion: nil, headerFields: nil)!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: data)

--- a/libs/GatewayPlugins/CuratorGatewayPlugin/CuratorGatewayPlugin/CuratorGatewayPlugin.swift
+++ b/libs/GatewayPlugins/CuratorGatewayPlugin/CuratorGatewayPlugin/CuratorGatewayPlugin.swift
@@ -5,7 +5,7 @@ import FoundationNetworking
 import FountainRuntime
 import OpenAPICurator
 
-extension OpenAPICurator.Truth: @unchecked Sendable {}
+extension OpenAPICurator.Truth: @retroactive @unchecked Sendable {}
 
 /// Gateway plugin that consults the curator service for evidence-based operation gating.
 public struct CuratorGatewayPlugin: Sendable {


### PR DESCRIPTION
## Summary
- silence Swift Sendable warning in CuratorGatewayPlugin
- ensure DNS metrics await completion before asserting
- capture streamed request bodies in OAuth2 test MockURLProtocol

## Testing
- `swift build --target CuratorGatewayPlugin`
- `swift test --filter DNSTests.DNSEngineTests/testMalformedPacketRecordedAsInvalid` *(failed: build timed out)*
- `swift test --filter TokenValidationTests/testOAuth2Validator` *(not run: build timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68baad56a54c8333ba507469b9826aac