### PR TITLE
feat: add local servers and port metadata

### DIFF
--- a/openapi/README.md
+++ b/openapi/README.md
@@ -30,6 +30,25 @@ For a repository-wide index of OpenAPI coverage, see [../OPENAPI_COVERAGE.md](..
 | Tool Server | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/tool-server.yml](v1/tool-server.yml) |
 | OpenAPI Curator Service | 1.0.2 | Contexter alias Benedikt Eickhoff | [v1/openapi-curator.yml](v1/openapi-curator.yml) |
 | Curator Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/curator-gateway.yml](v1/curator-gateway.yml) |
+| Auth Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/auth-gateway.yml](v1/auth-gateway.yml) |
+| Baseline Awareness Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/baseline-awareness.yml](v1/baseline-awareness.yml) |
+| Bootstrap Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/bootstrap.yml](v1/bootstrap.yml) |
+| DNS API | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/dns.yml](v1/dns.yml) |
+| Function Caller Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/function-caller.yml](v1/function-caller.yml) |
+| Gateway | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/gateway.yml](v1/gateway.yml) |
+| Persistence Service | 1.0.2 | Contexter alias Benedikt Eickhoff | [v1/persist.yml](v1/persist.yml) |
+| Planner Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/planner.yml](v1/planner.yml) |
+| Role Health Check Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/role-health-check-gateway.yml](v1/role-health-check-gateway.yml) |
+| Semantic Browser & Dissector API | 0.2.1 | Contexter alias Benedikt Eickhoff | [v1/semantic-browser.yml](v1/semantic-browser.yml) |
+| Tools Factory Service | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/tools-factory.yml](v1/tools-factory.yml) |
+| Rate Limiter Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/rate-limiter-gateway.yml](v1/rate-limiter-gateway.yml) |
+| Payload Inspection Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/payload-inspection-gateway.yml](v1/payload-inspection-gateway.yml) |
+| Budget Breaker Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/budget-breaker-gateway.yml](v1/budget-breaker-gateway.yml) |
+| Destructive Guardian Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/destructive-guardian-gateway.yml](v1/destructive-guardian-gateway.yml) |
+| Security Sentinel Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/security-sentinel-gateway.yml](v1/security-sentinel-gateway.yml) |
+| Tool Server | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/tool-server.yml](v1/tool-server.yml) |
+| OpenAPI Curator Service | 1.0.2 | Contexter alias Benedikt Eickhoff | [v1/openapi-curator.yml](v1/openapi-curator.yml) |
+| Curator Gateway Plugin | 1.0.0 | Contexter alias Benedikt Eickhoff | [v1/curator-gateway.yml](v1/curator-gateway.yml) |
 
 
 ## Gateway Plugins
@@ -44,11 +63,20 @@ For a repository-wide index of OpenAPI coverage, see [../OPENAPI_COVERAGE.md](..
 | Destructive Guardian Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/destructive-guardian-gateway.yml](v1/destructive-guardian-gateway.yml) |
 | Security Sentinel Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/security-sentinel-gateway.yml](v1/security-sentinel-gateway.yml) |
 | Curator Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/curator-gateway.yml](v1/curator-gateway.yml) |
+| Auth Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/auth-gateway.yml](v1/auth-gateway.yml) |
+| Role Health Check Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/role-health-check-gateway.yml](v1/role-health-check-gateway.yml) |
+| Rate Limiter Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/rate-limiter-gateway.yml](v1/rate-limiter-gateway.yml) |
+| Payload Inspection Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/payload-inspection-gateway.yml](v1/payload-inspection-gateway.yml) |
+| Budget Breaker Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/budget-breaker-gateway.yml](v1/budget-breaker-gateway.yml) |
+| Destructive Guardian Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/destructive-guardian-gateway.yml](v1/destructive-guardian-gateway.yml) |
+| Security Sentinel Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/security-sentinel-gateway.yml](v1/security-sentinel-gateway.yml) |
+| Curator Gateway Plugin | Contexter alias Benedikt Eickhoff | ✅ | [v1/curator-gateway.yml](v1/curator-gateway.yml) |
 
 ## Persistence/FountainStore
 
 | Service | Owner | Status | Spec |
 | --- | --- | --- | --- |
+| Persistence Service | Contexter alias Benedikt Eickhoff | ✅ | [v1/persist.yml](v1/persist.yml) |
 | Persistence Service | Contexter alias Benedikt Eickhoff | ✅ | [v1/persist.yml](v1/persist.yml) |
 
 ## Personas

--- a/openapi/v1/auth-gateway.yml
+++ b/openapi/v1/auth-gateway.yml
@@ -1,4 +1,3 @@
----
 openapi: 3.1.0
 info:
   title: FountainAI Auth Gateway Plugin
@@ -6,9 +5,13 @@ info:
     Lightweight authentication gateway plugin exposing token validation
     and claims retrieval endpoints.
   version: 1.0.0
+  x-fountain.port: 8010
+  x-fountain.binary: fountain-gateway
 x-persona: ../personas/auth.md
 servers:
-  - url: https://gateway.fountain.coach/api/v1
+  - url: http://gateway.local
+    description: Local development
+  - url: http://gateway.fountain.coach
 paths:
   /auth/validate:
     post:
@@ -16,7 +19,7 @@ paths:
       description: Verifies a bearer token and returns its role when valid.
       operationId: authValidate
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -39,7 +42,7 @@ paths:
       description: Returns claims associated with the supplied bearer token.
       operationId: authClaims
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - in: header
@@ -89,4 +92,4 @@ components:
       required:
         - scopes
 
-© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/baseline-awareness.yml
+++ b/openapi/v1/baseline-awareness.yml
@@ -1,4 +1,3 @@
----
 openapi: 3.1.0
 info:
   title: Baseline Awareness Service
@@ -6,15 +5,19 @@ info:
     Manages baselines, drift, patterns, reflection data,
     and semantic analytics.
   version: 1.0.0
+  x-fountain.port: 8001
+  x-fountain.binary: baseline-awareness
 servers:
-  - url: http://awareness.fountain.coach/api/v1
+  - url: http://awareness.local
+    description: Local development
+  - url: http://awareness.fountain.coach
 paths:
   /health:
     get:
       summary: Health
       operationId: health_health_get
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -29,7 +32,7 @@ paths:
       description: Creates a new corpus with the given corpus ID.
       operationId: initializeCorpus
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -52,7 +55,7 @@ paths:
       description: Adds a baseline text to the corpus.
       operationId: addBaseline
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -75,7 +78,7 @@ paths:
       description: Adds a drift document to the corpus.
       operationId: addDrift
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -98,7 +101,7 @@ paths:
       description: Adds narrative patterns to the corpus.
       operationId: addPatterns
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -121,7 +124,7 @@ paths:
       description: Adds a reflection item to the corpus.
       operationId: addReflection
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -144,7 +147,7 @@ paths:
       description: Lists all reflections in the specified corpus.
       operationId: listReflections
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: corpus_id
@@ -168,7 +171,7 @@ paths:
       description: Lists the change history of the specified corpus.
       operationId: listHistory
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: corpus_id
@@ -192,7 +195,7 @@ paths:
       description: Provides a semantic summary of the corpus history.
       operationId: summarizeHistory
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: corpus_id
@@ -219,7 +222,7 @@ paths:
         Retrieve the timeline of all semantic entries for the given corpus.
       operationId: listHistoryAnalytics
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: corpus_id
@@ -245,7 +248,7 @@ paths:
         Construct and return the semantic arc based on the corpus history.
       operationId: readSemanticArc
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: corpus_id
@@ -267,7 +270,7 @@ paths:
       summary: Stream History Analytics
       operationId: streamHistoryAnalytics
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       description: Stream historical analytics of the corpus.
       responses:
