### PR TITLE
Add Tutor dashboard terminal app and capability parsing updates

### DIFF
--- a/Configuration/tutor-dashboard.env.example
+++ b/Configuration/tutor-dashboard.env.example
@@ -1,0 +1,11 @@
+# Default endpoints for the Tutor dashboard runtime.
+# Copy to a custom file or override via environment variables as needed.
+
+AWARENESS_URL=http://127.0.0.1:8001
+BOOTSTRAP_URL=http://127.0.0.1:8002
+PLANNER_URL=http://127.0.0.1:8003
+FUNCTION_CALLER_URL=http://127.0.0.1:8004
+PERSIST_URL=http://127.0.0.1:8005
+FOUNTAINSTORE_URL=http://127.0.0.1:8005
+FOUNTAIN_GATEWAY_URL=http://127.0.0.1:8080
+TOOLS_FACTORY_URL=http://127.0.0.1:8011

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ var fullProducts: [Product] = [
     .library(name: "FlexBridge", targets: ["FlexBridge"]),
     .library(name: "SSEOverMIDI", targets: ["SSEOverMIDI"]),
     .library(name: "TutorDashboard", targets: ["TutorDashboard"]),
+    .executable(name: "tutor-dashboard", targets: ["tutor-dashboard"]),
     .executable(name: "gateway-server", targets: ["gateway-server"]),
     .executable(name: "fountain-gateway", targets: ["gateway-server"]),
     .executable(name: "clientgen-service", targets: ["clientgen-service"]),
@@ -53,6 +54,7 @@ var leanProducts: [Product] = [
     .library(name: "SemanticBrowserAPI", targets: ["SemanticBrowserAPI"]),
     .library(name: "LLMGatewayAPI", targets: ["LLMGatewayAPI"]),
     .library(name: "TutorDashboard", targets: ["TutorDashboard"]),
+    .executable(name: "tutor-dashboard", targets: ["tutor-dashboard"]),
     .executable(name: "publishing-frontend", targets: ["publishing-frontend"])
 ]
 
@@ -123,6 +125,14 @@ var fullTargets: [Target] = [
             .product(name: "Yams", package: "Yams")
         ],
         path: "libs/TutorDashboard/Sources"
+    ),
+    .executableTarget(
+        name: "tutor-dashboard",
+        dependencies: [
+            "TutorDashboard",
+            .product(name: "SwiftCursesKit", package: "swiftcurseskit")
+        ],
+        path: "apps/TutorDashboardApp"
     ),
     .target(
         name: "FountainAICore",
@@ -989,6 +999,14 @@ var uiLeanTargets: [Target] = [
             .product(name: "Yams", package: "Yams")
         ],
         path: "libs/TutorDashboard/Sources"
+    ),
+    .executableTarget(
+        name: "tutor-dashboard",
+        dependencies: [
+            "TutorDashboard",
+            .product(name: "SwiftCursesKit", package: "swiftcurseskit")
+        ],
+        path: "apps/TutorDashboardApp"
     ),
     .target(name: "FountainAICore", dependencies: [], path: "libs/FountainAICore/Sources/FountainAICore"),
     .target(name: "FountainAIAdapters", dependencies: ["FountainAICore", "LLMGatewayAPI", "SemanticBrowserAPI", "PersistAPI"], path: "libs/FountainAIAdapters/Sources/FountainAIAdapters"),

