### PR TITLE
Document OpenAPI curation requirement

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -18,9 +18,10 @@ This file is the **canonical manifest** at the repo root that Codex follows when
 ## 2) Deliverables (this PR series)
 
 ### 2.1 Specs & Text Updates
-- Purge all references to external or evolved indexer APIs.  
-- Update Semantic Browser spec to say: **“Artifacts are persisted into FountainStore under a corpus.”**  
+- Purge all references to external or evolved indexer APIs.
+- Update Semantic Browser spec to say: **“Artifacts are persisted into FountainStore under a corpus.”**
 - Ensure Bootstrapping and Baseline Awareness OpenAPIs are referenced as the definitional model for corpus creation, readiness, and baseline anchoring.
+- OpenAPI specs are the canonical source of truth; after modifying any spec, call the OpenAPI Curator (`POST /curate`) with the full list of repository specs and optionally submit the curated bundle to the Tools Factory.
 
 ### 2.2 FountainStore Client (Swift)
 Implement `libs/FountainStoreClient` with corpus-first methods:

--- a/openapi/AGENTS.md
+++ b/openapi/AGENTS.md
@@ -12,11 +12,15 @@
    - Mark the status column (e.g., ✅/❌) to reflect task completion.
    - Do **not** delete or rewrite existing spec links—only append entries so the README remains a versioned index of every OpenAPI document.
 
-3. **Validation & copyright**  
-   - Run the project’s OpenAPI validation tooling after changes.  
+3. **Validation & copyright**
+   - Run the project’s OpenAPI validation tooling after changes.
    - End every spec with `© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.`
 
-4. **Repository linkage**  
+4. **Repository linkage**
    - Each new gateway spec should have a corresponding Swift package under `libs/GatewayPlugins/` and a registration file `+GatewayPlugin.swift` in `services/GatewayServer/GatewayApp`.
+
+5. **Curatory requirement**
+   - After editing any spec, invoke the FountainAI OpenAPI Curator via `POST /curate` with a list of every `file://openapi/...` document and a `corpusId` for the bundle.
+   - The curated output is the single source of truth and may be submitted to the Tools Factory when `submitToToolsFactory` is `true`.
 
 Following these guidelines keeps OpenAPI specs discoverable, versioned, and consistently integrated with the Gateway and FountainStore layers.

--- a/services/ToolsFactoryServer/AGENTS.md
+++ b/services/ToolsFactoryServer/AGENTS.md
@@ -1,0 +1,8 @@
+# Tools Factory Server Agent
+
+1. **Curated OpenAPI source**
+   - This service trusts only operations coming from the FountainAI OpenAPI Curator.
+   - After modifying the spec or tool registration, call `POST /curate` with the full list of `file://openapi/...` specs and set `submitToToolsFactory` as needed.
+
+2. **Validation**
+   - Run the project’s OpenAPI validation tooling before committing changes.


### PR DESCRIPTION
## Summary
- Declare OpenAPI curator as canonical source in root agent
- Note curation mandate in openapi/AGENTS.md
- Add ToolsFactoryServer agent documenting curated spec requirement

## Testing
- `env FULL_TESTS=1 swift run openapi-curator-cli --spec openapi/v1/tools-factory.yml`
- `swift test` *(fails: build canceled)*

------
https://chatgpt.com/codex/tasks/task_b_68bac0d3a01083339dae93e42ae98bcc