### PR TITLE
Silence FileManager Sendable warning

### DIFF
--- a/libs/TutorDashboard/Sources/TutorDashboard/SendableShims.swift
+++ b/libs/TutorDashboard/Sources/TutorDashboard/SendableShims.swift
@@ -1,3 +1,3 @@
 import Foundation
 
-extension FileManager: @unchecked Sendable {}
+extension FileManager: @retroactive @unchecked Sendable {}


### PR DESCRIPTION
## Summary
- mark the FileManager Sendable conformance as retroactive to acknowledge the extension applies to an imported type and suppress the Swift warning

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68cff5a24a8c8333967248943bfe5639