--- a/Tests/TutorPathModule1Tests/ServiceStatusPollerTests.swift
+++ b/Tests/TutorPathModule1Tests/ServiceStatusPollerTests.swift
@@ -62,6 +62,7 @@ final class ServiceStatusPollerTests: XCTestCase {
         XCTAssertEqual(status.capabilities.first?.path, "/capabilities")
         XCTAssertTrue(status.capabilities.first?.ok ?? false)
         XCTAssertEqual(status.capabilities.first?.capabilities, ["corpus", "documents"])
+        XCTAssertEqual(status.capabilities.first?.missingCapabilities, ["empty", "flag"])
     }
 
     func testFetchStatusCapturesFailures() async {

--- a/apps/TutorDashboardApp/EnvironmentLoader.swift
+++ b/apps/TutorDashboardApp/EnvironmentLoader.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+struct DashboardConfiguration: Sendable {
+    let openAPIRoot: URL
+    let environment: [String: String]
+    let refreshIntervalTicks: Int
+
+    static func load(options: CommandLineOptions, fileManager: FileManager = .default) throws -> DashboardConfiguration {
+        let workingDirectory = URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
+        let openAPIRoot = try resolveOpenAPIRoot(options: options, workingDirectory: workingDirectory, fileManager: fileManager)
+        let environment = EnvironmentLoader.load(
+            workingDirectory: workingDirectory,
+            explicitFile: options.environmentFileOverride
+        )
+        let refreshSeconds = resolveRefreshInterval(options: options, environment: environment)
+        let ticks = max(1, Int((refreshSeconds / 0.05).rounded(.toNearestOrAwayFromZero)))
+        return DashboardConfiguration(openAPIRoot: openAPIRoot, environment: environment, refreshIntervalTicks: ticks)
+    }
+
+    private static func resolveOpenAPIRoot(
+        options: CommandLineOptions,
+        workingDirectory: URL,
+        fileManager: FileManager
+    ) throws -> URL {
+        let overridePath = options.openAPIRootOverride
+            ?? ProcessInfo.processInfo.environment["TUTOR_DASHBOARD_OPENAPI_ROOT"]
+
+        let rootURL: URL
+        if let overridePath, !overridePath.isEmpty {
+            let overrideURL = URL(fileURLWithPath: overridePath, isDirectory: true, relativeTo: workingDirectory)
+            rootURL = overrideURL.standardizedFileURL
+        } else {
+            rootURL = workingDirectory.appendingPathComponent("openapi/v1", isDirectory: true)
+        }
+
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: rootURL.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+            throw DashboardConfigurationError.missingOpenAPIDirectory(rootURL)
+        }
+
+        return rootURL
+    }
+
+    private static func resolveRefreshInterval(options: CommandLineOptions, environment: [String: String]) -> Double {
+        if let override = options.refreshIntervalOverride {
+            return max(1.0, override)
+        }
+        if let environmentValue = environment["TUTOR_DASHBOARD_REFRESH_SECONDS"],
+           let value = Double(environmentValue), value > 0 {
+            return value
+        }
+        return 5.0
+    }
+}
+
+enum DashboardConfigurationError: Error, LocalizedError {
+    case missingOpenAPIDirectory(URL)
+
+    var errorDescription: String? {
+        switch self {
+        case let .missingOpenAPIDirectory(url):
+            return "OpenAPI directory not found at \(url.path)"
+        }
+    }
+}
+
+enum EnvironmentLoader {
+    static func load(workingDirectory: URL, explicitFile: String?) -> [String: String] {
+        var defaults: [String: String] = [:]
+        var visited: Set<URL> = []
+
+        let environment = ProcessInfo.processInfo.environment
+        let fileManager = FileManager.default
+
+        let candidates: [URL] = [
+            explicitFile.map { URL(fileURLWithPath: $0, relativeTo: workingDirectory) },
+            environment["TUTOR_DASHBOARD_ENV"].map { URL(fileURLWithPath: $0, relativeTo: workingDirectory) },
+            workingDirectory.appendingPathComponent(".env", isDirectory: false),
+            workingDirectory.appendingPathComponent(".env.example", isDirectory: false),
+            workingDirectory.appendingPathComponent("Configuration/tutor-dashboard.env", isDirectory: false),
+            workingDirectory.appendingPathComponent("Configuration/tutor-dashboard.env.example", isDirectory: false)
+        ].compactMap { $0?.standardizedFileURL }
+
+        for url in candidates where visited.insert(url).inserted {
+            guard fileManager.fileExists(atPath: url.path) else { continue }
+            guard let contents = try? String(contentsOf: url, encoding: .utf8) else { continue }
+            let parsed = parseDotEnv(contents)
+            defaults.merge(parsed) { current, _ in current }
+        }
+
+        return defaults.merging(environment) { current, override in override }
+    }
+
+    private static func parseDotEnv(_ contents: String) -> [String: String] {
+        var values: [String: String] = [:]
+        contents.enumerateLines { rawLine, _ in
+            let trimmed = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else { return }
+            guard let separatorIndex = trimmed.firstIndex(of: "=") else { return }
+            let keySlice = trimmed[..<separatorIndex].trimmingCharacters(in: .whitespaces)
+            let valueSlice = trimmed[trimmed.index(after: separatorIndex)...].trimmingCharacters(in: .whitespaces)
+            let stripped = stripQuotes(valueSlice)
+            if !keySlice.isEmpty {
+                values[String(keySlice)] = stripped
+            }
+        }
+        return values
+    }
+
+    private static func stripQuotes(_ value: String) -> String {
+        if value.hasPrefix("\"") && value.hasSuffix("\"") && value.count >= 2 {
+            return String(value.dropFirst().dropLast())
+        }
+        if value.hasPrefix("'") && value.hasSuffix("'") && value.count >= 2 {
+            return String(value.dropFirst().dropLast())
+        }
+        return value
+    }
+}

