### PR TITLE
chore: add service config verifier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,12 @@ jobs:
         run: ./install-deps.sh
       - name: Check FountainCodex imports
         run: Scripts/check_no_codex.sh
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet pyyaml
+      - name: Validate OpenAPI specs
+        run: python3 scripts/validate_openapi.py
+      - name: Verify service config
+        run: swift scripts/verify-service-config.swift
       - name: Build
         continue-on-error: true
         run: |

--- a/scripts/verify-service-config.swift
+++ b/scripts/verify-service-config.swift
@@ -1,0 +1,42 @@
+#!/usr/bin/env swift
+import Foundation
+
+let root = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+let fm = FileManager.default
+
+let enumerator = fm.enumerator(at: root, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])!
+
+var offenders: [String] = []
+
+let forbiddenFileName = "services.json"
+let jsonPattern = try! NSRegularExpression(pattern: #"(?s)\"name\"\s*:\s*\"[^\"]+\".*\"port\"\s*:\s*\d{2,5}"#)
+let swiftPattern = try! NSRegularExpression(pattern: #"(?s)name:\s*\"[^\"]+\".*port:\s*\d{2,5}"#)
+
+while let url = enumerator.nextObject() as? URL {
+    let path = url.path
+    if path.contains("/.git/") { continue }
+    if path.contains("/Tests/") { continue }
+    if url.lastPathComponent == forbiddenFileName {
+        offenders.append(path)
+        continue
+    }
+    if let data = try? Data(contentsOf: url), let text = String(data: data, encoding: .utf8) {
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        if jsonPattern.firstMatch(in: text, options: [], range: range) != nil ||
+           swiftPattern.firstMatch(in: text, options: [], range: range) != nil {
+            offenders.append(path)
+        }
+    }
+}
+
+if !offenders.isEmpty {
+    fputs("Disallowed service configuration found:\n", stderr)
+    for o in offenders {
+        fputs("- \(o)\n", stderr)
+    }
+    exit(1)
+}
+
+print("Service configuration verified: no forbidden files found.")
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.


### PR DESCRIPTION
## Summary
- add verify-service-config Swift script to detect legacy service.json or port maps
- run OpenAPI and service config checks in CI before build

## Testing
- `python3 scripts/validate_openapi.py`
- `swift scripts/verify-service-config.swift` *(fails: Disallowed service configuration found)*
- `swift test` *(fails: 4 tests)*

------
https://chatgpt.com/codex/tasks/task_b_68bb2a9d84a483339735e7e65f9823f8