@@ -285,7 +288,7 @@ paths:
       description: Endpoint that serves Prometheus metrics.
       operationId: metrics_metrics_get
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -503,4 +506,6 @@ components:
       discriminator:
         propertyName: kind
         mapping:
-          tick: 
+          tick:
+
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/bootstrap.yml
+++ b/openapi/v1/bootstrap.yml
@@ -1,23 +1,26 @@
----
 openapi: 3.1.0
 info:
   title: FountainAI Bootstrap Service
   description: Initialize corpora, seed GPT roles, and add semantic baselines.
   version: 1.0.0
+  x-fountain.port: 8002
+  x-fountain.binary: bootstrap
 servers:
-  - url: http://bootstrap.fountain.coach/api/v1
+  - url: http://bootstrap.local
+    description: Local development
+  - url: http://bootstrap.fountain.coach
 paths:
   /bootstrap/corpus/init:
     post:
       tags:
         - Bootstrap
-      summary: "Bootstrap: Init Corpus + Seed Roles"
+      summary: 'Bootstrap: Init Corpus + Seed Roles'
       description: |
         1) Creates empty corpus via `/corpus-init` on Awareness.
         2) Seeds default GPT roles via `/bootstrap/roles/seed`.
       operationId: bootstrapInitializeCorpus
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -42,12 +45,12 @@ paths:
     post:
       tags:
         - Bootstrap
-      summary: "Bootstrap: Seed GPT Roles"
+      summary: 'Bootstrap: Seed GPT Roles'
       description: >
         Populates an existing corpus with the five default GPT role prompts.
       operationId: bootstrapSeedRoles
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -72,7 +75,7 @@ paths:
     post:
       tags:
         - Bootstrap
-      summary: "Bootstrap: Add Baseline, Stream Analyses & Persist Results"
+      summary: 'Bootstrap: Add Baseline, Stream Analyses & Persist Results'
       description: |
         1) Stores your new baseline snapshot in the Awareness Service.
         2) Immediately streams back two SSE channels:
@@ -87,7 +90,7 @@ paths:
         analytics—happens in one concise call.
       operationId: bootstrapAddBaseline
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -116,7 +119,7 @@ paths:
         Prerequisite: call `/corpus-init` first.
       operationId: seedRoles
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -143,7 +146,7 @@ paths:
       description: Endpoint that serves Prometheus metrics.
       operationId: metrics_metrics_get
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -241,7 +244,8 @@ components:
         patterns:
           type: string
           title: Patterns
-          description: Full prompt text for the narrative patterns analysis role.
+          description: Full prompt text for the narrative patterns analysis 
+            role.
           const: |-
             You are Patterns, a spotter of recurring motifs, themes, or rhetorical structures. Inspect the corpus and list the strongest patterns you find.
         history:
@@ -362,4 +366,6 @@ components:
       discriminator:
         propertyName: kind
         mapping:
-          drift: 
+          drift:
+
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/budget-breaker-gateway.yml
+++ b/openapi/v1/budget-breaker-gateway.yml
@@ -1,14 +1,17 @@
----
 openapi: 3.1.0
 info:
   title: Budget Breaker Gateway Plugin
   description: >
     Enforces request budgets with simple health checks.
   version: 1.0.0
-  
+
+  x-fountain.port: 8010
+  x-fountain.binary: fountain-gateway
 x-persona: ../personas/budget-breaker.md
 servers:
-  - url: http://budget-breaker.fountain.coach/api/v1
+  - url: http://budget-breaker.local
+    description: Local development
+  - url: http://budget-breaker.fountain.coach
 paths:
   /budget/check:
     post:
@@ -18,7 +21,7 @@ paths:
       description: Checks and consumes budget for a client.
       operationId: budgetCheck
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -47,7 +50,7 @@ paths:
       description: Reports plugin health status.
       operationId: budgetHealth
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -128,4 +131,4 @@ components:
           type: string
           title: Error Type
 
-© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/curator-gateway.yml
+++ b/openapi/v1/curator-gateway.yml
@@ -1,22 +1,26 @@
----
 openapi: 3.1.0
 info:
   title: Curator Gateway Plugin
   description: >
     Evidence-based operation gating for FountainAI gateway.
   version: 1.0.0
+  x-fountain.port: 8010
+  x-fountain.binary: fountain-gateway
 servers:
-  - url: http://curator-gateway.fountain.coach/api/v1
+  - url: http://curator-gateway.local
+    description: Local development
+  - url: http://curator-gateway.fountain.coach
 paths:
   /curator/check:
     post:
       tags:
         - Curator
       summary: Check operation evidence
-      description: Checks whether an operation is allowed with curator-provided evidence.
+      description: Checks whether an operation is allowed with curator-provided 
+        evidence.
       operationId: curatorCheck
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -91,4 +95,5 @@ components:
         type:
           type: string
           title: Error Type
-© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/destructive-guardian-gateway.yml
+++ b/openapi/v1/destructive-guardian-gateway.yml
@@ -1,4 +1,3 @@
----
 openapi: 3.1.0
 info:
   title: Destructive Guardian Gateway Plugin
@@ -6,9 +5,13 @@ info:
     Evaluates potentially destructive requests and returns allow/deny decisions.
   version: 1.0.0
 
+  x-fountain.port: 8010
+  x-fountain.binary: fountain-gateway
 x-persona: ../personas/destructive-guardian.md
 servers:
-  - url: http://destructive-guardian.fountain.coach/api/v1
+  - url: http://destructive-guardian.local
+    description: Local development
+  - url: http://destructive-guardian.fountain.coach
 paths:
   /guardian/evaluate:
     post:
@@ -18,7 +21,7 @@ paths:
       description: Evaluates a request and returns an allow or deny decision.
       operationId: guardianEvaluate
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -103,4 +106,4 @@ components:
           type: string
           title: Error Type
 
-© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/dns.yml
+++ b/openapi/v1/dns.yml
@@ -1,19 +1,21 @@
----
 openapi: 3.1.0
 info:
   title: Fountain Internal DNS API
   description: >
     API for managing internal DNS zones and records.
   version: 1.0.0
+  x-fountain.port: 8008
 servers:
-  - url: http://dns.fountain.coach/api/v1
+  - url: http://dns.local
+    description: Local development
+  - url: http://dns.fountain.coach
 paths:
   /zones:
     get:
       summary: List Zones
       operationId: listZones
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -26,7 +28,7 @@ paths:
       summary: Create Zone
       operationId: createZone
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -53,7 +55,7 @@ paths:
       summary: Delete Zone
       operationId: deleteZone
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '204':
@@ -70,7 +72,7 @@ paths:
       summary: List Records
       operationId: listRecords
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -83,7 +85,7 @@ paths:
       summary: Create Record
       operationId: createRecord
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -116,7 +118,7 @@ paths:
       summary: Update Record
       operationId: updateRecord
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -135,7 +137,7 @@ paths:
       summary: Delete Record
       operationId: deleteRecord
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '204':
@@ -214,4 +216,4 @@ components:
           type: string
           description: Description of the error
 
-© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/function-caller.yml
+++ b/openapi/v1/function-caller.yml
@@ -1,4 +1,3 @@
----
 openapi: 3.1.0
 info:
   title: FountainAI Function Caller Service
@@ -8,15 +7,19 @@ info:
     It acts as a dynamic operationId-to-HTTP call mapping factory,
     enabling LLM-driven orchestration.
   version: 1.0.0
+  x-fountain.port: 8004
+  x-fountain.binary: function-caller
 servers:
-  - url: http://functions.fountain.coach/api/v1
+  - url: http://functions.local
+    description: Local development
+  - url: http://functions.fountain.coach
 paths:
   /functions:
     get:
       summary: List Registered Functions
       operationId: list_functions
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       description: >
         Retrieve a paginated list of all registered functions available for