--- a/apps/TutorDashboardApp/ServiceRowModel.swift
+++ b/apps/TutorDashboardApp/ServiceRowModel.swift
@@ -1,0 +1,139 @@
+import Foundation
+import TutorDashboard
+
+struct ServiceRowModel: Sendable, Equatable {
+    let descriptor: ServiceDescriptor
+    let baseURL: URL
+    let healthStatuses: [ServiceStatus.EndpointStatus]
+    let capabilityStatuses: [ServiceStatus.EndpointStatus]
+
+    init(status: ServiceStatus) {
+        self.descriptor = status.descriptor
+        self.baseURL = status.baseURL
+        self.healthStatuses = status.health
+        self.capabilityStatuses = status.capabilities
+    }
+
+    var serviceName: String { descriptor.title }
+
+    var baseDisplay: String { baseURL.absoluteString }
+
+    var healthSummary: String {
+        guard !healthStatuses.isEmpty else { return "—" }
+        if healthStatuses.allSatisfy({ $0.ok }) {
+            return healthStatuses.count == 1 ? "Healthy" : "Healthy (\(healthStatuses.count))"
+        }
+        let problems = healthStatuses.compactMap { status -> String? in
+            guard !status.ok else { return nil }
+            if let code = status.statusCode {
+                return "\(status.path) \(code)"
+            }
+            if let message = status.message, !message.isEmpty {
+                return "\(status.path) \(message)"
+            }
+            return "\(status.path) error"
+        }
+        return problems.joined(separator: "; ")
+    }
+
+    var capabilitySummary: String {
+        if capabilityStatuses.isEmpty {
+            return descriptor.capabilityPaths.isEmpty ? "—" : "Needs: capabilities"
+        }
+
+        var parts: [String] = []
+        let available = Set(capabilityStatuses.flatMap { $0.capabilities }).sorted()
+        let missing = Set(capabilityStatuses.flatMap { $0.missingCapabilities }).sorted()
+        let failures = capabilityStatuses.filter { !$0.ok }
+
+        if !available.isEmpty {
+            parts.append(available.joined(separator: ", "))
+        }
+        if !missing.isEmpty {
+            parts.append("Needs: " + missing.joined(separator: ", "))
+        }
+        for failure in failures {
+            if let code = failure.statusCode {
+                parts.append("Error \(failure.path) \(code)")
+            } else if let message = failure.message, !message.isEmpty {
+                parts.append("Error \(failure.path) \(message)")
+            } else {
+                parts.append("Error \(failure.path)")
+            }
+        }
+
+        return parts.isEmpty ? "—" : parts.joined(separator: " | ")
+    }
+
+    var detailLines: [String] {
+        var lines: [String] = []
+        lines.append("Service: \(descriptor.title)")
+        lines.append("Base URL: \(baseURL.absoluteString)")
+        if let binary = descriptor.binaryName {
+            lines.append("Binary: \(binary)")
+        }
+        lines.append("Port: \(descriptor.port)")
+        lines.append("Health endpoints:")
+        if healthStatuses.isEmpty {
+            lines.append("  • None documented in OpenAPI spec")
+        } else {
+            for status in healthStatuses {
+                let symbol = status.ok ? "✓" : "✗"
+                let detail: String
+                if status.ok {
+                    if let code = status.statusCode {
+                        detail = "HTTP \(code)"
+                    } else {
+                        detail = "reachable"
+                    }
+                } else if let code = status.statusCode {
+                    detail = "HTTP \(code)"
+                } else if let message = status.message, !message.isEmpty {
+                    detail = message
+                } else {
+                    detail = "unreachable"
+                }
+                lines.append("  \(symbol) \(status.path) — \(detail)")
+            }
+        }
+
+        lines.append("Capabilities:")
+        if capabilityStatuses.isEmpty {
+            if descriptor.capabilityPaths.isEmpty {
+                lines.append("  • No capabilities endpoint documented")
+            } else {
+                lines.append("  • Needs: \(descriptor.capabilityPaths.joined(separator: ", "))")
+            }
+        } else {
+            for status in capabilityStatuses {
+                if status.ok {
+                    let available = status.capabilities.joined(separator: ", ")
+                    let missing = status.missingCapabilities.joined(separator: ", ")
+                    let suffix: String
+                    if !available.isEmpty && !missing.isEmpty {
+                        suffix = "available: \(available); needs: \(missing)"
+                    } else if !available.isEmpty {
+                        suffix = "available: \(available)"
+                    } else if !missing.isEmpty {
+                        suffix = "needs: \(missing)"
+                    } else {
+                        suffix = "reachable"
+                    }
+                    lines.append("  ✓ \(status.path) — \(suffix)")
+                } else {
+                    let detail: String
+                    if let code = status.statusCode {
+                        detail = "HTTP \(code)"
+                    } else if let message = status.message, !message.isEmpty {
+                        detail = message
+                    } else {
+                        detail = "unreachable"
+                    }
+                    lines.append("  ✗ \(status.path) — \(detail)")
+                }
+            }
+        }
+
+        return lines
+    }
+}

