### PR TITLE
Add SwiftCursesKit integration scaffolding

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -619,6 +619,13 @@ let fullTargets: [Target] = [
         path: "Tests/OpenAPICuratorTests",
         resources: [.copy("Fixtures")]
     ),
+    .testTarget(
+        name: "SwiftCursesKitIntegrationTests",
+        dependencies: [
+            .product(name: "SwiftCursesKit", package: "swiftcurseskit")
+        ],
+        path: "Tests/SwiftCursesKitIntegrationTests"
+    ),
 ]
 
 let leanTargets: [Target] = [
@@ -988,6 +995,13 @@ let uiLeanTargets: [Target] = [
     .testTarget(name: "PersistAPITests", dependencies: ["PersistAPI", "ApiClientsCore"], path: "Tests/PersistAPITests"),
     .testTarget(name: "SemanticBrowserAPITests", dependencies: ["SemanticBrowserAPI", "ApiClientsCore"], path: "Tests/SemanticBrowserAPITests"),
     .testTarget(name: "FountainAICoreTests", dependencies: ["FountainAICore"], path: "Tests/FountainAICoreTests"),
+    .testTarget(
+        name: "SwiftCursesKitIntegrationTests",
+        dependencies: [
+            .product(name: "SwiftCursesKit", package: "swiftcurseskit")
+        ],
+        path: "Tests/SwiftCursesKitIntegrationTests"
+    ),
     .executableTarget(
         name: "FountainLauncherUI",
         dependencies: [],
@@ -1012,6 +1026,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.0"),
         .package(url: "https://github.com/Fountain-Coach/midi2.git", from: "0.3.1"),
+        .package(url: "https://github.com/Fountain-Coach/swiftcurseskit.git", exact: "0.2.0"),
         .package(url: "https://github.com/apple/swift-numerics.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.3.0"),
         .package(url: "https://github.com/Fountain-Coach/Fountain-Store.git", from: "0.1.0"),

--- a/Tests/SwiftCursesKitIntegrationTests/SwiftCursesKitIntegrationTests.swift
+++ b/Tests/SwiftCursesKitIntegrationTests/SwiftCursesKitIntegrationTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+import SwiftCursesKit
+
+final class SwiftCursesKitIntegrationTests: XCTestCase {
+    func testGaugeWidgetProducesRenderCommands() {
+        let gaugeScene = Gauge(title: "Bootstrap", value: 0.72)
+        let nodes = gaugeScene.makeSceneNodes()
+        XCTAssertEqual(nodes.count, 1)
+
+        guard case let .widget(widget) = nodes.first?.kind else {
+            XCTFail("Expected Gauge scene to produce a widget node")
+            return
+        }
+
+        let constraints = LayoutConstraints(maxWidth: 24, maxHeight: 3)
+        let measured = widget.measure(in: constraints)
+        XCTAssertGreaterThan(measured.width, 0)
+        XCTAssertEqual(measured.height, 3)
+
+        var buffer = RenderBuffer()
+        widget.render(
+            in: LayoutRect(origin: .zero, size: measured),
+            buffer: &buffer
+        )
+
+        XCTAssertFalse(buffer.commands.isEmpty)
+        XCTAssertTrue(
+            buffer.commands.contains { $0.text.contains("[") && $0.text.contains("]") },
+            "Expected rendered output to include gauge bar"
+        )
+    }
+
+    func testStatusBarRendersSingleCommand() {
+        let status = StatusBar(items: [.label("q: quit"), .label("⌘R: refresh")])
+        let nodes = status.makeSceneNodes()
+        XCTAssertEqual(nodes.count, 1)
+
+        guard case let .widget(widget) = nodes.first?.kind else {
+            XCTFail("Expected StatusBar to produce a widget node")
+            return
+        }
+
+        var buffer = RenderBuffer()
+        widget.render(
+            in: LayoutRect(origin: .zero, size: LayoutSize(width: 40, height: 1)),
+            buffer: &buffer
+        )
+
+        XCTAssertEqual(buffer.commands.count, 1)
+        XCTAssertTrue(
+            buffer.commands[0].text.contains("q: quit"),
+            "Status bar should surface provided labels"
+        )
+    }
+}

--- a/docs/SwiftCursesKitTUIImplementationPlan.md
+++ b/docs/SwiftCursesKitTUIImplementationPlan.md
@@ -1,0 +1,51 @@
+# SwiftCursesKit Terminal UI Implementation Plan
+
+## Background and References
+- The existing macOS GUI path uses SwiftUI inside `FountainLauncherUI` to orchestrate repository management, service launches, and diagnostics shortcuts. Its `LauncherViewModel` drives tab-based navigation, scripts such as `Scripts/launcher`, and log streaming for the desktop experience.【F:apps/FountainLauncherUI/LauncherUIApp.swift†L1-L110】【F:apps/FountainLauncherUI/LauncherUIApp.swift†L111-L200】
+- The repository already ships a SwiftCursesKit bootstrap kit with ncurses-oriented schemas, adapters, and prompts intended for whitespace-safe terminal UIs, demonstrating prior art for text-based dashboards.【F:SwiftCursesKitBootstrap/codex-whitespace-tui/README.md†L1-L61】【F:SwiftCursesKitBootstrap/codex-whitespace-tui/adapter/Swift/LLMAdapter.swift†L1-L120】
+
+## Current Integration Status
+- `SwiftCursesKit` v0.2.0 is now a package dependency of FountainAI, available to all targets (lean and full) for terminal UI work.【F:Package.swift†L1018-L1039】【F:Package.swift†L614-L628】
+- A smoke-style integration test exercises widget measurement and rendering APIs to confirm we can compose gauges and status bars without requiring a live ncurses screen.【F:Tests/SwiftCursesKitIntegrationTests/SwiftCursesKitIntegrationTests.swift†L1-L47】
+
+## Executable Task List
+Each item can be run end-to-end on macOS or Linux terminals. Use the provided commands verbatim unless a task specifies templating.
+
+1. **Environment bootstrap**
+   - [ ] `tui-install-ncurses`
+     - _Purpose_: Install the wide-character ncurses headers SwiftCursesKit links against.
+     - _Command_: `brew install ncurses` (macOS) or `sudo apt-get update && sudo apt-get install -y libncursesw5-dev` (Linux).
+
+2. **Create the Fountain terminal shell**
+   - [ ] `tui-init-dashboard`
+     - _Purpose_: Scaffold an executable target `FountainTUIDashboard` under `apps/FountainTUIDashboard` that mirrors the Launcher UI’s controls using SwiftCursesKit scenes.
+     - _Command_: `swift package init --type executable --name FountainTUIDashboard --target-name FountainTUIDashboard --package-name the-fountainai` (run inside `apps` and then move generated files into place).
+     - _Next_: Wire the target into `Package.swift` with `.executableTarget(name: "FountainTUIDashboard", dependencies: [.product(name: "SwiftCursesKit", package: "swiftcurseskit"), "FountainRuntime"])`.
+
+3. **Model state synchronization**
+   - [ ] `tui-sync-viewmodel`
+     - _Purpose_: Port core logic from `LauncherViewModel` (repo discovery, script execution, log tailing, control plane polling) into an async SwiftCursesKit-friendly coordinator.
+     - _Command_: `swift run swift-format --in-place apps/FountainTUIDashboard` after copying the relevant SwiftUI state machine to maintain style.
+     - _Verification_: Add unit coverage that mocks `Process` execution and asserts the coordinator emits log/status updates similar to the macOS app.
+
+4. **Screen composition**
+   - [ ] `tui-build-scenes`
+     - _Purpose_: Define reusable SwiftCursesKit scenes for tabs: control actions (start/stop), environment variables, and live log panes using `VStack`, `HStack`, `Split`, and `LogView` widgets.
+     - _Command_: `swift test --filter FountainTUIDashboardTests.testControlTabLayout` (create a corresponding test target that snapshots render commands for a 120x40 terminal).
+
+5. **Interaction loop**
+   - [ ] `tui-wire-events`
+     - _Purpose_: Implement `TerminalApp.onEvent` handlers for keyboard shortcuts (`q`, `s`, `x`, arrow navigation) and tick-based refresh of service status.
+     - _Command_: `swift run FountainTUIDashboard --max-ticks 120 --preview` (support CLI flags to print a static preview for CI while still enabling interactive runs locally).
+
+6. **Packaging and release**
+   - [ ] `tui-bundle`
+     - _Purpose_: Extend `Scripts/make_app.sh` or add a new script to produce a standalone binary bundle (tarball or `.pkg`) with ncurses dependency notes for macOS users.
+     - _Command_: `Scripts/make_app.sh FountainTUIDashboard` (update script to support CLI-only packaging) followed by uploading the artifact to the release pipeline.
+
+7. **Documentation and support**
+   - [ ] `tui-docs`
+     - _Purpose_: Document the TUI workflow (install deps, run preview, connect to control plane) alongside the existing GUI quickstart.
+     - _Command_: `swift test --filter SwiftCursesKitIntegrationTests` (use the existing integration test to ensure widget APIs remain stable) and then add a tutorial under `docs/`.
+
+Complete these tasks to ship a feature-parity terminal dashboard that reuses FountainAI’s orchestration logic while staying entirely inside the Swift toolchain.


### PR DESCRIPTION
## Summary
- add the SwiftCursesKit v0.2.0 package dependency and expose an integration test target in both lean and full builds
- add smoke-style widget rendering tests that validate Gauge and StatusBar scenes compile against SwiftCursesKit without ncurses runtime access
- document a step-by-step terminal UI implementation plan that mirrors the existing macOS LauncherUI workflow and codifies executable follow-up tasks

## Testing
- `swift build` *(fails: macOS-specific FountainLauncherUI target imports Security which is unavailable on Linux toolchain)*
- `swift test --filter SwiftCursesKitIntegrationTests` *(fails: macOS-specific FountainLauncherUI target imports Security which is unavailable on Linux toolchain)*

------
https://chatgpt.com/codex/tasks/task_b_68cf7ae4bee883339aa7096fc905ace4