@@ -63,7 +66,7 @@ paths:
       summary: Get Function Details
       operationId: get_function_details
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       description: >
         Retrieve detailed metadata about a registered function by its ID.
@@ -91,7 +94,7 @@ paths:
       summary: Invoke a Registered Function
       operationId: invoke_function
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       description: |
         Invoke the specified function with the given input parameters.
@@ -143,7 +146,7 @@ paths:
       description: Endpoint that serves Prometheus metrics.
       operationId: metrics_metrics_get
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -222,4 +225,4 @@ components:
                 error_code: validation_error
                 message: Invalid input parameters
 
-© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/gateway.yml
+++ b/openapi/v1/gateway.yml
@@ -1,4 +1,3 @@
----
 openapi: 3.1.0
 info:
   title: FountainAI Gateway
@@ -6,8 +5,12 @@ info:
     Swift-based API gateway providing HTTPS termination, routing,
     authentication and metrics for FountainAI services.
   version: 1.0.0
+  x-fountain.port: 8010
+  x-fountain.binary: fountain-gateway
 servers:
-  - url: https://gateway.fountain.coach/api/v1
+  - url: http://gateway.local
+    description: Local development
+  - url: http://gateway.fountain.coach
 paths:
   /health:
     get:
@@ -15,7 +18,7 @@ paths:
       description: Returns 200 if the gateway is running.
       operationId: gatewayHealth
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -30,7 +33,7 @@ paths:
       description: Endpoint that serves runtime metrics encoded as JSON.
       operationId: gatewayMetrics
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -51,7 +54,7 @@ paths:
         protected routes.
       operationId: issueAuthToken
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -79,7 +82,7 @@ paths:
       description: Returns metadata about the active TLS certificate.
       operationId: certificateInfo
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -96,7 +99,7 @@ paths:
       description: Manually invoke the renewal process for the TLS certificate.
       operationId: renewCertificate
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '202':
@@ -113,7 +116,7 @@ paths:
       description: Returns all routing definitions active in the gateway.
       operationId: listRoutes
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -130,7 +133,7 @@ paths:
       summary: Add a new route
       operationId: createRoute
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -158,7 +161,7 @@ paths:
       summary: Update an existing route
       operationId: updateRoute
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: routeId
@@ -192,7 +195,7 @@ paths:
       summary: Delete a route
       operationId: deleteRoute
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: routeId
@@ -295,4 +298,4 @@ components:
           type: string
           description: Certificate issuer
 
-© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/openapi-curator.yml
+++ b/openapi/v1/openapi-curator.yml
@@ -1,8 +1,9 @@
----
 openapi: 3.1.0
 info:
   title: OpenAPI Curator Service
   version: 1.0.2
+  x-fountain.port: 8000
+  x-fountain.binary: openapi-curator-service
 paths:
   /curate:
     post:
@@ -11,7 +12,7 @@ paths:
       summary: Curate one or more OpenAPI documents
       operationId: curate
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -37,7 +38,7 @@ paths:
       summary: Validate specs without curating
       operationId: validate
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -63,7 +64,7 @@ paths:
       summary: Export truth table for specs
       operationId: truth_table
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -89,7 +90,7 @@ paths:
       summary: Get active curation rules
       operationId: get_rules
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -106,7 +107,7 @@ paths:
       summary: Replace curation rules
       operationId: put_rules
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -128,7 +129,7 @@ paths:
       summary: List curated snapshots for a corpus
       operationId: history
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - in: query
@@ -158,7 +159,7 @@ paths:
       description: Endpoint that serves Prometheus metrics.
       operationId: metrics_metrics_get
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -293,5 +294,9 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+servers:
+  - url: http://openapi-curator.local
+    description: Local development
+  - url: http://openapi-curator.fountain.coach
 
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/payload-inspection-gateway.yml
+++ b/openapi/v1/payload-inspection-gateway.yml
@@ -1,13 +1,16 @@
----
 openapi: 3.1.0
 info:
   title: Payload Inspection Gateway Plugin
   description: >
     Inspects payloads for forbidden content and either sanitizes them or reports violations.
   version: 1.0.0
+  x-fountain.port: 8010
+  x-fountain.binary: fountain-gateway
 x-persona: ../personas/payload-inspection.md
 servers:
-  - url: http://payload-inspection.fountain.coach/api/v1
+  - url: http://payload-inspection.local
+    description: Local development
+  - url: http://payload-inspection.fountain.coach
 paths:
   /inspect:
     post:
@@ -17,7 +20,7 @@ paths:
       description: Sanitizes payloads or reports violations.
       operationId: inspectPayload
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -95,4 +98,4 @@ components:
           type: string
           title: Error Type
 
-© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/persist.yml
+++ b/openapi/v1/persist.yml
@@ -1,4 +1,3 @@
----
 openapi: 3.1.0
 info:
   title: FountainStore Persistence Service
@@ -8,16 +7,20 @@ info:
     Collection schemas for pages, segments, entities, tables, and analyses are
     described in [docs/fountainstore-collections.md](../../docs/fountainstore-collections.md).
   version: 1.0.2
+  x-fountain.port: 8005
+  x-fountain.binary: persist
 x-persona: ../personas/persist.md
 servers:
-  - url: http://persist.fountain.coach/api/v1
+  - url: http://persist.local
+    description: Local development
+  - url: http://persist.fountain.coach
 paths:
   /capabilities:
     get:
       summary: Get supported capabilities
       operationId: capabilities
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -36,7 +39,7 @@ paths:
         Useful for clients to discover existing corpora.
       operationId: listCorpora
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: limit
@@ -80,7 +83,7 @@ paths:
         baselines, reflections, and other artifacts. Corpus IDs must be unique.
       operationId: createCorpus
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         description: Corpus creation request payload including unique corpusId.
@@ -107,7 +110,7 @@ paths:
         Useful for examining historical semantic state.
       operationId: listBaselines
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: corpusId
@@ -154,7 +157,7 @@ paths:
         analysis or reflection.
       operationId: addBaseline
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: corpusId
@@ -187,7 +190,7 @@ paths:
       summary: List functions in a corpus, supports pagination
       operationId: listFunctionsInCorpus
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: corpusId
@@ -213,7 +216,8 @@ paths:
             minimum: 0
         - name: q
           in: query
-          description: Optional substring filter across name, description, and httpPath.
+          description: Optional substring filter across name, description, and 
+            httpPath.
           schema:
             type: string
       responses:
@@ -235,7 +239,7 @@ paths:
       summary: Add a function to a corpus
       operationId: addFunction
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: corpusId
@@ -269,7 +273,7 @@ paths:
         semantic reasoning and planning.
       operationId: addReflection
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: corpusId
@@ -303,7 +307,7 @@ paths:
         for browsing semantic insights or planning data over time.
       operationId: listReflections
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: corpusId
@@ -351,7 +355,7 @@ paths:
         the persistence layer for orchestration and invocation.
       operationId: listFunctions
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: limit
@@ -371,7 +375,8 @@ paths:
             minimum: 0
         - name: q
           in: query
-          description: Optional substring filter across name, description, httpPath, functionId, and corpusId.
+          description: Optional substring filter across name, description, 
+            httpPath, functionId, and corpusId.
           schema:
             type: string
       responses:
@@ -398,7 +403,7 @@ paths:
         identifier.
       operationId: getFunctionDetails
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: functionId
@@ -423,7 +428,7 @@ paths:
       description: Endpoint that serves Prometheus metrics.
       operationId: metrics_metrics_get
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -576,5 +581,7 @@ components:
               message:
                 type: string
                 description: Human-readable error message.
+
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
 
 # © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/planner.yml
+++ b/openapi/v1/planner.yml
@@ -1,4 +1,3 @@
----
 openapi: 3.1.0
 info:
   title: FountainAI Planner Service