--- a/apps/TutorDashboardApp/ServiceTableFormatter.swift
+++ b/apps/TutorDashboardApp/ServiceTableFormatter.swift
@@ -1,0 +1,207 @@
+import Foundation
+import SwiftCursesKit
+
+struct ServiceTableFormatter: Sendable {
+    let rows: [ServiceRowModel]
+    let selectedIndex: Int
+    let isRefreshing: Bool
+    let message: String?
+
+    func lines(width: Int, height: Int?) -> [String] {
+        guard width > 0 else { return [] }
+
+        let columnLayout = ColumnLayout(rows: rows, width: width, selectedIndex: selectedIndex)
+        var rendered: [String] = []
+        rendered.append(columnLayout.headerLine())
+        if width >= 2 {
+            rendered.append(String(repeating: "─", count: width))
+        } else {
+            rendered.append("─")
+        }
+
+        let availableHeight = height.map { max(0, $0 - rendered.count) }
+        let visibleRows = rowsToDisplay(limit: availableHeight)
+        rendered.append(contentsOf: visibleRows.map { columnLayout.render(row: $0.row, index: $0.index, width: width) })
+
+        if rendered.count < (height ?? Int.max), let statusLine = statusLine(width: width) {
+            rendered.append(statusLine)
+        }
+
+        return rendered
+    }
+
+    private func rowsToDisplay(limit: Int?) -> [(row: ServiceRowModel, index: Int)] {
+        guard !rows.isEmpty else { return [] }
+        let limit = limit ?? rows.count
+        guard limit > 0 else { return [] }
+        let centerOffset = limit / 2
+        let start = max(0, min(selectedIndex - centerOffset, rows.count - limit))
+        let end = min(rows.count, start + limit)
+        return rows[start..<end].enumerated().map { (offset, row) in
+            (row: row, index: start + offset)
+        }
+    }
+
+    private func statusLine(width: Int) -> String? {
+        if let message, !message.isEmpty {
+            return pad(message, width: width)
+        }
+        if isRefreshing {
+            return pad("Refreshing…", width: width)
+        }
+        if rows.isEmpty {
+            return pad("No services discovered", width: width)
+        }
+        return nil
+    }
+
+    private func pad(_ text: String, width: Int) -> String {
+        guard width > 0 else { return "" }
+        if text.count >= width {
+            return String(text.prefix(width))
+        }
+        return text + String(repeating: " ", count: width - text.count)
+    }
+
+    private struct ColumnLayout {
+        let selectionWidth = 2
+        let spacing = 2
+        let nameWidth: Int
+        let baseWidth: Int
+        let healthWidth: Int
+        let capabilitiesWidth: Int
+        let rows: [ServiceRowModel]
+        let totalWidth: Int
+        let selectedIndex: Int
+
+        init(rows: [ServiceRowModel], width: Int, selectedIndex: Int) {
+            self.rows = rows
+            self.totalWidth = max(20, width)
+            self.selectedIndex = selectedIndex
+            let metrics = ColumnMetrics(rows: rows)
+            let available = max(0, totalWidth - selectionWidth - spacing * 3)
+            let desiredName = max(metrics.maxName, 16)
+            let desiredBase = max(metrics.maxBase, 20)
+            let desiredHealth = max(metrics.maxHealth, 12)
+            var name = min(desiredName, available / 3)
+            var base = min(desiredBase, available / 3 + available / 6)
+            var health = min(desiredHealth, available / 5)
+            if name + base + health > available {
+                let overflow = name + base + health - available
+                let reduceBase = min(overflow, max(0, base - 16))
+                base -= reduceBase
+                let reduceName = min(overflow - reduceBase, max(0, name - 12))
+                name -= reduceName
+                let reduceHealth = min(overflow - reduceBase - reduceName, max(0, health - 10))
+                health -= reduceHealth
+            }
+            let remaining = max(0, available - name - base - health)
+            let desiredCapabilities = max(metrics.maxCapabilities, 16)
+            var capability = min(desiredCapabilities, remaining)
+            if capability < 8 {
+                capability = max(8, remaining)
+            }
+            self.nameWidth = max(12, name)
+            self.baseWidth = max(16, base)
+            self.healthWidth = max(10, health)
+            self.capabilitiesWidth = max(8, capability)
+        }
+
+        func headerLine() -> String {
+            renderColumns(
+                indicator: "  ",
+                name: "Service",
+                base: "Base URL",
+                health: "Health",
+                capabilities: "Capabilities"
+            )
+        }
+
+        func render(row: ServiceRowModel, index: Int, width: Int) -> String {
+            let indicator = index == selectedIndex ? "➤ " : "  "
+            return renderColumns(
+                indicator: indicator,
+                name: row.serviceName,
+                base: row.baseDisplay,
+                health: row.healthSummary,
+                capabilities: row.capabilitySummary,
+                width: width
+            )
+        }
+
+        private func renderColumns(
+            indicator: String,
+            name: String,
+            base: String,
+            health: String,
+            capabilities: String,
+            width: Int? = nil
+        ) -> String {
+            let total = width ?? totalWidth
+            let padded = indicator
+                + pad(name, width: nameWidth)
+                + String(repeating: " ", count: spacing)
+                + pad(base, width: baseWidth)
+                + String(repeating: " ", count: spacing)
+                + pad(health, width: healthWidth)
+                + String(repeating: " ", count: spacing)
+                + pad(capabilities, width: capabilitiesWidth)
+            if padded.count <= total {
+                return padded + String(repeating: " ", count: max(0, total - padded.count))
+            }
+            return String(padded.prefix(total))
+        }
+
+        private func pad(_ text: String, width: Int) -> String {
+            guard width > 0 else { return "" }
+            if text.count >= width {
+                return String(text.prefix(width))
+            }
+            return text + String(repeating: " ", count: width - text.count)
+        }
+    }
+
+    private struct ColumnMetrics {
+        let maxName: Int
+        let maxBase: Int
+        let maxHealth: Int
+        let maxCapabilities: Int
+
+        init(rows: [ServiceRowModel]) {
+            self.maxName = max(16, rows.map { $0.serviceName.count }.max() ?? 16)
+            self.maxBase = max(20, rows.map { $0.baseDisplay.count }.max() ?? 20)
+            self.maxHealth = max(12, rows.map { $0.healthSummary.count }.max() ?? 12)
+            self.maxCapabilities = max(16, rows.map { $0.capabilitySummary.count }.max() ?? 16)
+        }
+    }
+}
+
+struct ServiceTableWidget: Widget {
+    var rows: [ServiceRowModel]
+    var selectedIndex: Int
+    var isRefreshing: Bool
+    var message: String?
+
+    func measure(in constraints: LayoutConstraints) -> LayoutSize {
+        let height = max(6, min(constraints.maxHeight, rows.count + 4))
+        let width = max(40, constraints.maxWidth)
+        return LayoutSize(width: width, height: height)
+    }
+
+    func render(in frame: LayoutRect, buffer: inout RenderBuffer) {
+        guard frame.size.width > 0, frame.size.height > 0 else { return }
+        let formatter = ServiceTableFormatter(
+            rows: rows,
+            selectedIndex: selectedIndex,
+            isRefreshing: isRefreshing,
+            message: message
+        )
+        let renderedLines = formatter.lines(width: frame.size.width, height: frame.size.height)
+        var currentY = frame.origin.y
+        for line in renderedLines.prefix(frame.size.height) {
+            let point = LayoutPoint(x: frame.origin.x, y: currentY)
+            buffer.write(String(line.prefix(frame.size.width)), at: point, maxWidth: frame.size.width)
+            currentY += 1
+        }
+    }
+}

