### PR TITLE
Add Teatro dependency for GUI development

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -811,6 +811,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.3.0"),
         .package(url: "https://github.com/Fountain-Coach/Fountain-Store.git", from: "0.1.0"),
         .package(url: "https://github.com/Fountain-Coach/semantic-browser.git", exact: "0.0.2"),
+        .package(url: "https://github.com/Fountain-Coach/Teatro.git", branch: "main"),
         .package(path: "libs/OpenAPICurator"),
     ],
     targets: targets

--- a/Tests/GatewayPluginsTests/AuthGatewayPluginTests.swift
+++ b/Tests/GatewayPluginsTests/AuthGatewayPluginTests.swift
@@ -50,13 +50,18 @@ final class AuthGatewayPluginTests: XCTestCase {
     }
 
     func testClaimsUsesLLM() async throws {
-        _ = URLProtocol.registerClass(MockURLProtocol.self)
-        defer { URLProtocol.unregisterClass(MockURLProtocol.self); MockURLProtocol.lastRequest = nil }
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
+
         let token = "Bearer stub-token"
         MockURLProtocol.error = nil
         MockURLProtocol.responseData = Data("{\"ok\":true}".utf8)
+        MockURLProtocol.lastRequest = nil
 
-        let plugin = AuthGatewayPlugin()
+        let client = LLMPluginClient(personaPath: "openapi/personas/auth.md", session: session)
+        let handlers = Handlers(client: client)
+        let plugin = AuthGatewayPlugin(router: Router(handlers: handlers))
         let request = HTTPRequest(method: "POST", path: "/auth/claims", headers: ["Authorization": token])
         let response = try await plugin.router.route(request)
         XCTAssertEqual(response?.status, 200)

--- a/Tests/TokenValidationTests/TokenValidationTests.swift
+++ b/Tests/TokenValidationTests/TokenValidationTests.swift
@@ -79,10 +79,13 @@ final class TokenValidationTests: XCTestCase {
     }
 
     func testJWKSKeyProvider() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
         let url = URL(string: "https://example.com/jwks")!
         let jwksJSON = "{\"keys\":[{\"kty\":\"oct\",\"k\":\"" + Data("jwksSecret".utf8).base64URLEncodedString() + "\"}]}"
         MockURLProtocol.handlers[url] = { _ in (200, Data(jwksJSON.utf8)) }
-        guard let provider = JWKSKeyProvider(jwksURL: url.absoluteString) else { return XCTFail("provider") }
+        guard let provider = JWKSKeyProvider(jwksURL: url.absoluteString, session: session) else { return XCTFail("provider") }
         await provider.refresh()
         let keyData = provider.symmetricKey().withUnsafeBytes { Data($0) }
         XCTAssertEqual(keyData, Data("jwksSecret".utf8))
@@ -107,6 +110,9 @@ final class TokenValidationTests: XCTestCase {
     }
 
     func testOAuth2Validator() async throws {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [MockURLProtocol.self]
+        let session = URLSession(configuration: config)
         let url = URL(string: "https://example.com/introspect")!
         // success
         MockURLProtocol.handlers[url] = { req in
@@ -117,13 +123,13 @@ final class TokenValidationTests: XCTestCase {
             let json = "{\"active\":true,\"scope\":\"s1 s2\",\"role\":\"r1\"}"
             return (200, Data(json.utf8))
         }
-        var validator = OAuth2Validator(introspectionURL: url, clientId: "id", clientSecret: "secret")
+        var validator = OAuth2Validator(introspectionURL: url, clientId: "id", clientSecret: "secret", session: session)
         var claims = await validator.validate(token: "good")
         XCTAssertEqual(claims?.role, "r1")
         XCTAssertEqual(claims?.scopes, ["s1", "s2"])
         // inactive
         MockURLProtocol.handlers[url] = { _ in (200, Data("{\"active\":false}".utf8)) }
-        validator = OAuth2Validator(introspectionURL: url)
+        validator = OAuth2Validator(introspectionURL: url, session: session)
         claims = await validator.validate(token: "bad")
         XCTAssertNil(claims)
         // invalid JSON

--- a/libs/GatewayPlugins/AuthGatewayPlugin/AuthGatewayPlugin/Handlers.swift
+++ b/libs/GatewayPlugins/AuthGatewayPlugin/AuthGatewayPlugin/Handlers.swift
@@ -6,9 +6,11 @@ import FountainRuntime
 
 /// Collection of handlers for auth gateway endpoints backed by an LLM.
 public actor Handlers {
-    private let client = LLMPluginClient(personaPath: "openapi/personas/auth.md")
+    private let client: LLMPluginClient
 
-    public init() {}
+    public init(client: LLMPluginClient = LLMPluginClient(personaPath: "openapi/personas/auth.md")) {
+        self.client = client
+    }
 
     /// Delegates validation to the LLM using the Auth persona.
     public func authValidate(_ request: HTTPRequest, body: ValidateRequest?) async throws -> HTTPResponse {
@@ -26,23 +28,26 @@ public actor Handlers {
 }
 
 /// Minimal client that forwards prompts and persona to the LLM Gateway.
-struct LLMPluginClient {
-    let persona: String
-    let url: URL
+public struct LLMPluginClient: Sendable {
+    public let persona: String
+    public let url: URL
+    public let session: URLSession
 
-    init(personaPath: String,
-         url: URL = URL(string: ProcessInfo.processInfo.environment["LLM_GATEWAY_URL"] ?? "http://localhost:8080/chat")!) {
+    public init(personaPath: String,
+                url: URL = URL(string: ProcessInfo.processInfo.environment["LLM_GATEWAY_URL"] ?? "http://localhost:8080/chat")!,
+                session: URLSession = .shared) {
         self.persona = (try? String(contentsOfFile: personaPath, encoding: .utf8)) ?? ""
         self.url = url
+        self.session = session
     }
 
-    func call(prompt: String) async throws -> String {
+    public func call(prompt: String) async throws -> String {
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
         req.addValue("application/json", forHTTPHeaderField: "Content-Type")
         let payload = ["persona": persona, "prompt": prompt]
         req.httpBody = try JSONSerialization.data(withJSONObject: payload)
-        let (data, _) = try await URLSession.shared.data(for: req)
+        let (data, _) = try await session.data(for: req)
         return String(data: data, encoding: .utf8) ?? "{}"
     }
 }

--- a/services/GatewayServer/GatewayApp/TokenValidation.swift
+++ b/services/GatewayServer/GatewayApp/TokenValidation.swift
@@ -43,9 +43,11 @@ public struct EnvKeyProvider: KeyProvider {
 public final class JWKSKeyProvider: @unchecked Sendable, KeyProvider {
     private var key: SymmetricKey
     private let url: URL
-    public init?(jwksURL: String) {
+    private let session: URLSession
+    public init?(jwksURL: String, session: URLSession = .shared) {
         guard let u = URL(string: jwksURL) else { return nil }
         self.url = u
+        self.session = session
         self.key = SymmetricKey(data: Data())
         // Best-effort fetch at init; failures will keep an empty key which will fail validation.
         Task.detached { [weak self] in await self?.refresh() }
@@ -55,7 +57,7 @@ public final class JWKSKeyProvider: @unchecked Sendable, KeyProvider {
         var req = URLRequest(url: url)
         req.httpMethod = "GET"
         do {
-            let (data, resp) = try await URLSession.shared.data(for: req)
+            let (data, resp) = try await session.data(for: req)
             guard (resp as? HTTPURLResponse)?.statusCode == 200 else { return }
             if let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any], let keys = obj["keys"] as? [[String: Any]] {
                 // Pick first symmetric (oct) key
@@ -147,19 +149,22 @@ public struct OAuth2Validator: TokenValidator {
     private let introspectionURL: URL
     private let clientId: String?
     private let clientSecret: String?
+    private let session: URLSession
     public init(introspectionURL: URL,
                 clientId: String? = nil,
-                clientSecret: String? = nil) {
+                clientSecret: String? = nil,
+                session: URLSession = .shared) {
         self.introspectionURL = introspectionURL
         self.clientId = clientId
         self.clientSecret = clientSecret
+        self.session = session
     }
-    public init?(environment: [String: String] = ProcessInfo.processInfo.environment) {
+    public init?(environment: [String: String] = ProcessInfo.processInfo.environment, session: URLSession = .shared) {
         guard let urlStr = environment["GATEWAY_OAUTH2_INTROSPECTION_URL"],
               let url = URL(string: urlStr) else { return nil }
         let id = environment["GATEWAY_OAUTH2_CLIENT_ID"]
         let secret = environment["GATEWAY_OAUTH2_CLIENT_SECRET"]
-        self.init(introspectionURL: url, clientId: id, clientSecret: secret)
+        self.init(introspectionURL: url, clientId: id, clientSecret: secret, session: session)
     }
     public func validate(token: String) async -> TokenClaims? {
         var request = URLRequest(url: introspectionURL)
@@ -172,7 +177,7 @@ public struct OAuth2Validator: TokenValidator {
             request.setValue("Basic \(auth)", forHTTPHeaderField: "Authorization")
         }
         do {
-            let (data, resp) = try await URLSession.shared.data(for: request)
+            let (data, resp) = try await session.data(for: request)
             guard (resp as? HTTPURLResponse)?.statusCode == 200 else { return nil }
             struct IntrospectionResponse: Decodable {
                 let active: Bool


### PR DESCRIPTION
## Summary
- add Teatro package dependency for GUI work
- make AuthGateway and token-validation network clients injectable for reliable tests

## Testing
- `swift package resolve`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68bbab76a2c083339fe3964bca974802