### PR TITLE
Mark launcher completion handler as Sendable

### DIFF
--- a/apps/FountainLauncherUI/LauncherUIApp.swift
+++ b/apps/FountainLauncherUI/LauncherUIApp.swift
@@ -109,7 +109,7 @@ final class LauncherViewModel: ObservableObject {
         NSWorkspace.shared.open(ctrlURL)
     }
 
-    private func run(command: [String], cwd: String, env: [String: String]? = nil, completion: @escaping (Int32, String) -> Void) {
+    private func run(command: [String], cwd: String, env: [String: String]? = nil, completion: @Sendable @escaping (Int32, String) -> Void) {
         DispatchQueue.global().async {
             let proc = Process()
             proc.currentDirectoryURL = URL(fileURLWithPath: cwd)


### PR DESCRIPTION
## Summary
- mark the launcher process completion handler as @Sendable to align with Swift concurrency expectations

## Testing
- `swift build` *(fails: macOS Security framework unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cf7e8b9df48333af030da7d817f1ab