--- a/apps/TutorDashboardApp/TutorDashboardApp.swift
+++ b/apps/TutorDashboardApp/TutorDashboardApp.swift
@@ -1,0 +1,232 @@
+import Foundation
+import SwiftCursesKit
+import TutorDashboard
+
+struct TutorDashboardApp: TerminalApp {
+    var configuration: DashboardConfiguration
+    private var discovery: ServiceDiscovery
+    private var poller: ServiceStatusPoller
+
+    private var statuses: [ServiceStatus] = []
+    private var selectedIndex: Int = 0
+    private var isRefreshing: Bool = false
+    private var lastRefreshTick: Int = .min
+    private var tickCount: Int = 0
+    private var performedInitialRefresh = false
+    private var lastUpdated: Date?
+    private var message: String? = "Loading OpenAPI specs…"
+    private var escapeState: EscapeSequenceState = .idle
+
+    init(configuration: DashboardConfiguration) {
+        self.configuration = configuration
+        self.discovery = ServiceDiscovery(openAPIRoot: configuration.openAPIRoot)
+        self.poller = ServiceStatusPoller()
+    }
+
+    var banner: String { "FountainAI Tutor Dashboard" }
+
+    var body: some Scene {
+        Screen {
+            VStack(spacing: 1) {
+                Title("FountainAI Tutor Dashboard")
+                WidgetView(ServiceTableWidget(
+                    rows: rows,
+                    selectedIndex: selectedIndex,
+                    isRefreshing: isRefreshing,
+                    message: tableMessage
+                ))
+                LogView(
+                    lines: detailLines,
+                    maximumVisibleLines: 8
+                )
+                StatusBar(items: statusBarItems)
+            }
+            .padding(1)
+        }
+    }
+
+    mutating func onEvent(_ event: Event, context: AppContext) async {
+        switch event {
+        case .tick:
+            tickCount += 1
+            await handleTick()
+        case let .key(key):
+            await handleKey(key, context: context)
+        }
+    }
+
+    private mutating func handleTick() async {
+        if !performedInitialRefresh {
+            performedInitialRefresh = true
+            await refreshStatuses()
+            return
+        }
+
+        if tickCount - lastRefreshTick >= configuration.refreshIntervalTicks {
+            await refreshStatuses()
+        }
+    }
+
+    private mutating func handleKey(_ key: KeyEvent, context: AppContext) async {
+        switch key {
+        case let .character(character):
+            await interpret(character: character, context: context)
+        }
+    }
+
+    private mutating func interpret(character: Character, context: AppContext) async {
+        switch escapeState {
+        case .idle:
+            if character == "\u{1B}" {
+                escapeState = .sawEscape
+                return
+            }
+            await handleBaseKey(character: character, context: context)
+        case .sawEscape:
+            if character == "[" {
+                escapeState = .sawBracket
+            } else {
+                escapeState = .idle
+                await handleBaseKey(character: character, context: context)
+            }
+        case .sawBracket:
+            escapeState = .idle
+            switch character {
+            case "A":
+                moveSelection(delta: -1)
+            case "B":
+                moveSelection(delta: 1)
+            case "H":
+                moveSelection(to: 0)
+            case "F":
+                moveSelection(to: rows.count - 1)
+            default:
+                break
+            }
+        }
+    }
+
+    private mutating func handleBaseKey(character: Character, context: AppContext) async {
+        switch character {
+        case "q", "Q":
+            await context.quit()
+        case "r", "R":
+            await refreshStatuses()
+        case "j", "J", "\u{000A}", "\u{000D}", "\t":
+            moveSelection(delta: 1)
+        case "k", "K":
+            moveSelection(delta: -1)
+        case "g":
+            moveSelection(to: 0)
+        case "G":
+            moveSelection(to: rows.count - 1)
+        default:
+            break
+        }
+    }
+
+    private mutating func moveSelection(delta: Int) {
+        guard !rows.isEmpty else { return }
+        let newIndex = max(0, min(rows.count - 1, selectedIndex + delta))
+        selectedIndex = newIndex
+    }
+
+    private mutating func moveSelection(to index: Int) {
+        guard !rows.isEmpty else { return }
+        let clamped = max(0, min(rows.count - 1, index))
+        selectedIndex = clamped
+    }
+
+    private mutating func refreshStatuses() async {
+        guard !isRefreshing else { return }
+        isRefreshing = true
+        message = "Refreshing…"
+        defer {
+            isRefreshing = false
+            lastRefreshTick = tickCount
+        }
+
+        do {
+            let descriptors = try discovery.loadServices()
+            let fetched = await poller.fetchStatus(for: descriptors, environment: configuration.environment)
+            statuses = fetched
+            if selectedIndex >= rows.count {
+                selectedIndex = max(0, rows.count - 1)
+            }
+            lastUpdated = Date()
+            message = rows.isEmpty ? "No services discovered" : nil
+        } catch {
+            message = "Failed to load OpenAPI specs: \(error.localizedDescription)"
+        }
+    }
+
+    private var rows: [ServiceRowModel] {
+        statuses.map(ServiceRowModel.init(status:))
+    }
+
+    private var tableMessage: String? {
+        if let message {
+            return message
+        }
+        if rows.isEmpty {
+            return "Waiting for service status…"
+        }
+        return nil
+    }
+
+    private var detailLines: [String] {
+        var lines: [String] = []
+        if let row = rows[safe: selectedIndex] {
+            lines.append(contentsOf: row.detailLines)
+        } else if let message {
+            lines.append(message)
+        } else {
+            lines.append("Select a service to view details.")
+        }
+        lines.append(contentsOf: instructions)
+        return lines
+    }
+
+    private var instructions: [String] {
+        [
+            "Use ↑/↓ or Tab to move between services.",
+            "Press r to refresh, q to quit."
+        ]
+    }
+
+    private var statusBarItems: [StatusBar.Item] {
+        var items: [StatusBar.Item] = [
+            .label("q: quit"),
+            .label("r: refresh"),
+            .label("↑/↓: move"),
+            .label("tab: cycle"),
+            .label("services: \(rows.count)")
+        ]
+        if isRefreshing {
+            items.append(.label("refreshing…"))
+        } else if let lastUpdated {
+            items.append(.label("updated: \(formatted(time: lastUpdated))"))
+        }
+        return items
+    }
+
+    private func formatted(time: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        formatter.timeZone = .current
+        return formatter.string(from: time)
+    }
+
+    private enum EscapeSequenceState {
+        case idle
+        case sawEscape
+        case sawBracket
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        guard index >= 0, index < count else { return nil }
+        return self[index]
+    }
+}

