### PR TITLE
Add tutor path docs and service discovery tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import Foundation
 // Set FULL_TESTS=1 to build and test all targets.
 let LEAN = (ProcessInfo.processInfo.environment["FULL_TESTS"] != "1")
 
-let fullProducts: [Product] = [
+var fullProducts: [Product] = [
     .library(name: "FountainCodex", targets: ["FountainCodex"]),
     .library(name: "FountainRuntime", targets: ["FountainRuntime"]),
     .library(name: "FountainStoreClient", targets: ["FountainStoreClient"]),
@@ -42,25 +42,32 @@ let fullProducts: [Product] = [
     .executable(name: "bootstrap-server", targets: ["bootstrap-server"]),
     .executable(name: "bootstrap", targets: ["bootstrap-server"]),
     .executable(name: "persist-server", targets: ["persist-server"]),
-    .executable(name: "persist", targets: ["persist-server"]),
-    .executable(name: "FountainLauncherUI", targets: ["FountainLauncherUI"]),
-    .executable(name: "FountainDashboard", targets: ["FountainLauncherUI"])
+    .executable(name: "persist", targets: ["persist-server"])
 ]
 
-let leanProducts: [Product] = [
+var leanProducts: [Product] = [
     .library(name: "ApiClientsCore", targets: ["ApiClientsCore"]),
     .library(name: "GatewayAPI", targets: ["GatewayAPI"]),
     .library(name: "PersistAPI", targets: ["PersistAPI"]),
     .library(name: "SemanticBrowserAPI", targets: ["SemanticBrowserAPI"]),
     .library(name: "LLMGatewayAPI", targets: ["LLMGatewayAPI"]),
-    .executable(name: "publishing-frontend", targets: ["publishing-frontend"]),
+    .executable(name: "publishing-frontend", targets: ["publishing-frontend"])
+]
+
+#if os(macOS)
+fullProducts.append(contentsOf: [
     .executable(name: "FountainLauncherUI", targets: ["FountainLauncherUI"]),
     .executable(name: "FountainDashboard", targets: ["FountainLauncherUI"])
-]
+])
+leanProducts.append(contentsOf: [
+    .executable(name: "FountainLauncherUI", targets: ["FountainLauncherUI"]),
+    .executable(name: "FountainDashboard", targets: ["FountainLauncherUI"])
+])
+#endif
 
 var products: [Product] = LEAN ? leanProducts : fullProducts
 
-let fullTargets: [Target] = [
+var fullTargets: [Target] = [
     .target(
         name: "ApiClientsCore",
         dependencies: [],
@@ -78,6 +85,13 @@ let fullTargets: [Target] = [
             "openapi-curator-service"
         ],
         path: "Tests/SystemSmokeTests"
+    ),
+    .testTarget(
+        name: "TutorPathModule1Tests",
+        dependencies: [
+            .product(name: "Yams", package: "Yams")
+        ],
+        path: "Tests/TutorPathModule1Tests"
     ),
     .target(
         name: "GatewayAPI",
@@ -108,11 +122,6 @@ let fullTargets: [Target] = [
         name: "FountainAIAdapters",
         dependencies: ["FountainAICore", "LLMGatewayAPI", "SemanticBrowserAPI", "PersistAPI"],
         path: "libs/FountainAIAdapters/Sources/FountainAIAdapters"
-    ),
-    .executableTarget(
-        name: "FountainLauncherUI",
-        dependencies: [],
-        path: "apps/FountainLauncherUI"
     ),
     
     .target(
@@ -713,11 +722,6 @@ let leanTargets: [Target] = [
         path: "libs/FountainStoreClient"
     ),
     .executableTarget(
-        name: "FountainLauncherUI",
-        dependencies: [],
-        path: "apps/FountainLauncherUI"
-    ),
-    .executableTarget(
         name: "semantic-browser-server",
         dependencies: [
             .product(name: "SemanticBrowser", package: "semantic-browser"),
@@ -942,8 +946,18 @@ let leanTargets: [Target] = [
     ),
 ]
 
+#if os(macOS)
+fullTargets.append(
+    .executableTarget(
+        name: "FountainLauncherUI",
+        dependencies: [],
+        path: "apps/FountainLauncherUI"
+    )
+)
+#endif
+
 // Minimal lean target set focused on API clients + tests to avoid linking heavy executables during local runs.
-let uiLeanTargets: [Target] = [
+var uiLeanTargets: [Target] = [
     .target(name: "ApiClientsCore", dependencies: [], path: "libs/ApiClientsCore/Sources/ApiClientsCore"),
     .target(name: "GatewayAPI", dependencies: ["ApiClientsCore"], path: "libs/GatewayAPI/Sources/GatewayAPI"),
     .target(name: "PersistAPI", dependencies: ["ApiClientsCore"], path: "libs/PersistAPI/Sources/PersistAPI"),
@@ -986,10 +1000,6 @@ let uiLeanTargets: [Target] = [
         dependencies: [.product(name: "FountainStore", package: "fountain-store")],
         path: "libs/FountainStoreClient"
     ),
-    .executableTarget(name: "gui-diagnostics", dependencies: ["ApiClientsCore", "GatewayAPI", "PersistAPI", "SemanticBrowserAPI", "LLMGatewayAPI"], path: "tools/GuiDiagnostics"),
-    .executableTarget(name: "gui-seed", dependencies: ["ApiClientsCore", "PersistAPI"], path: "tools/GuiSeed"),
-    .executableTarget(name: "gui-browse", dependencies: ["ApiClientsCore", "PersistAPI", "SemanticBrowserAPI"], path: "tools/GuiBrowse"),
-    .executableTarget(name: "gui-capabilities", dependencies: ["ApiClientsCore", "PersistAPI"], path: "tools/GuiCapabilities"),
     .testTarget(name: "ApiClientsCoreTests", dependencies: ["ApiClientsCore", "LLMGatewayAPI"], path: "Tests/ApiClientsCoreTests"),
     .testTarget(name: "GatewayAPITests2", dependencies: ["GatewayAPI", "ApiClientsCore"], path: "Tests/GatewayAPITests2"),
     .testTarget(name: "PersistAPITests", dependencies: ["PersistAPI", "ApiClientsCore"], path: "Tests/PersistAPITests"),
@@ -1002,12 +1012,28 @@ let uiLeanTargets: [Target] = [
         ],
         path: "Tests/SwiftCursesKitIntegrationTests"
     ),
+    .testTarget(
+        name: "TutorPathModule1Tests",
+        dependencies: [
+            .product(name: "Yams", package: "Yams")
+        ],
+        path: "Tests/TutorPathModule1Tests"
+    ),
+]
+
+#if os(macOS)
+uiLeanTargets.append(contentsOf: [
     .executableTarget(
         name: "FountainLauncherUI",
         dependencies: [],
         path: "apps/FountainLauncherUI"
     ),
-]
+    .executableTarget(name: "gui-diagnostics", dependencies: ["ApiClientsCore", "GatewayAPI", "PersistAPI", "SemanticBrowserAPI", "LLMGatewayAPI"], path: "tools/GuiDiagnostics"),
+    .executableTarget(name: "gui-seed", dependencies: ["ApiClientsCore", "PersistAPI"], path: "tools/GuiSeed"),
+    .executableTarget(name: "gui-browse", dependencies: ["ApiClientsCore", "PersistAPI", "SemanticBrowserAPI"], path: "tools/GuiBrowse"),
+    .executableTarget(name: "gui-capabilities", dependencies: ["ApiClientsCore", "PersistAPI"], path: "tools/GuiCapabilities")
+])
+#endif
 
 var targets: [Target] = LEAN ? uiLeanTargets : fullTargets
 

--- a/Tests/ApiClientsCoreTests/RESTClientTests.swift
+++ b/Tests/ApiClientsCoreTests/RESTClientTests.swift
@@ -1,5 +1,8 @@
 import XCTest
 @testable import ApiClientsCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 @MainActor
 final class RESTClientTests: XCTestCase {

--- a/Tests/GatewayAPITests2/GatewayClientTests.swift
+++ b/Tests/GatewayAPITests2/GatewayClientTests.swift
@@ -1,6 +1,9 @@
 import XCTest
 @testable import GatewayAPI
 import ApiClientsCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 @MainActor
 final class GatewayClientTests2: XCTestCase {

--- a/Tests/LLMGatewayAPITests/LLMGatewayClientTests.swift
+++ b/Tests/LLMGatewayAPITests/LLMGatewayClientTests.swift
@@ -1,6 +1,9 @@
 import XCTest
 @testable import LLMGatewayAPI
 import ApiClientsCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 @MainActor
 final class LLMGatewayClientTests: XCTestCase {

--- a/Tests/PersistAPITests/PersistClientTests.swift
+++ b/Tests/PersistAPITests/PersistClientTests.swift
@@ -1,6 +1,9 @@
 import XCTest
 @testable import PersistAPI
 import ApiClientsCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 @MainActor
 final class PersistClientTests: XCTestCase {

--- a/Tests/SemanticBrowserAPITests/SemanticBrowserClientTests.swift
+++ b/Tests/SemanticBrowserAPITests/SemanticBrowserClientTests.swift
@@ -1,6 +1,9 @@
 import XCTest
 @testable import SemanticBrowserAPI
 import ApiClientsCore
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 @MainActor
 final class SemanticBrowserClientTests: XCTestCase {

--- a/Tests/TutorPathModule1Tests/ServiceDiscoveryTests.swift
+++ b/Tests/TutorPathModule1Tests/ServiceDiscoveryTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+import Yams
+
+final class ServiceDiscoveryTests: XCTestCase {
+    func testEnumeratesServicesAndFlagsMissingEndpoints() throws {
+        let testDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let packageRoot = testDirectory.deletingLastPathComponent().deletingLastPathComponent()
+        let openAPIRoot = packageRoot.appendingPathComponent("openapi/v1", isDirectory: true)
+
+        let discovery = ServiceDiscovery(openAPIRoot: openAPIRoot)
+        let services = try discovery.loadServices()
+
+        let servicesByFile = Dictionary(uniqueKeysWithValues: services.map { ($0.fileName, $0) })
+
+        let expected: [String: (port: Int, hasHealth: Bool, hasCapabilities: Bool)] = [
+            "baseline-awareness.yml": (port: 8001, hasHealth: true, hasCapabilities: false),
+            "bootstrap.yml": (port: 8002, hasHealth: false, hasCapabilities: false),
+            "persist.yml": (port: 8005, hasHealth: false, hasCapabilities: true),
+            "planner.yml": (port: 8003, hasHealth: false, hasCapabilities: false),
+            "function-caller.yml": (port: 8004, hasHealth: false, hasCapabilities: false),
+            "tools-factory.yml": (port: 8011, hasHealth: false, hasCapabilities: false),
+            "semantic-browser.yml": (port: 8007, hasHealth: true, hasCapabilities: false)
+        ]
+
+        XCTAssertGreaterThanOrEqual(servicesByFile.count, expected.count, "Expected to discover module 01 services")
+
+        for (fileName, expectation) in expected {
+            guard let descriptor = servicesByFile[fileName] else {
+                XCTFail("Missing descriptor for \(fileName)")
+                continue
+            }
+
+            XCTAssertEqual(descriptor.port, expectation.port, "Unexpected port for \(fileName)")
+            XCTAssertEqual(!descriptor.healthPaths.isEmpty, expectation.hasHealth, "Health path mismatch for \(fileName)")
+            XCTAssertEqual(!descriptor.capabilityPaths.isEmpty, expectation.hasCapabilities, "Capabilities path mismatch for \(fileName)")
+        }
+    }
+}
+
+struct ServiceDescriptor {
+    let fileName: String
+    let title: String
+    let port: Int
+    let healthPaths: [String]
+    let capabilityPaths: [String]
+}
+
+struct ServiceDiscovery {
+    let openAPIRoot: URL
+
+    func loadServices() throws -> [ServiceDescriptor] {
+        let manager = FileManager.default
+        let files = try manager.contentsOfDirectory(at: openAPIRoot, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension.lowercased() == "yml" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        return try files.compactMap { url in
+            let yamlString = try String(contentsOf: url, encoding: .utf8)
+            guard let root = try Yams.load(yaml: yamlString) as? [String: Any] else { return nil }
+
+            let info = root["info"] as? [String: Any] ?? [:]
+            let title = (info["title"] as? String) ?? url.deletingPathExtension().lastPathComponent
+            guard let port = ServiceDiscovery.parsePort(info["x-fountain.port"]) else { return nil }
+            let paths = root["paths"] as? [String: Any] ?? [:]
+
+            let health = ServiceDiscovery.extractPaths(paths, containing: "health")
+            let capabilities = ServiceDiscovery.extractPaths(paths, containing: "capabilities")
+
+            return ServiceDescriptor(
+                fileName: url.lastPathComponent,
+                title: title,
+                port: port,
+                healthPaths: health,
+                capabilityPaths: capabilities
+            )
+        }
+    }
+
+    private static func parsePort(_ value: Any?) -> Int? {
+        switch value {
+        case let intValue as Int:
+            return intValue
+        case let stringValue as String:
+            return Int(stringValue)
+        case let doubleValue as Double:
+            return Int(doubleValue)
+        default:
+            return nil
+        }
+    }
+
+    private static func extractPaths(_ paths: [String: Any], containing substring: String) -> [String] {
+        let lowercased = substring.lowercased()
+        return paths.keys
+            .filter { $0.lowercased().contains(lowercased) }
+            .sorted()
+    }
+}

--- a/apps/FountainLauncherUI/KeychainHelper.swift
+++ b/apps/FountainLauncherUI/KeychainHelper.swift
@@ -1,7 +1,10 @@
 import Foundation
+#if canImport(Security)
 import Security
+#endif
 
 enum KeychainHelper {
+#if canImport(Security)
     static func save(service: String, account: String, secret: String) -> Bool {
         let data = Data(secret.utf8)
         let query: [String: Any] = [
@@ -39,5 +42,18 @@ enum KeychainHelper {
         let status = SecItemDelete(query as CFDictionary)
         return status == errSecSuccess || status == errSecItemNotFound
     }
+#else
+    static func save(service: String, account: String, secret: String) -> Bool {
+        return false
+    }
+
+    static func read(service: String, account: String) -> String? {
+        return nil
+    }
+
+    static func delete(service: String, account: String) -> Bool {
+        return false
+    }
+#endif
 }
 

--- a/docs/tutor/AGENTS.md
+++ b/docs/tutor/AGENTS.md
@@ -1,0 +1,19 @@
+# Tutor Path Docs Agent
+
+This directory mirrors the [tutor v1.0.0](https://github.com/Fountain-Coach/tutor/releases/tag/v1.0.0) documentation pack. Keep the layout stable when updating:
+
+- `README.md` provides the Tutor Path overview for this repository.
+- `modules/` contains the numbered module walkthroughs.
+- `_includes/` stores shared environment, testing, and repo link snippets.
+
+## Editing guidelines
+- Preserve the shared outline inside every module (**Outcome**, **What you’ll ship**, **Specs to read**, **Behavioral acceptance**, **Test plan**, **Runbook**, **Hand-off to Codex**).
+- When cross-linking, use relative paths so the docs render correctly in local viewers.
+- Reuse `_includes/` snippets rather than duplicating environment or testing guidance.
+- Reference FountainAI specs via relative paths (e.g. `openapi/v1/...`).
+- When adding modules, follow the numbering and kebab-case naming pattern (`NN-title`).
+
+## Keeping parity with the upstream release
+- Note the release version in `README.md` when updating the docs.
+- If you pull changes from a future Tutor release, update the version annotation and summarize the differences in the commit message.
+- Do not remove sections without replacing them with equivalent guidance—surface deltas as TODO callouts instead.

--- a/docs/tutor/README.md
+++ b/docs/tutor/README.md
@@ -1,0 +1,74 @@
+# Tutor Path (v1.0.0)
+
+> Documentation imported from the [Tutor v1.0.0 release](https://github.com/Fountain-Coach/tutor/releases/tag/v1.0.0). This copy tracks the upstream walkthrough so the FountainAI repo can follow the tutorial path locally.
+
+> Each stage treats the documented APIs as the single source of truth while the curses UI surfaces service health, corpus insights, and planner activity without private backdoors.
+
+---
+
+## Repository Layout (Proposed)
+
+```
+README.md
+AGENTS.md
+LICENSE
+docs/
+  tutor/
+    README.md
+    modules/
+      01-spec-literacy-and-health.md
+      02-corpus-bootstrap.md
+      03-awareness-baselines-drift-reflections.md
+      04-planner-and-llm-gateway-loop.md
+      05-tools-factory-to-function-caller.md
+      06-teatro-gui-spec-only-integration.md
+      07-observability-and-guards.md
+      08-reasoning-streams-midi2-optional.md
+    _includes/
+      env.md
+      repo-links.md
+      testing-checklists.md
+```
+
+> **Notes**
+> - Keep all module docs within `docs/tutor/modules/` and reference common snippets (env, links, testing) from `_includes/`.
+> - Expect `swiftcurseskit` views—tables, forms, event loops—to hydrate from `/v1/health`, `/v1/capabilities`, and OpenAPI definitions under `openapi/` directories across repos.
+
+---
+
+## Global Principles
+
+1. **Specs Drive the Dashboard** — curate the OpenAPI schema before wiring `swiftcurseskit` tables or panels.
+2. **Corpus Widgets Everywhere** — hydrate curses forms from a seeded FountainStore corpus to keep data entry consistent.
+3. **HTTP-Powered Curses UI** — route every `swiftcurseskit` surface (service tables, planner loops) through documented endpoints only.
+4. **Capability Panels** — render `/v1/capabilities` deltas directly inside the dashboard so missing features stay visible.
+
+## Profiles (Conceptual)
+
+- `ai` — completions/streaming via an HTTP gateway (model-agnostic).
+- `persist` — FountainStore as the durable store for corpora & artifacts.
+- `teatro` — GUI that renders strictly from API responses.
+- `midi2` — optional reasoning/timing/sonic transparency (SSE-over-MIDI).
+
+## Modules
+
+1. [**Spec Literacy & Health**](modules/01-spec-literacy-and-health.md) — list services, check `/v1/health`, and project them into `swiftcurseskit` service tables.
+2. [**Corpus Bootstrap**](modules/02-corpus-bootstrap.md) — create a corpus, seed baselines/roles, and back the curses data-entry forms with FountainStore.
+3. [**Awareness: Baselines, Drift, Reflections**](modules/03-awareness-baselines-drift-reflections.md) — add baselines, inspect drift patterns, and wire dashboards to awareness feeds.
+4. [**Planner + LLM Gateway Loop**](modules/04-planner-and-llm-gateway-loop.md) — surface ordered planner steps in `swiftcurseskit` loops before triggering Function Caller execution.
+5. [**Tools Factory → Function Caller**](modules/05-tools-factory-to-function-caller.md) — register/invoke tools from OpenAPI operations and expose invocation logs in curses panels.
+6. [**Teatro GUI: Spec-Only Integration**](modules/06-teatro-gui-spec-only-integration.md) — translate lessons into a spec-bound curses shell while keeping Teatro parity.
+7. [**Observability & Guards**](modules/07-observability-and-guards.md) — chart budgets, rate limits, and guardrails through `swiftcurseskit` gauges.
+8. [**Reasoning Streams (Optional, MIDI2)**](modules/08-reasoning-streams-midi2-optional.md) — stream planner and awareness events into live terminal transports.
+
+## How To Use This Path
+
+- Start at Module 01 and continue sequentially; each module keeps the previous app useful.
+- Treat the **acceptance criteria** and **test plans** as your source of truth.
+- When a capability is missing, surface it in the UI as a request with guidance.
+
+## Shared Resources
+
+- **Environment Baseline:** [`_includes/env.md`](_includes/env.md)
+- **Testing Checklists:** [`_includes/testing-checklists.md`](_includes/testing-checklists.md)
+- **Repo Links:** [`_includes/repo-links.md`](_includes/repo-links.md)

--- a/docs/tutor/_includes/env.md
+++ b/docs/tutor/_includes/env.md
@@ -1,0 +1,14 @@
+# Environment (shared)
+
+Define these environment variables in your preferred method (dotenv, Xcode scheme, or runtime flags):
+
+- `FOUNTAINSTORE_URL` — base URL for the FountainStore API
+- `FOUNTAINSTORE_API_KEY` — API key/token for FountainStore
+- `FOUNTAIN_GATEWAY_URL` — base URL for the LLM/Gateway facade
+- `PLANNER_URL` — base URL for Planner service
+- `AWARENESS_URL` — base URL for Baseline Awareness service
+- `TOOLS_FACTORY_URL` — base URL for the Tools Factory service
+- `FUNCTION_CALLER_URL` — base URL for the Function Caller service
+- `TEATRO_BASE_URL` — (if the GUI is served separately)
+
+> All reads/writes must go through HTTP APIs. No direct DB/filesystem access from GUI.

--- a/docs/tutor/_includes/repo-links.md
+++ b/docs/tutor/_includes/repo-links.md
@@ -1,0 +1,8 @@
+# Repository links (Fountain-Coach org)
+
+- **FountainAI (core specs & services)** — openapi/ for service definitions; source for Planner, Awareness, FountainStore, Gateways.
+- **Teatro** — GUI and deterministic rendering primitives; integrates strictly via APIs.
+- **MIDI2** — Swift MIDI 2.0 library; optional SSE-over-MIDI transparency & sonic cues.
+- **Toolsmith** — OpenAPI-driven tool generation/orchestration; used by Tools Factory.
+
+> Keep links relative or organization-absolute per your docs policy.

--- a/docs/tutor/_includes/testing-checklists.md
+++ b/docs/tutor/_includes/testing-checklists.md
@@ -1,0 +1,29 @@
+# Testing checklists (contract-first)
+
+Use these recurring checklists across modules:
+
+## Health & Capabilities
+- [ ] `/v1/health` returns 200 and includes build/revision info
+- [ ] `/v1/capabilities` enumerates features; unknowns marked `NotSupported`
+
+## Corpus I/O
+- [ ] Create/read/update corpus resources through FountainStore
+- [ ] Versioning semantics are visible where applicable (baselines, cards, scenes)
+
+## Planner Loop
+- [ ] `POST /planner` returns ordered steps with corpus context
+- [ ] `POST /planner/execute` orchestrates tools via Function Caller
+
+## GUI Discipline
+- [ ] GUI issues only HTTP requests against documented OpenAPI operations
+- [ ] Missing capabilities are surfaced with actionable messaging (no crashes)
+
+## Curses UI
+- [ ] Refresh cadence stays aligned with the `swiftcurseskit` render loop so screens reuse the shared throttling instead of hand-rolled timers
+- [ ] Keyboard navigation hooks into the `swiftcurseskit` shortcut maps; module-specific keys are layered on top without overriding core bindings
+- [ ] Focus management defers to the `swiftcurseskit` focus stack so only one pane or form captures input and tab/arrow order remains deterministic
+- [ ] Redraw stability matches `swiftcurseskit` double-buffer expectations—no flicker, ghosting, or partial updates when data streams in
+
+## Observability & Guards
+- [ ] Budget/Rate limit decisions observable in responses/headers
+- [ ] Destructive operations require explicit guard approval paths

--- a/docs/tutor/modules/01-spec-literacy-and-health.md
+++ b/docs/tutor/modules/01-spec-literacy-and-health.md
@@ -1,0 +1,54 @@
+# Module 01 — Spec Literacy & Health
+
+**Outcome**: Deliver a Swift curses dashboard powered by `swiftcurseskit` that enumerates services from OpenAPI specs, checks `/v1/health`, and lists `/v1/capabilities`.
+
+## What you’ll ship
+A terminal dashboard built with `swiftcurseskit` that renders documented services with live health and capability status.
+
+## Setup
+- Add `swiftcurseskit` as a SwiftPM dependency and include the module target in your executable:
+
+  ```swift
+  // Package.swift (excerpt)
+  dependencies: [
+      .package(url: "https://github.com/fountainai/swiftcurseskit", from: "1.2.0")
+  ],
+  targets: [
+      .executableTarget(
+          name: "TutorDashboard",
+          dependencies: [
+              .product(name: "SwiftCursesKit", package: "swiftcurseskit")
+          ]
+      )
+  ]
+  ```
+- Load environment variables for FountainAI clients (see **_includes/env.md**) so the dashboard can query each documented service. Provide local `.env` defaults for contributors.
+
+## Specs to read
+- `openapi/bootstrap.yml`
+- `openapi/baseline-awareness.yml`
+- `openapi/persist.yml` (FountainStore)
+- `openapi/planner.yml`
+- `openapi/function-caller.yml`
+- `openapi/tools-factory.yml`
+- Relevant gateway specs (rate limiter, budget breaker, security, etc.)
+
+## Behavioral acceptance
+- [ ] Load the above specs and render a services table (name, base URL, health, capabilities)
+- [ ] Unknown/missing capability is shown with guidance: “Needs: <capability>”
+- [ ] The curses view refreshes on a predictable cadence (e.g., every 5 seconds) and responds immediately to manual refresh commands
+- [ ] Keyboard navigation (arrow keys/tab) moves focus across service rows without breaking health/capability polling
+
+## Test plan
+- Validate 200 from `/v1/health` per service
+- Parse and render `/v1/capabilities`
+- Exercise the refresh loop to confirm screen redraws occur without input glitches
+- Simulate navigation keystrokes to verify focus handling and status updates remain in sync
+
+## Runbook
+- Configure base URLs and keys from **_includes/env.md**
+- Wire `/v1/health` responses into the `swiftcurseskit` view model that feeds service row status indicators
+- Map `/v1/capabilities` payloads into `swiftcurseskit` list/detail components so operators can drill into capability explanations
+
+## Hand-off to Codex
+> Build a service table that reads from the listed specs and queries `/v1/health` and `/v1/capabilities`. No hardcoded endpoints. Ensure Codex implementers connect those endpoints to the `swiftcurseskit` views described above, preserving the refresh cadence and keyboard navigation affordances.

--- a/docs/tutor/modules/02-corpus-bootstrap.md
+++ b/docs/tutor/modules/02-corpus-bootstrap.md
@@ -1,0 +1,36 @@
+# Module 02 — Corpus Bootstrap
+
+**Outcome**: Add a curses-driven bootstrap panel inside `swiftcurseskit` that creates a corpus, seeds roles/baselines, and surfaces the initial Awareness snapshot without leaving the terminal app.
+
+## What you’ll ship
+A new panel in the existing `swiftcurseskit` app that routes to the bootstrap API, captures corpus metadata via keyboard-driven forms, and renders the resulting baseline data alongside Awareness polling output.
+
+## Setup
+- Wire the bootstrap client dependency into `swiftcurseskit` alongside the existing FountainStore bindings.
+- Ensure the terminal environment has ncurses available (`swift build` should link against `libncursesw`).
+- Configure environment variables for Bootstrap, Awareness, and FountainStore endpoints (see **_includes/env.md**) so the panel can submit and refresh data.
+
+## Specs to read
+- `openapi/bootstrap.yml`
+- `openapi/persist.yml`
+- `openapi/baseline-awareness.yml`
+
+## Behavioral acceptance
+- [ ] `POST /bootstrap` creates a corpus and seeds roles/baselines
+- [ ] FountainStore reflects corpus records; Awareness shows an initial snapshot
+- [ ] The curses form allows full keyboard navigation (Tab/Shift-Tab or arrow keys) between fields and actions without mouse input
+- [ ] After a corpus is created, the panel triggers a refresh cadence that repolls Awareness until the baseline snapshot renders in the UI
+
+## Test plan
+- Confirm corpus creation returns identifiers and version info
+- Confirm Awareness reads back seeded baseline
+- Exercise curses navigation in a local run (`swift run swiftcurseskit`) to ensure focus states and submit shortcuts operate as documented
+- Validate that the panel repolls Awareness on an interval after corpus creation and stops once the baseline is shown
+
+## Runbook
+- Ensure FountainStore, Bootstrap, and Awareness URLs are configured (see **_includes/env.md**) and routed through the `swiftcurseskit` configuration layer.
+- Register the new panel in the router so `/bootstrap` commands or menu entries open the curses view instead of a placeholder.
+- Keep the Awareness poller scoped to the panel view and reuse existing module logging so refresh cadence issues surface in the standard terminal status area.
+
+## Hand-off to Codex
+> Implement the curses bootstrap flow end-to-end: route `/bootstrap` into the new `swiftcurseskit` panel, submit the form to `POST /bootstrap`, and wire the existing Awareness polling utilities so baseline updates hydrate the curses widgets without breaking module style conventions.

--- a/docs/tutor/modules/03-awareness-baselines-drift-reflections.md
+++ b/docs/tutor/modules/03-awareness-baselines-drift-reflections.md
@@ -1,0 +1,32 @@
+# Module 03 — Awareness: Baselines, Drift, Reflections
+
+**Outcome**: Extend the Swift curses dashboard so baseline management, drift visualization, and reflections timelines live beside the existing awareness panes.
+
+## What you’ll ship
+A curses module that layers baseline CRUD, scrollable drift graphs, and a reflections timeline onto the Swift dashboard.
+
+> **Setup**: Reuse the shared curses fixtures from Module 02—`swiftcurseskit` mocks, `AwarenessService` stubs, and the `DashboardHarness` integration harness—so acceptance checks can assert keyboard navigation, pane refresh cadence, and persistence wiring without duplicating scaffolding.
+
+## Specs to read
+- `openapi/baseline-awareness.yml`
+- `openapi/persist.yml`
+
+## Behavioral acceptance
+- [ ] `POST /corpora/{id}/baselines` persists a new baseline version and surfaces it in the Baselines pane without requiring a dashboard restart
+- [ ] Version history renders as a scrollable list that highlights the active baseline and responds to `j`/`k` navigation keys
+- [ ] Drift and pattern visualizations refresh every 5 seconds while the dashboard is focused, using the `/drift` endpoints without blocking other panes
+- [ ] Reflections timeline supports pagination via `[` and `]`, maintains cursor position, and preserves timestamps/author badges
+- [ ] Keyboard shortcuts (`b`, `d`, `r`) switch between Baseline, Drift, and Reflection panes while keeping the curses layout consistent with Module 02
+
+## Test plan
+- Verify version bump after baseline creation and ensure the curses list updates on the next refresh tick
+- Validate drift/pattern data shapes, empty-state handling, and redraw cadence stays within 100ms of the refresh interval
+- Exercise reflections pagination to confirm cursor persistence and keyboard shortcut routing across panes
+
+## Runbook
+- Depend on corpus id from Module 02; reuse environment from **_includes/env.md**
+- Wire Awareness endpoints into the `swiftcurseskit` view models: `BaselineListViewModel`, `DriftViewModel`, and `ReflectionsTimelineViewModel` should orchestrate data pulls while delegating rendering to existing dashboard components.
+- Maintain curses UX constraints—non-blocking network calls, fixed-width columns, and shared status bar updates—by scheduling async refresh work on the dashboard's poll loop.
+
+## Hand-off to Codex
+> Implement baseline CRUD, render drift/pattern insights, and extend the reflections timeline by wiring Awareness HTTP clients into `swiftcurseskit` view models while preserving the dashboard’s keyboard and refresh behaviors.

--- a/docs/tutor/modules/04-planner-and-llm-gateway-loop.md
+++ b/docs/tutor/modules/04-planner-and-llm-gateway-loop.md
@@ -1,0 +1,29 @@
+# Module 04 — Planner + LLM Gateway Loop
+
+**Outcome**: Plan then execute inside the Swift curses dashboard; the planner orchestrates steps via Function Caller with corpus context while the UI keeps focus and layout predictable.
+
+## What you’ll ship
+A two-pane Swift `swiftcurseskit` dashboard module: the left pane hosts the planner step list (creation, navigation, status), the right pane renders execution details and tool outputs. Keyboard focus should move predictably between panes (e.g., `Tab` to toggle, arrow keys within a pane) and the screen should maintain a persistent header/footer for status and capability messaging.
+
+## Specs to read
+- `openapi/planner.yml`
+- `openapi/function-caller.yml`
+- Gateway specs used by the LLM gateway
+
+## Behavioral acceptance
+- [ ] `POST /planner` yields an ordered step list with corpus context
+- [ ] `POST /planner/execute` runs steps via Function Caller and shows ordered outputs
+- [ ] Planner steps can be navigated via keyboard controls inside the curses dashboard without losing focus context
+- [ ] Execution status updates render live in the execution pane and refresh when the operator presses the designated manual refresh key
+
+## Test plan
+- Contract test for step ordering and minimal error handling per step
+- Curses interaction test pass: simulated key events traverse planner steps, trigger execute, and confirm status refresh behavior
+
+## Runbook
+- Ensure Planner and Function Caller URLs are set; surface `NotSupported` if capabilities are missing
+- Map `/planner` responses into planner pane views and `/planner/execute` payloads into execution detail views via `swiftcurseskit`
+- Keep capability-aware messaging in the curses UI header/footer so missing planner/execute capabilities show actionable guidance
+
+## Hand-off to Codex
+> Implement plan → execute controls wired to the documented endpoints only, rendering planner and execution panes with `swiftcurseskit` components and maintaining capability-aware status messaging in the curses UI.

--- a/docs/tutor/modules/05-tools-factory-to-function-caller.md
+++ b/docs/tutor/modules/05-tools-factory-to-function-caller.md
@@ -1,0 +1,37 @@
+# Module 05 — Tools Factory → Function Caller
+
+**Outcome**: Register a tool from an OpenAPI operation; invoke it via Function Caller; persist results.
+
+## What you’ll ship
+An end-to-end tool management workflow inside `swiftcurseskit`:
+
+- A curses-based tool registration pane that binds `operationId` entries from Tools Factory to shared view models.
+- An invocation panel that calls Function Caller endpoints and streams output into a scrolling results history buffer.
+- Terminal UI rendering that surfaces past results inline (status, timestamp, payload excerpts) so operators can review history without leaving the curses session.
+
+## Specs to read
+- `openapi/tools-factory.yml`
+- `openapi/function-caller.yml`
+- `openapi/persist.yml`
+
+## Behavioral Acceptance
+- [ ] Register operations in Tools Factory
+- [ ] Tools appear in the curses catalog pane and are invokable by `operationId`
+- [ ] Cursor navigation toggles between catalog and invocation panes with visible focus cues
+- [ ] Invocation pane exposes keyboard shortcuts (e.g., `r`) to rerun the highlighted tool without re-registering
+- [ ] Results history refreshes on a fixed cadence (e.g., every poll tick) and renders within the curses UI without tearing
+- [ ] Results persisted in corpus with links back to tool invocation
+
+## Test Plan
+- Validate tool registration lifecycle and result persistence
+- Exercise curses navigation between catalog and invocation panes (arrow keys, tab cycling)
+- Verify rerun shortcuts dispatch Function Caller requests using the cached registration metadata
+- Confirm results history refresh cadence matches the configured poll interval and reflects new corpus entries
+
+## Runbook
+- Configure Tools Factory and Function Caller URLs, wiring them into the shared `swiftcurseskit` view models used by both panes
+- Ensure invocation responses append to the persistent results history buffer rendered in the curses interface
+- Monitor poll cadence to keep the results history synchronized without flicker; adjust timer intervals if rendering lags
+
+## Hand-off to Codex
+> Wire Tools Factory and Function Caller endpoints into the shared `swiftcurseskit` view models, implement the curses panes for registration/invocation, and persist invocation outputs to the on-screen history and corpus.

--- a/docs/tutor/modules/06-teatro-gui-spec-only-integration.md
+++ b/docs/tutor/modules/06-teatro-gui-spec-only-integration.md
@@ -1,0 +1,28 @@
+# Module 06 — Teatro GUI: Spec-Only Integration
+
+**Outcome**: Deliver spec-derived browsing panes in `swiftcurseskit` that surface corpora, baselines/drift, and planner runs without relying on GUI-only shortcuts.
+
+## What you’ll ship
+A curses workspace built with `swiftcurseskit` that renders corpora, baseline lineage, and planner execution history straight from the documented APIs.
+
+## Specs to read
+- The same specs from Modules 02–05 (persist, awareness, planner, tools, function caller)
+
+## Behavioral acceptance
+- [ ] Each pane (corpora, baselines, planner runs) loads exclusively from documented HTTP responses
+- [ ] Keyboard navigation transitions between panes and datasets without stale state or hidden shortcuts
+- [ ] Rendered records stay read-only and match spec-defined schemas
+- [ ] Missing capability paths echo the documented guidance inside the curses views
+
+## Test plan
+- Simulate navigation keystrokes to move between corpora, baseline timelines, and planner runs
+- Assert rendered cells map 1:1 with spec payloads and remain read-only
+- Verify only documented endpoints are invoked when refreshing panes
+- Snapshot the curses output against canned API fixtures to prevent regression drift
+
+## Runbook
+- Wire FountainAI client responses directly into `swiftcurseskit` list/detail components for each pane
+- Ensure keyboard commands stay in sync with HTTP refresh loops instead of GUI affordances
+
+## Hand-off to Codex
+> Surface the HTTP responses from the documented APIs in the `swiftcurseskit` panes and keep capability guidance visible inside the terminal experience. No direct file or DB access.

--- a/docs/tutor/modules/07-observability-and-guards.md
+++ b/docs/tutor/modules/07-observability-and-guards.md
@@ -1,0 +1,26 @@
+# Module 07 — Observability & Guards
+
+**Outcome**: Extend the Swift curses dashboard with live widgets that surface gateway budgets, rate limits, and guard prompts in-line with operator workflows.
+
+## What you’ll ship
+Swift `swiftcurseskit` indicators that paint budget/rate-limit states, prompt overlays for destructive operations, and guard status banners that refresh alongside the terminal dashboard.
+
+## Specs to read
+- Gateway OpenAPIs: budget breaker, rate limiter, destructive operations guard, security sentinel
+
+## Behavioral acceptance
+- [ ] Gateway budget and rate-limit headers are polled on the curses dashboard cadence and update the corresponding widgets without flicker
+- [ ] Sensitive/destructive calls require keyboard confirmation within the curses prompt and block until the gateway guard approves
+- [ ] Guard alerts render as terminal overlays that clear on acknowledgment while the API response metadata remains visible for audit
+- [ ] Metrics remain available via `/metrics` or equivalent endpoints for downstream collectors
+
+## Test plan
+- Exercise simulated throttling to verify curses indicators reflect header changes and API responses stay correct
+- Trigger guard rails to confirm keyboard confirmation flows mirror gateway decisions and that API contracts remain honored
+
+## Runbook
+- Configure gateway base URLs and route response headers/metadata into `swiftcurseskit` data sources feeding the dashboard widgets
+- Persist and rehydrate operator prompts within the curses UI so guard dialogues survive screen refreshes and reconnects
+
+## Hand-off to Codex
+> Wire gateway metadata into the Swift terminal UI via `swiftcurseskit` components and maintain operator prompts end-to-end in the curses experience.

--- a/docs/tutor/modules/08-reasoning-streams-midi2-optional.md
+++ b/docs/tutor/modules/08-reasoning-streams-midi2-optional.md
@@ -1,0 +1,29 @@
+# Module 08 — Reasoning Streams (Optional, MIDI2)
+
+**Outcome**: Stream planner/awareness events as SSE-over-MIDI for transparency; add basic transport controls.
+
+## What you’ll ship
+A Swift `swiftcurseskit` dashboard that renders the SSE-over-MIDI stream viewer in the left pane with event metadata on the right, anchored by a status bar showing transport state and connection health. The dashboard must map keyboard controls (`space` toggles play/pause, `r` rewinds to the first event, `n` steps to the next event) and surface on-screen hints so terminal users discover the bindings.
+
+## Specs to read
+- Planner/Awareness streaming endpoints
+- MIDI2 transport interfaces (consumer side)
+
+## Behavioral acceptance
+- [ ] Live stream appears with event sequencing; transport works (play/stop/replay) via documented keyboard controls
+- [ ] Curses dashboard redraws at the configured cadence without frame tearing and survives terminal resize events
+- [ ] No out-of-spec/private calls; only documented streaming endpoints
+
+## Test plan
+- Fixture-based stream playback and UI timeline assertions
+- Curses transport harness that sends keyboard events (`space`, `r`, `n`) and asserts transport state transitions
+- Integration test that exercises redraw cadence (e.g., 250 ms ticker) and verifies layout recovery after simulated `SIGWINCH`
+
+## Runbook
+- Bind planner and awareness SSE endpoints to `swiftcurseskit` stream widgets via the MIDI2 client adapter; confirm the MIDI client identifier matches the terminal session and is discoverable to the OS MIDI stack.
+- Export `MIDI_CLIENT_NAME` (or platform equivalent) before launching the curses dashboard so the MIDI2 bridge registers correctly, then `swift run` the module with terminal colors enabled.
+- Validate the dashboard by connecting to staging endpoints first, watching the transport status bar for latency/backpressure indicators, and only then switch to production URLs.
+- Document the expected keyboard shortcuts in the deployment notes so on-call engineers can triage from an SSH session without a pointing device.
+
+## Hand-off to Codex
+> Implement a curses-native event stream viewer that wires planner/awareness SSE endpoints into `swiftcurseskit` components, includes keyboard transport controls, and configures the MIDI client for terminal execution.

--- a/libs/ApiClientsCore/Sources/ApiClientsCore/HTTP.swift
+++ b/libs/ApiClientsCore/Sources/ApiClientsCore/HTTP.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public enum HTTPMethod: String, Sendable {
     case GET, POST, PUT, PATCH, DELETE

--- a/libs/FountainAIAdapters/Sources/FountainAIAdapters/OpenAIAdapter.swift
+++ b/libs/FountainAIAdapters/Sources/FountainAIAdapters/OpenAIAdapter.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import FountainAICore
 
 public final class OpenAIAdapter: LLMService {


### PR DESCRIPTION
## Summary
- import the Tutor Path v1.0.0 documentation into docs/tutor with release notes and authoring guidance
- add a TutorPathModule1Tests target and service discovery test that scans OpenAPI specs for health and capabilities endpoints
- gate macOS-specific executables and add FoundationNetworking fallbacks so Linux builds succeed

## Testing
- swift test --filter TutorPathModule1Tests

------
https://chatgpt.com/codex/tasks/task_b_68cf951d4424833387a24070108810ee