### PR TITLE
feat: add interactive local start script

### DIFF
--- a/scripts/start-local.sh
+++ b/scripts/start-local.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+
+# Load environment variables from .env if present
+env_file="$REPO_ROOT/.env"
+if [[ -f "$env_file" ]]; then
+  set -a
+  source "$env_file"
+  set +a
+fi
+
+prompt_var() {
+  local var="$1"
+  local secret="$2"
+  if [[ -z "${!var:-}" ]]; then
+    if [[ "$secret" == "1" ]]; then
+      read -s -p "Enter $var: " value
+      echo
+    else
+      read -r -p "Enter $var: " value
+    fi
+    export "$var"="$value"
+    read -r -p "Save $var to .env for future runs? [y/N]: " save
+    if [[ "$save" =~ ^[Yy]$ ]]; then
+      if [[ -f "$env_file" ]]; then
+        grep -v "^${var}=" "$env_file" > "${env_file}.tmp" && mv "${env_file}.tmp" "$env_file"
+      fi
+      echo "$var=$value" >> "$env_file"
+    fi
+  fi
+}
+
+prompt_var "FOUNTAINSTORE_URL" 0
+prompt_var "FOUNTAINSTORE_API_KEY" 1
+prompt_var "OPENAI_API_KEY" 1
+
+"$SCRIPT_DIR/boot.sh"


### PR DESCRIPTION
## Summary
- add `scripts/start-local.sh` to prompt for needed API keys and delegate to existing `boot.sh`

## Testing
- `FOUNTAINSTORE_URL=http://example.com FOUNTAINSTORE_API_KEY=dummy OPENAI_API_KEY=dummy CHECK_ENV=1 RUN_DIAGNOSTICS=0 BUILD=0 INSTALL_BINARIES=0 LAUNCH_DEMO=0 ./scripts/start-local.sh`


------
https://chatgpt.com/codex/tasks/task_b_68bac9c5b00883339beaf3e8d4b4fa7c