--- a/apps/TutorDashboardApp/TutorDashboardCLI.swift
+++ b/apps/TutorDashboardApp/TutorDashboardCLI.swift
@@ -1,0 +1,107 @@
+import Foundation
+import SwiftCursesKit
+import TutorDashboard
+
+@main
+struct TutorDashboardCLI {
+    static func main() async {
+        do {
+            let rawArguments = Array(CommandLine.arguments.dropFirst())
+            let options = try CommandLineOptions.parse(rawArguments)
+
+            if options.showHelp {
+                print(CommandLineOptions.helpText)
+                return
+            }
+
+            let configuration = try DashboardConfiguration.load(options: options)
+
+            if options.previewMode {
+                let preview = TutorDashboardPreview(configuration: configuration)
+                try await preview.render(width: options.previewWidth)
+                return
+            }
+
+            let app = TutorDashboardApp(configuration: configuration)
+            _ = try await app.run()
+        } catch {
+            let message = "TutorDashboard error: \(error.localizedDescription)\n"
+            FileHandle.standardError.write(Data(message.utf8))
+            exit(1)
+        }
+    }
+}
+
+struct CommandLineOptions: Sendable {
+    var showHelp: Bool = false
+    var previewMode: Bool = false
+    var previewWidth: Int = 100
+    var openAPIRootOverride: String?
+    var refreshIntervalOverride: Double?
+    var environmentFileOverride: String?
+
+    static let helpText: String = {
+        """
+        Usage: tutor-dashboard [options]
+
+        Options:
+          --help                   Show this help message and exit
+          --preview                Render a headless snapshot of the service table and exit
+          --preview-width=<cols>   Width to use for preview output (default: 100)
+          --openapi-root=<path>    Override the OpenAPI directory used for service discovery
+          --refresh-seconds=<n>    Override the automatic refresh cadence (seconds)
+          --env-file=<path>        Load environment defaults from a specific dotenv file
+        """
+    }()
+
+    static func parse(_ arguments: [String]) throws -> CommandLineOptions {
+        var parsed = CommandLineOptions()
+
+        for argument in arguments {
+            if argument == "--help" || argument == "-h" {
+                parsed.showHelp = true
+            } else if argument == "--preview" {
+                parsed.previewMode = true
+            } else if let value = argument.value(forPrefix: "--preview-width=") {
+                guard let width = Int(value), width > 0 else {
+                    throw CommandLineError.invalidValue(argument)
+                }
+                parsed.previewWidth = max(40, width)
+            } else if let value = argument.value(forPrefix: "--openapi-root=") {
+                parsed.openAPIRootOverride = value
+            } else if let value = argument.value(forPrefix: "--refresh-seconds=") {
+                guard let seconds = Double(value), seconds > 0 else {
+                    throw CommandLineError.invalidValue(argument)
+                }
+                parsed.refreshIntervalOverride = seconds
+            } else if let value = argument.value(forPrefix: "--env-file=") {
+                parsed.environmentFileOverride = value
+            } else {
+                throw CommandLineError.unknownArgument(argument)
+            }
+        }
+
+        return parsed
+    }
+}
+
+enum CommandLineError: Error, LocalizedError {
+    case unknownArgument(String)
+    case invalidValue(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .unknownArgument(argument):
+            return "Unknown argument: \(argument)"
+        case let .invalidValue(argument):
+            return "Invalid value for argument: \(argument)"
+        }
+    }
+}
+
+private extension String {
+    func value(forPrefix prefix: String) -> String? {
+        guard hasPrefix(prefix) else { return nil }
+        return String(dropFirst(prefix.count))
+    }
+}

