### PR TITLE
Add HelloFountainAITeatro macOS example

### DIFF
--- a/Examples/HelloFountainAITeatro/Package.swift
+++ b/Examples/HelloFountainAITeatro/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "HelloFountainAITeatro",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .executable(name: "HelloFountainAITeatro", targets: ["HelloFountainAITeatro"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Fountain-Coach/Teatro.git", branch: "main"),
+        .package(path: "../..")
+    ],
+    targets: [
+        .executableTarget(
+            name: "HelloFountainAITeatro",
+            dependencies: [
+                .product(name: "Teatro", package: "teatro"),
+                .product(name: "TeatroRenderAPI", package: "teatro"),
+                .product(name: "FountainRuntime", package: "the-fountainai")
+            ],
+            path: "macOS"
+        )
+    ]
+)
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Examples/HelloFountainAITeatro/README.md
+++ b/Examples/HelloFountainAITeatro/README.md
@@ -1,0 +1,13 @@
+# HelloFountainAITeatro
+
+Minimal macOS SwiftUI example for rendering a message with **Teatro** after
+calling the FountainAI Semantic Browser health endpoint.
+
+## Build & Run (macOS)
+
+```bash
+swift run HelloFountainAITeatro
+```
+
+The app requests `GET http://localhost:8007/v1/health` and renders the response
+status inside a Teatro scene.

--- a/Examples/HelloFountainAITeatro/macOS/HelloFountainAITeatroApp.swift
+++ b/Examples/HelloFountainAITeatro/macOS/HelloFountainAITeatroApp.swift
@@ -1,0 +1,66 @@
+#if canImport(SwiftUI) && os(macOS)
+import SwiftUI
+import Foundation
+import Teatro
+import TeatroRenderAPI
+
+struct HealthResponse: Decodable {
+    let status: String
+    let version: String
+}
+
+@available(macOS 13.0, *)
+struct ContentView: View {
+    @State private var svg: Data? = nil
+    @State private var loading = true
+
+    var body: some View {
+        Group {
+            if let svg {
+                TeatroPlayerView(svg: svg)
+            } else if loading {
+                ProgressView()
+            } else {
+                Text("Failed to load")
+            }
+        }
+        .task {
+            await load()
+        }
+        .frame(minWidth: 400, minHeight: 300)
+    }
+
+    private func load() async {
+        do {
+            let url = URL(string: "http://localhost:8007/v1/health")!
+            let (data, _) = try await URLSession.shared.data(from: url)
+            let health = try JSONDecoder().decode(HealthResponse.self, from: data)
+            let message = "Hello FountainAI World — \(health.status)"
+            let rendered = try TeatroRenderer.renderScript(SimpleScriptInput(fountainText: message))
+            if let svgData = rendered.svg {
+                self.svg = svgData
+            }
+        } catch {
+            print("Health check failed: \(error)")
+        }
+        loading = false
+    }
+}
+
+@main
+@available(macOS 13.0, *)
+struct HelloFountainAITeatroApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}
+#else
+@main
+struct HelloFountainAITeatroApp {
+    static func main() {
+        print("HelloFountainAITeatro requires macOS with SwiftUI")
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Add macOS SwiftUI sample that fetches `/v1/health` and renders a Teatro SVG message.
- Provide standalone package pulling in Teatro, TeatroRenderAPI, and FountainRuntime.
- Document build & run instructions for `swift run HelloFountainAITeatro`.

## Testing
- `swift build`


------
https://chatgpt.com/codex/tasks/task_b_68bbbe53b7b08333bac90e98336f0d1a