### PR TITLE
Update SwiftCursesKit bootstrap prerequisites

### DIFF
--- a/SwiftCursesKitBootstrap/.gitignore
+++ b/SwiftCursesKitBootstrap/.gitignore
@@ -1,0 +1,29 @@
+# Swift Package Manager
+.build/
+.swiftpm/
+Packages/
+Package.pins
+
+# Xcode / Apple platforms
+DerivedData/
+*.xcodeproj/
+xcuserdata/
+*.xcscmblueprint
+*.xccheckout
+
+# Swift tooling
+.swift-format
+.swiftformat
+*.swiftpm
+
+# Editors / OS artifacts
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Logs & diagnostics
+*.log
+*.trace

--- a/SwiftCursesKitBootstrap/AGENTS.md
+++ b/SwiftCursesKitBootstrap/AGENTS.md
@@ -1,0 +1,36 @@
+# SwiftCursesKit Agent
+
+## Scope
+This agent governs the entire repository. Add a more specific `AGENTS.md` inside a subdirectory if you need to override or extend these rules.
+
+## Mission
+Deliver a safe, expressive Swift wrapper around **ncurses** so developers can compose terminal dashboards and text-based user interfaces with declarative layouts, modern Swift concurrency, and predictable resource management.
+
+## Repository Layout
+- `Package.swift` → Declare the core library target `SwiftCursesKit`, a low-level bridging target `CNCursesSupport`, and any example executables.
+- `Sources/SwiftCursesKit/` → Public API surface (windows, widgets, layout system, input handling, color management).
+- `Sources/CNCursesSupport/` → Thin wrappers over C ncurses symbols; keep this module minimal and internal.
+- `Examples/` → Sample terminal apps that demonstrate layout primitives and event handling.
+- `Tests/SwiftCursesKitTests/` → Unit and integration tests covering rendering, input translation, and resource teardown.
+
+## API & Style Guidelines
+- Provide high-level types (`TerminalApp`, `Screen`, `Window`, `Panel`, `ColorPair`, `KeyEvent`) instead of exposing raw ncurses pointers.
+- Encapsulate every ncurses resource (windows, pads, color pairs) inside a Swift type that owns initialization and cleanup (`deinit` or explicit `close()`).
+- Keep global state confined to a single runtime coordinator; prefer dependency injection for testability.
+- Favor value semantics for configuration objects and small view descriptors; use reference types only for long-lived controllers.
+- Document every public symbol with Swift documentation comments and maintain DocC tutorials for end-to-end examples.
+- Offer async-friendly APIs where appropriate (e.g., `async sequence` for input events, `Task`-based animation hooks).
+- Use `swift-format` (with the project’s shared configuration) before committing changes.
+
+## Interop Requirements
+- Call ncurses only through `CNCursesSupport`. Centralize unsafe pointer operations there and wrap them with `Result`- or `throws`-based Swift APIs.
+- Guard platform-specific features (mouse support, color depth detection) behind capability checks and expose them as optional Swift features.
+- Provide shims for wide-character builds (`ncursesw`) and ensure the build script detects and links against the correct library on macOS and Linux.
+
+## Testing & Quality Gates
+1. `swift build`
+2. `swift test`
+3. `swift-format --in-place` on the entire repository (or the configured `mint run swiftformat` equivalent if we standardize on SwiftFormat).
+4. Run `swift run Examples/DashboardDemo --recording` (or the latest integration example) before publishing releases to ensure rendering works against a real terminal.
+
+A change is ready to merge only when all of the above succeed locally and in CI, public documentation is updated if behavior changes, and at least one example app showcases new widgets or layout features.