--- a/apps/TutorDashboardApp/TutorDashboardPreview.swift
+++ b/apps/TutorDashboardApp/TutorDashboardPreview.swift
@@ -1,0 +1,22 @@
+import Foundation
+import TutorDashboard
+
+struct TutorDashboardPreview {
+    var configuration: DashboardConfiguration
+
+    func render(width: Int) async throws {
+        let discovery = ServiceDiscovery(openAPIRoot: configuration.openAPIRoot)
+        let descriptors = try discovery.loadServices()
+        let poller = ServiceStatusPoller()
+        let statuses = await poller.fetchStatus(for: descriptors, environment: configuration.environment)
+        let rows = statuses.map(ServiceRowModel.init(status:))
+        let formatter = ServiceTableFormatter(
+            rows: rows,
+            selectedIndex: 0,
+            isRefreshing: false,
+            message: rows.isEmpty ? "No services discovered" : nil
+        )
+        let snapshot = formatter.lines(width: max(20, width), height: nil).joined(separator: "\n")
+        print(snapshot)
+    }
+}

--- a/docs/tutor/modules/01-spec-literacy-and-health.md
+++ b/docs/tutor/modules/01-spec-literacy-and-health.md
@@ -49,6 +49,7 @@ A terminal dashboard built with `swiftcurseskit` that renders documented service
 - Configure base URLs and keys from **_includes/env.md**
 - Wire `/v1/health` responses into the `swiftcurseskit` view model that feeds service row status indicators
 - Map `/v1/capabilities` payloads into `swiftcurseskit` list/detail components so operators can drill into capability explanations
