### PR TITLE
feat: add HelloFountainAITeatro example

### DIFF
--- a/Examples/HelloFountainAITeatro/Linux/main.swift
+++ b/Examples/HelloFountainAITeatro/Linux/main.swift
@@ -1,0 +1,23 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+import TeatroRenderAPI
+
+@main
+struct HelloFountainAITeatro {
+    static func main() async throws {
+        let url = URL(string: "http://127.0.0.1:8006/v1/health")!
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let obj = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let status = obj?["status"] as? String ?? "unknown"
+        let message = "Hello FountainAI World — \(status)"
+        let input = SimpleScriptInput(fountainText: message)
+        let result = try TeatroRenderer.renderScript(input)
+        if let svgData = result.svg, let svg = String(data: svgData, encoding: .utf8) {
+            print(svg)
+        }
+    }
+}
+
+// © 2025 Contexter alias Benedikt Eickhoff 🛡️ All rights reserved.

--- a/Examples/HelloFountainAITeatro/Package.swift
+++ b/Examples/HelloFountainAITeatro/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version: 6.1
+import PackageDescription
+
+let package = Package(
+    name: "HelloFountainAITeatro",
+    products: [
+        .executable(name: "hello-fountainai-teatro", targets: ["HelloFountainAITeatro"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Fountain-Coach/Teatro.git", branch: "main")
+    ],
+    targets: [
+        .executableTarget(
+            name: "HelloFountainAITeatro",
+            dependencies: [
+                .product(name: "TeatroRenderAPI", package: "Teatro")
+            ],
+            path: "Linux"
+        )
+    ]
+)

--- a/Examples/HelloFountainAITeatro/README.md
+++ b/Examples/HelloFountainAITeatro/README.md
@@ -1,0 +1,14 @@
+# HelloFountainAITeatro
+
+This example queries a running Semantic Browser service and renders the response status using Teatro.
+
+## Linux
+
+Build and run:
+
+```bash
+swift run hello-fountainai-teatro > output.svg
+```
+
+The SVG is written to `stdout`, redirect it to a file to save.
+


### PR DESCRIPTION
## Summary
- add HelloFountainAITeatro sample CLI
- fetch semantic-browser health and render SVG with Teatro
- document Linux build/run steps

## Testing
- `swift build`


------
https://chatgpt.com/codex/tasks/task_b_68bbbe53f1d8833387b3c16d73c76887