@@ -6,8 +5,12 @@ info:
     Orchestrates LLM-driven planning workflows; all endpoints are
     grouped by router tags.
   version: 1.0.0
+  x-fountain.port: 8003
+  x-fountain.binary: planner
 servers:
-  - url: http://planner.fountain.coach/api/v1
+  - url: http://planner.local
+    description: Local development
+  - url: http://planner.fountain.coach
 paths:
   /planner/reason:
     post:
@@ -18,7 +21,7 @@ paths:
         Accepts a high-level user objective and returns a step-by-step plan.
       operationId: planner_reason
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -49,7 +52,7 @@ paths:
         returning results.
       operationId: planner_execute
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -79,7 +82,7 @@ paths:
         Returns the names/IDs of all corpora that the planner knows about.
       operationId: planner_list_corpora
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -99,7 +102,7 @@ paths:
       description: Retrieve all stored reflections for a given corpus ID.
       operationId: get_reflection_history
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: corpus_id
@@ -130,7 +133,7 @@ paths:
         insights, etc.).
       operationId: get_semantic_arc
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       parameters:
         - name: corpus_id
@@ -161,7 +164,7 @@ paths:
       description: Send a message to be reflected on and appended to the corpus.
       operationId: post_reflection
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -188,7 +191,7 @@ paths:
       description: Endpoint that serves Prometheus metrics.
       operationId: metrics_metrics_get
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -352,4 +355,4 @@ components:
           type: string
           title: Error Type
 
-© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/rate-limiter-gateway.yml
+++ b/openapi/v1/rate-limiter-gateway.yml
@@ -1,13 +1,16 @@
----
 openapi: 3.1.0
 info:
   title: Rate Limiter Gateway Plugin
   description: >
     Token bucket rate limiter for FountainAI gateway.
   version: 1.0.0
+  x-fountain.port: 8010
+  x-fountain.binary: fountain-gateway
 x-persona: ../personas/rate-limiter.md
 servers:
-  - url: http://rate-limiter.fountain.coach/api/v1
+  - url: http://rate-limiter.local
+    description: Local development
+  - url: http://rate-limiter.fountain.coach
 paths:
   /rate-limit/check:
     post:
@@ -17,7 +20,7 @@ paths:
       description: Checks and consumes a rate limit token.
       operationId: rateLimitCheck
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -45,7 +48,7 @@ paths:
       summary: Retrieve rate limiter statistics
       operationId: rateLimitStats
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -126,4 +129,4 @@ components:
           type: string
           title: Error Type
 
-© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/role-health-check-gateway.yml
+++ b/openapi/v1/role-health-check-gateway.yml
@@ -1,13 +1,16 @@
----
 openapi: 3.1.0
 info:
   title: Role Health Check Gateway Plugin
   description: >
     Verifies seeded roles and promotes validated reflections.
   version: 1.0.0
+  x-fountain.port: 8010
+  x-fountain.binary: fountain-gateway
 x-persona: ../personas/role-health-check.md
 servers:
-  - url: http://role-health-check.fountain.coach/api/v1
+  - url: http://role-health-check.local
+    description: Local development
+  - url: http://role-health-check.fountain.coach
 x-prompts:
   system: |-
     You are the Role Health Check Gateway Plugin. Validate the five default GPT roles: drift, semantic_arc, patterns, history, and view_creator.
@@ -20,7 +23,7 @@ paths:
       description: Enqueues the health-check reflection in the corpus.
       operationId: roleHealthCheckReflect
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -49,7 +52,7 @@ paths:
       description: Promotes the latest health-check reflection to a role.
       operationId: roleHealthCheckPromote
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -137,4 +140,4 @@ components:
           type: string
           title: Error Type
 
-© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/security-sentinel-gateway.yml
+++ b/openapi/v1/security-sentinel-gateway.yml
@@ -1,23 +1,27 @@
----
 openapi: 3.1.0
 info:
   title: Security Sentinel Gateway Plugin
   description: >
     Consults the Security Sentinel role for allow/deny/escalate decisions.
   version: 1.0.0
+  x-fountain.port: 8010
+  x-fountain.binary: fountain-gateway
 x-persona: ../personas/security-sentinel.md
 servers:
-  - url: http://security-sentinel.fountain.coach/api/v1
+  - url: http://security-sentinel.local
+    description: Local development
+  - url: http://security-sentinel.fountain.coach
 paths:
   /sentinel/consult:
     post:
       tags:
         - Sentinel
       summary: Consult Security Sentinel
-      description: Sends a summary of a potentially destructive operation for a decision.
+      description: Sends a summary of a potentially destructive operation for a 
+        decision.
       operationId: sentinelConsult
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -94,4 +98,4 @@ components:
           type: string
           title: Error Type
 
-© 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/semantic-browser.yml
+++ b/openapi/v1/semantic-browser.yml
@@ -3,30 +3,38 @@ info:
   title: Semantic Browser & Dissector API
   version: 0.2.1
   summary: >
-    A Swift-only, JS-capable semantic browser that (1) renders a page, (2) snapshots network+DOM,
-    (3) semantically dissects rendered content into blocks/entities/claims/tables with span-level citations,
-    and (4) optionally persists artifacts into FountainStore under a corpus defined by Bootstrapping and Baseline Awareness.
-    See [docs/fountainstore-collections.md](../../docs/fountainstore-collections.md) for collection schemas.
+    A Swift-only, JS-capable semantic browser that (1) renders a page, (2) snapshots
+    network+DOM,
+    (3) semantically dissects rendered content into blocks/entities/claims/tables
+    with span-level citations,
+    and (4) optionally persists artifacts into FountainStore under a corpus defined
+    by Bootstrapping and Baseline Awareness.
+    See [docs/fountainstore-collections.md](../../docs/fountainstore-collections.md)
+    for collection schemas.
   contact:
     name: FountainAI
     url: https://fountain.coach
+  x-fountain.port: 8007
+  x-fountain.binary: semantic-browser
 servers:
-  - url: https://semantic-browser.local
+  - url: http://semantic-browser.local
     description: Local development
-  - url: https://api.fountain.coach/semantic-browser
-    description: Production
-
+  - url: http://semantic-browser.fountain.coach
 tags:
   - name: Browse
-    description: Navigate with a real browser (CDP/WebKit), wait for readiness, and capture a Snapshot.
+    description: Navigate with a real browser (CDP/WebKit), wait for readiness, 
+      and capture a Snapshot.
   - name: Analyze
-    description: Turn a Snapshot into a normalized Analysis (blocks, entities, claims, tables, summaries).
+    description: Turn a Snapshot into a normalized Analysis (blocks, entities, 
+      claims, tables, summaries).
   - name: Index
-    description: Persist derived artifacts into FountainStore under a corpus defined by Bootstrapping and Baseline Awareness.
+    description: Persist derived artifacts into FountainStore under a corpus 
+      defined by Bootstrapping and Baseline Awareness.
   - name: Query
     description: Query previously indexed pages, segments, entities, and tables.
   - name: Export
-    description: Export artifacts (rendered HTML/text/markdown/tables.csv) for auditing and handoff.
+    description: Export artifacts (rendered HTML/text/markdown/tables.csv) for 
+      auditing and handoff.
   - name: Admin
     description: Health, version, and runtime information.
 
@@ -38,43 +46,48 @@ paths:
     post:
       operationId: browseAndDissect
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       tags: [Browse]
-      summary: Navigate to a URL, snapshot the rendered page, optionally analyze and index in a single call.
+      summary: Navigate to a URL, snapshot the rendered page, optionally analyze
+        and index in a single call.
       description: >