+- Launch the dashboard with `swift run tutor-dashboard` (or `--preview` for a headless snapshot) to verify the table renders with live status data
 
 ## Hand-off to Codex
 > Build a service table that reads from the listed specs and queries `/v1/health` and `/v1/capabilities`. No hardcoded endpoints. Ensure Codex implementers connect those endpoints to the `swiftcurseskit` views described above, preserving the refresh cadence and keyboard navigation affordances.

--- a/libs/TutorDashboard/Sources/TutorDashboard/SendableShims.swift
+++ b/libs/TutorDashboard/Sources/TutorDashboard/SendableShims.swift
@@ -1,0 +1,3 @@
+import Foundation
+
+extension FileManager: @unchecked Sendable {}

--- a/libs/TutorDashboard/Sources/TutorDashboard/ServiceStatusPoller.swift
+++ b/libs/TutorDashboard/Sources/TutorDashboard/ServiceStatusPoller.swift
@@ -11,13 +11,22 @@ public struct ServiceStatus: Sendable, Equatable {
         public let statusCode: Int?
         public let message: String?
         public let capabilities: [String]
+        public let missingCapabilities: [String]
 
-        public init(path: String, ok: Bool, statusCode: Int?, message: String?, capabilities: [String] = []) {
+        public init(
+            path: String,
+            ok: Bool,
+            statusCode: Int?,
+            message: String?,
+            capabilities: [String] = [],
+            missingCapabilities: [String] = []
+        ) {
             self.path = path
             self.ok = ok
             self.statusCode = statusCode
             self.message = message
             self.capabilities = capabilities
+            self.missingCapabilities = missingCapabilities
         }
     }
 
@@ -38,7 +47,7 @@ public struct ServiceStatus: Sendable, Equatable {
     }
 }
 
-public struct ServiceStatusPoller: Sendable {
+public struct ServiceStatusPoller: @unchecked Sendable {
     private let session: URLSession
 
     public init(session: URLSession = .shared) {
@@ -91,13 +100,19 @@ public struct ServiceStatusPoller: Sendable {
 
         do {
             let response = try await client.send(APIRequest(method: .GET, url: url))
-            let capabilities = isCapabilities ? Self.parseCapabilities(from: response.data) : []
+            let capabilities: ([String], [String])
+            if isCapabilities {
+                capabilities = Self.parseCapabilities(from: response.data)
+            } else {
+                capabilities = ([], [])
+            }
             return ServiceStatus.EndpointStatus(
                 path: path,
                 ok: true,
                 statusCode: response.status,
                 message: nil,
-                capabilities: capabilities
+                capabilities: capabilities.0,
+                missingCapabilities: capabilities.1
             )
         } catch let APIError.httpStatus(code, body) {
             let message = body.isEmpty ? nil : body
@@ -119,27 +134,38 @@ public struct ServiceStatusPoller: Sendable {
         }
     }
 
-    private static func parseCapabilities(from data: Data) -> [String] {
+    private static func parseCapabilities(from data: Data) -> ([String], [String]) {
         guard !data.isEmpty,
               let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else { return [] }
+        else { return ([], []) }
 
         var available: [String] = []
+        var missing: [String] = []
         for (key, value) in object {
-            switch value {
-            case let bool as Bool where bool:
+            if isCapabilitySatisfied(value) {
                 available.append(key)
-            case let array as [Any] where !array.isEmpty:
-                available.append(key)
-            case let dict as [String: Any] where !dict.isEmpty:
-                available.append(key)
-            case let string as String where !string.isEmpty:
-                available.append(key)
-            default:
-                continue
+            } else {
+                missing.append(key)
             }
         }
 
-        return available.sorted()
+        return (available.sorted(), missing.sorted())
+    }
+
+    private static func isCapabilitySatisfied(_ value: Any) -> Bool {
+        switch value {
+        case let bool as Bool:
+            return bool
+        case let string as String:
+            return !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case let array as [Any]:
+            return !array.isEmpty
+        case let dict as [String: Any]:
+            return !dict.isEmpty
+        case let number as NSNumber:
+            return number.doubleValue != 0
+        default:
+            return false
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extend `ServiceStatusPoller` capability parsing and add sendable shims for Foundation types
- add a SwiftCursesKit-powered `tutor-dashboard` executable with service table UI, preview mode, and environment loading
- document the new dashboard workflow and ship a sample tutor-specific dotenv file

## Testing
- `swift test --filter TutorPathModule1Tests`
- `swift build --product tutor-dashboard`


------
https://chatgpt.com/codex/tasks/task_b_68cfa1d07fc883339aac5f716cfb6577