--- a/SwiftCursesKitBootstrap/README.md
+++ b/SwiftCursesKitBootstrap/README.md
@@ -1,0 +1,148 @@
+# SwiftCursesKit
+
+SwiftCursesKit is a Swift-native wrapper around **ncurses** that lets you build rich, windowed dashboards directly in the terminal. It combines ncurses’ battle-tested capabilities (cursor control, colors, mouse input, panels) with ergonomic Swift APIs, async event loops, and declarative layout primitives.
+
+https://github.com/your-org/swiftcurseskits (replace with the final repository URL)
+
+---
+
+## Features
+
+- **Safe resource management** – Windows, panels, and color pairs are owned by Swift types that automatically initialize and tear down ncurses resources.
+- **Declarative layout** – Compose split views, stacks, gauges, tables, and log panes with familiar Swift builders.
+- **Async input handling** – Translate keystrokes, mouse events, and timers into structured `KeyEvent`/`MouseEvent` values.
+- **Cross-platform** – Works on Linux and macOS (wide-character ncurses), with automatic capability detection.
+- **Examples included** – Sample dashboards demonstrate live metrics, log streaming, and modal dialogs.
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- Swift 6.1 or newer
+- `ncurses` development headers installed (`sudo apt install libncursesw5-dev` on Debian/Ubuntu, `brew install ncurses` on macOS)
+
+### Installation
+
+Add SwiftCursesKit to your `Package.swift`:
+
+```swift
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "MyTerminalApp",
+    dependencies: [
+        .package(url: "https://github.com/your-org/SwiftCursesKit.git", from: "0.1.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "MyTerminalApp",
+            dependencies: [
+                .product(name: "SwiftCursesKit", package: "SwiftCursesKit")
+            ]
+        )
+    ]
+)
+```
+
+Then fetch dependencies:
+
+```bash
+swift package update
+```
+
+---
+
+## Quick Start
+
+```swift
+import SwiftCursesKit
+
+@main
+struct DemoDashboard: TerminalApp {
+    var body: some Scene {
+        Screen {
+            VStack(spacing: 1) {
+                Title("SwiftCursesKit Demo")
+                HStack {
+                    Gauge(title: "CPU", value: cpuUsage)
+                    Gauge(title: "Memory", value: memoryUsage)
+                }
+                LogView(lines: logBuffer)
+                StatusBar(items: [
+                    .label("q: quit"),
+                    .label("f: toggle fullscreen")
+                ])
+            }
+            .padding(1)
+        }
+    }
+
+    func onEvent(_ event: Event, context: AppContext) async {
+        switch event {
+        case .key(.character("q")):
+            await context.quit()
+        case .tick:
+            await context.updateMetrics()
+        default:
+            break
+        }
+    }
+}
+```
+
+Run the demo:
+
+```bash
+swift run DemoDashboard
+```
+
+---
+
+## Project Layout
+
+```
+.
+├── Package.swift
+├── Sources
+│   ├── SwiftCursesKit        # Public Swift API
+│   └── CNCursesSupport       # C shims and unsafe interop
+├── Examples
+│   └── DashboardDemo         # Reference terminal dashboard
+└── Tests
+    └── SwiftCursesKitTests   # Unit and integration tests
+```
+
+Refer to `AGENTS.md` for detailed contribution standards.
+
+---
+
+## Development Workflow
+
+```bash
+swift build
+swift test
+swift-format --in-place .
+swift run Examples/DashboardDemo
+```
+
+Before submitting a pull request:
+
+1. Verify that examples render correctly in a real terminal session.
+2. Update DocC tutorials or inline documentation for new features.
+3. Add regression tests for bug fixes and new widgets.
+
+---
+
+## Contributing
+
+We welcome issues, feature ideas, and pull requests! Please read `AGENTS.md` for style, testing, and review expectations before contributing. Open a discussion if you plan to propose major architectural changes such as alternate renderers or event loops.
+
+---
+
+## License
+
+SwiftCursesKit is released under the MIT License. See `LICENSE` for details.


### PR DESCRIPTION
## Summary
- update the Swift version prerequisite in the SwiftCursesKit bootstrap README to require Swift 6.1 or newer

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68ce4a1fc4b48333bae2a4bf46b87a71