-        Executes JavaScript (via a headless browser), waits for page readiness, captures DOM and network
-        responses, optionally runs semantic dissection and persists artifacts into FountainStore under a corpus
-        as shaped by Bootstrapping and Baseline Awareness. Returns the Snapshot and, if requested, the Analysis and Index summary.
+        Executes JavaScript (via a headless browser), waits for page readiness, captures
+        DOM and network
+        responses, optionally runs semantic dissection and persists artifacts into
+        FountainStore under a corpus
+        as shaped by Bootstrapping and Baseline Awareness. Returns the Snapshot and,
+        if requested, the Analysis and Index summary.
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/BrowseRequest"
+              $ref: '#/components/schemas/BrowseRequest'
             examples:
               basic:
                 value:
-                  url: "https://github.com/explore"
-                  wait: { strategy: "networkIdle", networkIdleMs: 500, maxWaitMs: 10000 }
-                  mode: "standard"
-                  index: { enabled: true }
+                  url: https://github.com/explore
+                  wait: {strategy: networkIdle, networkIdleMs: 500, maxWaitMs: 
+                      10000}
+                  mode: standard
+                  index: {enabled: true}
       responses:
-        "200":
+        '200':
           description: Snapshot (and optionally Analysis + Index result)
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BrowseResponse"
-        "400": { $ref: "#/components/responses/BadRequest" }
-        "429": { $ref: "#/components/responses/TooManyRequests" }
-        "500": { $ref: "#/components/responses/ServerError" }
+                $ref: '#/components/schemas/BrowseResponse'
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '429': {$ref: '#/components/responses/TooManyRequests'}
+        '500': {$ref: '#/components/responses/ServerError'}
 
   /v1/snapshot:
     post:
       operationId: snapshotOnly
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       tags: [Browse]
       summary: Navigate and return only the Snapshot (no semantic analysis).
@@ -82,22 +95,22 @@ paths:
         required: true
         content:
           application/json:
-            schema: { $ref: "#/components/schemas/SnapshotRequest" }
+            schema: {$ref: '#/components/schemas/SnapshotRequest'}
       responses:
-        "200":
+        '200':
           description: Snapshot captured
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/SnapshotResponse" }
-        "400": { $ref: "#/components/responses/BadRequest" }
-        "429": { $ref: "#/components/responses/TooManyRequests" }
-        "500": { $ref: "#/components/responses/ServerError" }
+              schema: {$ref: '#/components/schemas/SnapshotResponse'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '429': {$ref: '#/components/responses/TooManyRequests'}
+        '500': {$ref: '#/components/responses/ServerError'}
 
   /v1/analyze:
     post:
       operationId: analyzeSnapshot
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       tags: [Analyze]
       summary: Run semantic dissection on a Snapshot (inline or by reference).
@@ -105,48 +118,50 @@ paths:
         required: true
         content:
           application/json:
-            schema: { $ref: "#/components/schemas/AnalyzeRequest" }
+            schema: {$ref: '#/components/schemas/AnalyzeRequest'}
             examples:
               byId:
                 value:
-                  snapshotRef: { snapshotId: "snap_01HXYZ..." }
-                  mode: "deep"
+                  snapshotRef: {snapshotId: snap_01HXYZ...}
+                  mode: deep
       responses:
-        "200":
+        '200':
           description: Analysis produced
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/Analysis" }
-        "400": { $ref: "#/components/responses/BadRequest" }
-        "500": { $ref: "#/components/responses/ServerError" }
+              schema: {$ref: '#/components/schemas/Analysis'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '500': {$ref: '#/components/responses/ServerError'}
 
   /v1/index:
     post:
       operationId: indexAnalysis
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       tags: [Index]
-      summary: Persist Analysis-derived artifacts (page/segments/entities/tables/analyses) into FountainStore collections under a corpus.
+      summary: Persist Analysis-derived artifacts 
+        (page/segments/entities/tables/analyses) into FountainStore collections 
+        under a corpus.
       requestBody:
         required: true
         content:
           application/json:
-            schema: { $ref: "#/components/schemas/IndexRequest" }
+            schema: {$ref: '#/components/schemas/IndexRequest'}
       responses:
-        "200":
+        '200':
           description: Index summary
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/IndexResult" }
-        "400": { $ref: "#/components/responses/BadRequest" }
-        "502": { $ref: "#/components/responses/UpstreamError" }
+              schema: {$ref: '#/components/schemas/IndexResult'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '502': {$ref: '#/components/responses/UpstreamError'}
 
   /v1/pages:
     get:
       operationId: queryPages
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       tags: [Query]
       summary: Search previously persisted pages in FountainStore.
@@ -154,47 +169,47 @@ paths:
         - name: q
           in: query
           description: Full-text query string.
-          schema: { type: string }
+          schema: {type: string}
         - name: host
           in: query
           description: Filter by page host (e.g., github.com).
-          schema: { type: string }
+          schema: {type: string}
         - name: lang
           in: query
           description: ISO language code filter.
-          schema: { type: string, pattern: "^[a-z]{2}(-[A-Z]{2})?$" }
+          schema: {type: string, pattern: '^[a-z]{2}(-[A-Z]{2})?$'}
         - name: after
           in: query
           description: Filter pages fetched after this instant (RFC 3339).
-          schema: { type: string, format: date-time }
+          schema: {type: string, format: date-time}
         - name: before
           in: query
           description: Filter pages fetched before this instant (RFC 3339).
-          schema: { type: string, format: date-time }
+          schema: {type: string, format: date-time}
         - name: limit
           in: query
-          schema: { type: integer, minimum: 1, maximum: 200, default: 20 }
+          schema: {type: integer, minimum: 1, maximum: 200, default: 20}
         - name: offset
           in: query
-          schema: { type: integer, minimum: 0, default: 0 }
+          schema: {type: integer, minimum: 0, default: 0}
       responses:
-        "200":
+        '200':
           description: Page hits
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  total: { type: integer }
+                  total: {type: integer}
                   items:
                     type: array
-                    items: { $ref: "#/components/schemas/PageDoc" }
+                    items: {$ref: '#/components/schemas/PageDoc'}
 
   /v1/pages/{id}:
     get:
       operationId: getPage
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       tags: [Query]
       summary: Fetch a single indexed page document by ID.
@@ -203,21 +218,21 @@ paths:
           in: path
           required: true
           description: Page document ID (FountainStore or canonical ID).
-          schema: { type: string }
+          schema: {type: string}
       responses:
-        "200":
+        '200':
           description: Page document
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/PageDoc" }
-        "404":
+              schema: {$ref: '#/components/schemas/PageDoc'}
+        '404':
           description: Not found
 
   /v1/segments:
     get:
       operationId: querySegments
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       tags: [Query]
       summary: Search segments (headings/paragraphs/code/captions/tables).
@@ -225,7 +240,7 @@ paths:
         - name: q
           in: query
           description: Full-text query string.
-          schema: { type: string }
+          schema: {type: string}
         - name: kind
           in: query
           schema:
@@ -233,31 +248,32 @@ paths:
             enum: [heading, paragraph, code, caption, table]
         - name: entity
           in: query
-          schema: { type: string, description: "Filter segments mentioning a canonical entity" }
+          schema: {type: string, description: Filter segments mentioning a 
+              canonical entity}
         - name: limit
           in: query
-          schema: { type: integer, minimum: 1, maximum: 200, default: 20 }
+          schema: {type: integer, minimum: 1, maximum: 200, default: 20}
         - name: offset
           in: query
-          schema: { type: integer, minimum: 0, default: 0 }
+          schema: {type: integer, minimum: 0, default: 0}
       responses:
-        "200":
+        '200':
           description: Segment hits
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  total: { type: integer }
+                  total: {type: integer}
                   items:
                     type: array
-                    items: { $ref: "#/components/schemas/SegmentDoc" }
+                    items: {$ref: '#/components/schemas/SegmentDoc'}
 
   /v1/entities:
     get:
       operationId: queryEntities
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       tags: [Query]
       summary: Search canonicalized entities.
@@ -265,34 +281,34 @@ paths:
         - name: q
           in: query
           description: Full-text query string.
-          schema: { type: string }
+          schema: {type: string}
         - name: type
           in: query
-          schema: { type: string, enum: [PERSON, ORG, LOC, PROD, EVENT, OTHER] }
+          schema: {type: string, enum: [PERSON, ORG, LOC, PROD, EVENT, OTHER]}
         - name: limit
           in: query
-          schema: { type: integer, minimum: 1, maximum: 200, default: 20 }
+          schema: {type: integer, minimum: 1, maximum: 200, default: 20}
         - name: offset
           in: query
-          schema: { type: integer, minimum: 0, default: 0 }
+          schema: {type: integer, minimum: 0, default: 0}
       responses:
-        "200":
+        '200':
           description: Entity hits
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  total: { type: integer }
+                  total: {type: integer}
                   items:
                     type: array
-                    items: { $ref: "#/components/schemas/EntityDoc" }
+                    items: {$ref: '#/components/schemas/EntityDoc'}
 
   /v1/export:
     get:
       operationId: exportArtifacts
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       tags: [Export]
       summary: Export artifacts for a page/analysis.
@@ -300,47 +316,48 @@ paths:
         - name: pageId
           in: query
           required: true
-          schema: { type: string }
+          schema: {type: string}
         - name: format
           in: query
           required: true
           schema:
             type: string
-            enum: [snapshot.html, snapshot.text, analysis.json, summary.md, tables.csv]
+            enum: [snapshot.html, snapshot.text, analysis.json, summary.md, 
+                  tables.csv]
       responses:
-        "200":
+        '200':
           description: Artifact stream
           content:
-            text/html: { schema: { type: string } }
-            text/plain: { schema: { type: string } }
-            application/json: { schema: { type: object } }
-            text/markdown: { schema: { type: string } }
-            text/csv: { schema: { type: string } }
-        "404": { description: Not found }
+            text/html: {schema: {type: string}}
+            text/plain: {schema: {type: string}}
+            application/json: {schema: {type: object}}
+            text/markdown: {schema: {type: string}}
+            text/csv: {schema: {type: string}}
+        '404': {description: Not found}
 
   /v1/health:
     get:
       operationId: health
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       tags: [Admin]
       summary: Liveness and readiness probe.
       responses:
-        "200":
+        '200':
           description: OK
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  status: { type: string, enum: [ok] }
-                  version: { type: string }
+                  status: {type: string, enum: [ok]}
+                  version: {type: string}
                   browserPool:
                     type: object
                     properties:
-                      capacity: { type: integer }
-                      inUse: { type: integer }
+                      capacity: {type: integer}
+                      inUse: {type: integer}
 
 components:
   securitySchemes:
@@ -354,57 +371,57 @@ components:
       name: q
       in: query
       description: Full-text query string.
-      schema: { type: string }
+      schema: {type: string}
     host:
       name: host
       in: query
       description: Filter by page host (e.g., github.com).
-      schema: { type: string }
+      schema: {type: string}
     lang:
       name: lang
       in: query
       description: ISO language code filter.
-      schema: { type: string, pattern: "^[a-z]{2}(-[A-Z]{2})?$" }
+      schema: {type: string, pattern: '^[a-z]{2}(-[A-Z]{2})?$'}
     after:
       name: after
       in: query
       description: Filter pages fetched after this instant (RFC 3339).
-      schema: { type: string, format: date-time }
+      schema: {type: string, format: date-time}
     before:
       name: before
       in: query
       description: Filter pages fetched before this instant (RFC 3339).
-      schema: { type: string, format: date-time }
+      schema: {type: string, format: date-time}
     limit:
       name: limit
       in: query
-      schema: { type: integer, minimum: 1, maximum: 200, default: 20 }
+      schema: {type: integer, minimum: 1, maximum: 200, default: 20}
     offset:
       name: offset
       in: query
-      schema: { type: integer, minimum: 0, default: 0 }
+      schema: {type: integer, minimum: 0, default: 0}
 
   responses:
     BadRequest:
       description: Bad request
       content:
-        application/json: { schema: { $ref: "#/components/schemas/Error" } }
+        application/json: {schema: {$ref: '#/components/schemas/Error'}}
     TooManyRequests:
       description: Client or host concurrency/rate limit exceeded
       headers:
         Retry-After:
           description: Seconds until a new attempt is allowed.
-          schema: { type: integer }
+          schema: {type: integer}
       content:
-        application/json: { schema: { $ref: "#/components/schemas/Error" } }
+        application/json: {schema: {$ref: '#/components/schemas/Error'}}
     UpstreamError:
       description: Upstream service error (e.g., FountainStore unavailable)
       content:
-        application/json: { schema: { $ref: "#/components/schemas/Error" } }
+        application/json: {schema: {$ref: '#/components/schemas/Error'}}
     ServerError:
       description: Unexpected server error
       content:
-        application/json: { schema: { $ref: "#/components/schemas/Error" } }
+        application/json: {schema: {$ref: '#/components/schemas/Error'}}
 
   schemas:
     # -------- Requests / Orchestration --------
@@ -412,20 +429,20 @@ components:
       type: object
       required: [url, wait, mode]
       properties:
-        url: { type: string, format: uri }
+        url: {type: string, format: uri}
         wait:
-          $ref: "#/components/schemas/WaitPolicy"
+          $ref: '#/components/schemas/WaitPolicy'
         mode:
-          $ref: "#/components/schemas/DissectionMode"
+          $ref: '#/components/schemas/DissectionMode'
         index:
-          $ref: "#/components/schemas/IndexOptions"
+          $ref: '#/components/schemas/IndexOptions'
         storeArtifacts:
           type: boolean
           description: Persist snapshot & analysis artifacts for later export.
           default: true
         labels:
           type: array
-          items: { type: string }
+          items: {type: string}
           description: Optional labels to tag the page in FountainStore facets.
 
     BrowseResponse:
@@ -433,18 +450,18 @@ components:
       required: [snapshot]
       properties:
         snapshot:
-          $ref: "#/components/schemas/Snapshot"
+          $ref: '#/components/schemas/Snapshot'
         analysis:
-          $ref: "#/components/schemas/Analysis"
+          $ref: '#/components/schemas/Analysis'
         index:
-          $ref: "#/components/schemas/IndexResult"
+          $ref: '#/components/schemas/IndexResult'
 
     SnapshotRequest:
       type: object
       required: [url, wait]
       properties:
-        url: { type: string, format: uri }
-        wait: { $ref: "#/components/schemas/WaitPolicy" }
+        url: {type: string, format: uri}
+        wait: {$ref: '#/components/schemas/WaitPolicy'}
         storeArtifacts:
           type: boolean
           default: true
@@ -453,30 +470,31 @@ components:
       type: object
       required: [snapshot]
       properties:
-        snapshot: { $ref: "#/components/schemas/Snapshot" }
+        snapshot: {$ref: '#/components/schemas/Snapshot'}
 
     AnalyzeRequest:
       type: object
       required: [mode]
       properties:
         snapshot:
-          $ref: "#/components/schemas/Snapshot"
+          $ref: '#/components/schemas/Snapshot'
         snapshotRef:
           type: object
           properties:
-            snapshotId: { type: string }
-          description: Use a stored snapshot by ID (mutually exclusive with inline snapshot).
+            snapshotId: {type: string}
+          description: Use a stored snapshot by ID (mutually exclusive with 
+            inline snapshot).
         mode:
-          $ref: "#/components/schemas/DissectionMode"
+          $ref: '#/components/schemas/DissectionMode'
 
     IndexRequest:
       type: object
       required: [analysis]
       properties:
         analysis:
-          $ref: "#/components/schemas/Analysis"
+          $ref: '#/components/schemas/Analysis'
         options:
-          $ref: "#/components/schemas/IndexOptions"
+          $ref: '#/components/schemas/IndexOptions'
 
     IndexOptions:
       type: object
@@ -500,14 +518,15 @@ components:
           type: object
           description: Minimal FountainStore connection details.
           properties:
-            url: { type: string, format: uri }
-            apiKey: { type: string }
-            timeoutMs: { type: integer, default: 3000 }
+            url: {type: string, format: uri}
+            apiKey: {type: string}
+            timeoutMs: {type: integer, default: 3000}
 
     DissectionMode:
       type: string
       enum: [quick, standard, deep]
-      description: quick=outline+summary, standard=+entities/tables, deep=+claims/relations.
+      description: quick=outline+summary, standard=+entities/tables, 
+        deep=+claims/relations.
 
     WaitPolicy:
       type: object
@@ -533,30 +552,30 @@ components:
       type: object
       required: [snapshotId, page, rendered]
       properties:
-        snapshotId: { type: string }
+        snapshotId: {type: string}
         page:
           type: object
           required: [uri, fetchedAt, status, contentType]
           properties:
-            uri: { type: string, format: uri }
-            finalUrl: { type: string, format: uri }
-            fetchedAt: { type: string, format: date-time }
-            status: { type: integer }
-            contentType: { type: string }
+            uri: {type: string, format: uri}
+            finalUrl: {type: string, format: uri}
+            fetchedAt: {type: string, format: date-time}
+            status: {type: integer}
+            contentType: {type: string}
             navigation:
               type: object
               properties:
-                ttfbMs: { type: integer }
-                loadMs: { type: integer }
+                ttfbMs: {type: integer}
+                loadMs: {type: integer}
         rendered:
           type: object
           required: [html, text]
           properties:
-            html: { type: string }
-            text: { type: string }
+            html: {type: string}
+            text: {type: string}
             meta:
               type: object
-              additionalProperties: { type: string }
+              additionalProperties: {type: string}
         network:
           type: object
           properties:
@@ -565,13 +584,15 @@ components:
               items:
                 type: object
                 properties:
-                  url: { type: string, format: uri }
-                  type: { type: string, enum: [Document, Stylesheet, Image, Media, Font, Script, XHR, Fetch, Other] }
-                  status: { type: integer }
-                  body: { type: string, description: "Captured body (sniffed; may be truncated for large content)" }
+                  url: {type: string, format: uri}
+                  type: {type: string, enum: [Document, Stylesheet, Image, Media,
+                      Font, Script, XHR, Fetch, Other]}
+                  status: {type: integer}
+                  body: {type: string, description: Captured body (sniffed; may 
+                      be truncated for large content)}
         diagnostics:
           type: array
-          items: { type: string }
+          items: {type: string}
 
     Analysis:
       type: object
@@ -581,22 +602,22 @@ components:
           type: object
           required: [id, source, contentType, language]
           properties:
-            id: { type: string, description: "sha256 of raw bytes or url+etag" }
+            id: {type: string, description: sha256 of raw bytes or url+etag}
             source:
               type: object
               properties:
-                uri: { type: string, format: uri }
-                fetchedAt: { type: string, format: date-time }
-            contentType: { type: string }
-            language: { type: string }
-            bytes: { type: integer }
+                uri: {type: string, format: uri}
+                fetchedAt: {type: string, format: date-time}
+            contentType: {type: string}
+            language: {type: string}
+            bytes: {type: integer}
             diagnostics:
               type: array
-              items: { type: string }
+              items: {type: string}
         blocks:
           type: array
           items:
-            $ref: "#/components/schemas/Block"
+            $ref: '#/components/schemas/Block'
         semantics:
           type: object
           properties:
@@ -605,41 +626,42 @@ components:
               items:
                 type: object
                 properties:
-                  block: { type: string }
-                  level: { type: integer, minimum: 1, maximum: 6 }
+                  block: {type: string}
+                  level: {type: integer, minimum: 1, maximum: 6}
             entities:
               type: array
-              items: { $ref: "#/components/schemas/Entity" }
+              items: {$ref: '#/components/schemas/Entity'}
             claims:
               type: array
-              items: { $ref: "#/components/schemas/Claim" }
+              items: {$ref: '#/components/schemas/Claim'}
             relations:
               type: array
               items:
                 type: object
                 properties:
-                  type: { type: string, enum: [SUPPORTS, CONTRADICTS, CITES, REFERS_TO] }
-                  from: { type: string }
-                  to: { type: string }
+                  type: {type: string, enum: [SUPPORTS, CONTRADICTS, CITES, 
+                          REFERS_TO]}
+                  from: {type: string}
+                  to: {type: string}
         summaries:
           type: object
           properties:
-            abstract: { type: string }
+            abstract: {type: string}
             keyPoints:
               type: array
-              items: { type: string }
-            tl;dr: { type: string }
+              items: {type: string}
+            tl;dr: {type: string}
         provenance:
           type: object
           properties:
-            pipeline: { type: string }
-            model: { type: string }
+            pipeline: {type: string}
+            model: {type: string}
 
     Block:
       type: object
       required: [id, kind, text]
       properties:
-        id: { type: string }
+        id: {type: string}
         kind:
           type: string
           enum: [heading, paragraph, code, caption, table]
@@ -650,43 +672,43 @@ components:
           type: string
         span:
           type: array
-          items: { type: integer }
+          items: {type: integer}
           minItems: 2
           maxItems: 2
           description: Character offsets [start,end) into rendered.text
         table:
-          $ref: "#/components/schemas/Table"
+          $ref: '#/components/schemas/Table'
 
     Table:
       type: object
       required: [rows]
       properties:
-        caption: { type: string }
+        caption: {type: string}
         columns:
           type: array
-          items: { type: string }
+          items: {type: string}
         rows:
           type: array
           items:
             type: array
-            items: { type: string }
+            items: {type: string}
 
     Entity:
       type: object
       required: [id, name, type, mentions]
       properties:
-        id: { type: string }
-        name: { type: string }
-        type: { type: string, enum: [PERSON, ORG, LOC, PROD, EVENT, OTHER] }
+        id: {type: string}
+        name: {type: string}
+        type: {type: string, enum: [PERSON, ORG, LOC, PROD, EVENT, OTHER]}
         mentions:
           type: array
           items:
             type: object
             properties:
-              block: { type: string }
+              block: {type: string}
               span:
                 type: array
-                items: { type: integer }
+                items: {type: integer}
                 minItems: 2
                 maxItems: 2
 
@@ -694,81 +716,85 @@ components:
       type: object
       required: [id, text, evidence]
       properties:
-        id: { type: string }
-        text: { type: string }
-        stance: { type: string, enum: [AUTHOR_ASSERTED, REPORTED, UNCERTAIN], default: AUTHOR_ASSERTED }
-        hedge: { type: string, enum: [LOW, MEDIUM, HIGH], default: MEDIUM }
+        id: {type: string}
+        text: {type: string}
+        stance: {type: string, enum: [AUTHOR_ASSERTED, REPORTED, UNCERTAIN], 
+            default: AUTHOR_ASSERTED}
+        hedge: {type: string, enum: [LOW, MEDIUM, HIGH], default: MEDIUM}
         evidence:
           type: array
           items:
             type: object
             properties:
-              block: { type: string }
+              block: {type: string}
               span:
                 type: array
-                items: { type: integer }
+                items: {type: integer}
                 minItems: 2
                 maxItems: 2
               tableCell:
                 type: array
-                items: { type: integer }
+                items: {type: integer}
                 minItems: 2
                 maxItems: 2
-                description: Optional [rowIndex, colIndex] when citing a table cell
+                description: Optional [rowIndex, colIndex] when citing a table 
+                  cell
 
     # -------- Index (FountainStore docs) --------
     PageDoc:
       type: object
       properties:
-        id: { type: string }
-        url: { type: string, format: uri }
-        host: { type: string }
-        status: { type: integer }
-        contentType: { type: string }
-        lang: { type: string }
-        title: { type: string }
-        textSize: { type: integer }
-        fetchedAt: { type: integer, description: "epoch ms" }
+        id: {type: string}
+        url: {type: string, format: uri}
+        host: {type: string}
+        status: {type: integer}
+        contentType: {type: string}
+        lang: {type: string}
+        title: {type: string}
+        textSize: {type: integer}
+        fetchedAt: {type: integer, description: epoch ms}
         labels:
           type: array
-          items: { type: string }
+          items: {type: string}
 
     SegmentDoc:
       type: object
       properties:
-        id: { type: string }
-        pageId: { type: string }
-        kind: { type: string, enum: [heading, paragraph, code, caption, table] }
-        text: { type: string }
-        pathHint: { type: string }
-        offsetStart: { type: integer }
-        offsetEnd: { type: integer }
+        id: {type: string}
+        pageId: {type: string}
+        kind: {type: string, enum: [heading, paragraph, code, caption, table]}
+        text: {type: string}
+        pathHint: {type: string}
+        offsetStart: {type: integer}
+        offsetEnd: {type: integer}
         entities:
           type: array
-          items: { type: string }
+          items: {type: string}
 
     EntityDoc:
       type: object
       properties:
-        id: { type: string }
-        name: { type: string }
-        type: { type: string }
-        pageCount: { type: integer }
-        mentions: { type: integer }
+        id: {type: string}
+        name: {type: string}
+        type: {type: string}
+        pageCount: {type: integer}
+        mentions: {type: integer}
 
     IndexResult:
       type: object
       properties:
-        pagesUpserted: { type: integer }
-        segmentsUpserted: { type: integer }
-        entitiesUpserted: { type: integer }
-        tablesUpserted: { type: integer }
+        pagesUpserted: {type: integer}
+        segmentsUpserted: {type: integer}
+        entitiesUpserted: {type: integer}
+        tablesUpserted: {type: integer}
 
     # -------- Errors --------
     Error:
       type: object
       properties:
-        code: { type: string }
-        message: { type: string }
-        details: { type: object }
+        code: {type: string}
+        message: {type: string}
+        details: {type: object}
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+
 # © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/tool-server.yml
+++ b/openapi/v1/tool-server.yml
@@ -2,12 +2,14 @@ openapi: 3.1.0
 info:
   title: Tool Server
   version: 1.0.0
+  x-fountain.port: 8012
+  x-fountain.binary: tool-server
 paths:
   /imagemagick:
     post:
       operationId: runImageMagick
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -27,7 +29,7 @@ paths:
     post:
       operationId: runFFmpeg
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -36,12 +38,12 @@ paths:
             schema:
               $ref: '#/components/schemas/ToolRequest'
       responses:
-        '200': { description: output }
+        '200': {description: output}
   /exiftool:
     post:
       operationId: runExifTool
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -50,12 +52,12 @@ paths:
             schema:
               $ref: '#/components/schemas/ToolRequest'
       responses:
-        '200': { description: output }
+        '200': {description: output}
   /pandoc:
     post:
       operationId: runPandoc
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -64,12 +66,12 @@ paths:
             schema:
               $ref: '#/components/schemas/ToolRequest'
       responses:
-        '200': { description: output }
+        '200': {description: output}
   /libplist:
     post:
       operationId: runLibPlist
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       requestBody:
         required: true
@@ -78,12 +80,12 @@ paths:
             schema:
               $ref: '#/components/schemas/ToolRequest'
       responses:
-        '200': { description: output }
+        '200': {description: output}
   /pdf/scan:
     post:
       operationId: pdfScan
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       summary: Scan one or more PDFs into a semantic index
       requestBody:
@@ -103,7 +105,7 @@ paths:
     post:
       operationId: pdfIndexValidate
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       summary: Validate an index structure
       requestBody:
@@ -123,7 +125,7 @@ paths:
     post:
       operationId: pdfQuery
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       summary: Query an index by keyword
       requestBody:
@@ -143,7 +145,7 @@ paths:
     post:
       operationId: pdfExportMatrix
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       summary: Export a Midi2Swift-friendly matrix skeleton from an index
       requestBody:
@@ -233,7 +235,8 @@ components:
           type: string
         pageRange:
           type: string
-          description: 'Comma-separated list of pages or ranges to search (e.g., 1-3,5)'
+          description: Comma-separated list of pages or ranges to search (e.g., 
+            1-3,5)
     QueryResponse:
       type: object
       properties:
@@ -342,5 +345,11 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/EnumCase'
+
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
+servers:
+  - url: http://tool-server.local
+    description: Local development
+  - url: http://tool-server.fountain.coach
 
 # © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/openapi/v1/tools-factory.yml
+++ b/openapi/v1/tools-factory.yml
@@ -1,4 +1,3 @@
----
 openapi: 3.1.0
 info:
   title: FountainAI Tools Factory Service
@@ -7,15 +6,19 @@ info:
     them in the shared FountainStore corpus used by the Function Caller
     Service.
   version: 1.0.0
+  x-fountain.port: 8011
+  x-fountain.binary: tools-factory
 servers:
-  - url: http://tools-factory.fountain.coach/api/v1
+  - url: http://tools-factory.local
+    description: Local development
+  - url: http://tools-factory.fountain.coach
 paths:
   /tools:
     get:
       summary: List Registered Tools
       operationId: list_tools
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       description: Retrieve a paginated list of registered tools.
       parameters:
@@ -49,7 +52,7 @@ paths:
       summary: Register Tools from OpenAPI
       operationId: register_openapi
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       description: |
         Store a collection of tool definitions provided via an OpenAPI
@@ -82,7 +85,7 @@ paths:
       description: Endpoint that serves Prometheus metrics.
       operationId: metrics_metrics_get
       x-fountain.visibility: public
-      x-fountain.reason: ""
+      x-fountain.reason: ''
       x-fountain.allow-as-tool: true
       responses:
         '200':
@@ -166,5 +169,7 @@ components:
               value:
                 error_code: validation_error
                 message: Invalid input parameters
+
+# © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.
 
 # © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- document local development and production servers for all v1 OpenAPI specs
- record service ports and binaries via `x-fountain` metadata
- extend `openapi/README.md` with appended entries for updated specs

## Testing
- `python scripts/validate_openapi.py`
- `curl -s -X POST https://openapi-curator.fountain.coach/curate -H 'Content-Type: application/json' -d '{"corpusId":"openapi-v1","specs":["file://openapi/v1/auth-gateway.yml","file://openapi/v1/baseline-awareness.yml","file://openapi/v1/bootstrap.yml","file://openapi/v1/budget-breaker-gateway.yml","file://openapi/v1/curator-gateway.yml","file://openapi/v1/destructive-guardian-gateway.yml","file://openapi/v1/dns.yml","file://openapi/v1/function-caller.yml","file://openapi/v1/gateway.yml","file://openapi/v1/openapi-curator.yml","file://openapi/v1/payload-inspection-gateway.yml","file://openapi/v1/persist.yml","file://openapi/v1/planner.yml","file://openapi/v1/rate-limiter-gateway.yml","file://openapi/v1/role-health-check-gateway.yml","file://openapi/v1/security-sentinel-gateway.yml","file://openapi/v1/semantic-browser.yml","file://openapi/v1/tool-server.yml","file://openapi/v1/tools-factory.yml"]}'` *(fails: DNS resolution failure)*

------
https://chatgpt.com/codex/tasks/task_b_68bb2a419ecc83339e54b42777cac9e8