### PR TITLE
docs: add execution guidance to tutor modules

### DIFF
--- a/docs/tutor/modules/01-spec-literacy-and-health.md
+++ b/docs/tutor/modules/01-spec-literacy-and-health.md
@@ -46,10 +46,12 @@ A terminal dashboard built with `swiftcurseskit` that renders documented service
 - Simulate navigation keystrokes to verify focus handling and status updates remain in sync
 
 ## Runbook
-- Configure base URLs and keys from **_includes/env.md**
-- Wire `/v1/health` responses into the `swiftcurseskit` view model that feeds service row status indicators
-- Map `/v1/capabilities` payloads into `swiftcurseskit` list/detail components so operators can drill into capability explanations
-- Launch the dashboard with `swift run tutor-dashboard` (or `--preview` for a headless snapshot) to verify the table renders with live status data
+1. Configure base URLs and keys from **_includes/env.md** (`cp .env.example .env` if needed, then export with `source .env`).
+2. Build the dashboard target to ensure dependencies resolve: `swift build`.
+3. Launch the curses UI with `swift run tutor-dashboard` (append `--preview` to capture a headless snapshot) and wait for the services table to populate.
+4. Use the arrow keys or `Tab` to move focus between rows; verify the health column flips to green once `/v1/health` returns `200` and that the capabilities column lists `/v1/capabilities` responses with "Needs: <capability>" for gaps.
+5. Press the manual refresh binding (configured per `swiftcurseskit` defaults) and confirm the poll timer still re-runs every ~5 s without breaking keyboard navigation.
+6. Exit with `q`; review the terminal log output to confirm both `/v1/health` and `/v1/capabilities` calls succeeded before handing off.
 
 ## Hand-off to Codex
 > Build a service table that reads from the listed specs and queries `/v1/health` and `/v1/capabilities`. No hardcoded endpoints. Ensure Codex implementers connect those endpoints to the `swiftcurseskit` views described above, preserving the refresh cadence and keyboard navigation affordances.

--- a/docs/tutor/modules/02-corpus-bootstrap.md
+++ b/docs/tutor/modules/02-corpus-bootstrap.md
@@ -28,9 +28,12 @@ A new panel in the existing `swiftcurseskit` app that routes to the bootstrap AP
 - Validate that the panel repolls Awareness on an interval after corpus creation and stops once the baseline is shown
 
 ## Runbook
-- Ensure FountainStore, Bootstrap, and Awareness URLs are configured (see **_includes/env.md**) and routed through the `swiftcurseskit` configuration layer.
-- Register the new panel in the router so `/bootstrap` commands or menu entries open the curses view instead of a placeholder.
-- Keep the Awareness poller scoped to the panel view and reuse existing module logging so refresh cadence issues surface in the standard terminal status area.
+1. Export FountainStore, Bootstrap, and Awareness URLs from **_includes/env.md** (`source .env` in the repo root before launching).
+2. Build the dashboard to validate the new panel target compiles: `swift build`.
+3. Run the terminal app: `swift run tutor-dashboard --panel bootstrap` (use the router shortcut you wired if different) and confirm the Bootstrap pane appears.
+4. Navigate the curses form with `Tab`/arrow keys, submit a corpus seed, and watch the status area for the `POST /bootstrap` confirmation (corpus id + version).
+5. After submission, leave the pane open for two refresh cycles; confirm Awareness data streams into the adjacent widgets without freezing keyboard focus.
+6. Exit with `q` and review the log buffer to ensure FountainStore received the created corpus and Awareness polling completed without errors.
 
 ## Hand-off to Codex
 > Implement the curses bootstrap flow end-to-end: route `/bootstrap` into the new `swiftcurseskit` panel, submit the form to `POST /bootstrap`, and wire the existing Awareness polling utilities so baseline updates hydrate the curses widgets without breaking module style conventions.

--- a/docs/tutor/modules/03-awareness-baselines-drift-reflections.md
+++ b/docs/tutor/modules/03-awareness-baselines-drift-reflections.md
@@ -5,7 +5,10 @@
 ## What you’ll ship
 A curses module that layers baseline CRUD, scrollable drift graphs, and a reflections timeline onto the Swift dashboard.
 
-> **Setup**: Reuse the shared curses fixtures from Module 02—`swiftcurseskit` mocks, `AwarenessService` stubs, and the `DashboardHarness` integration harness—so acceptance checks can assert keyboard navigation, pane refresh cadence, and persistence wiring without duplicating scaffolding.
+## Setup
+- Reuse the shared curses fixtures from Module 02—`swiftcurseskit` mocks, `AwarenessService` stubs, and the `DashboardHarness` integration harness—so acceptance checks can assert keyboard navigation, pane refresh cadence, and persistence wiring without duplicating scaffolding.
+- Populate the `.env` variables from **_includes/env.md** so baseline, drift, and reflections endpoints resolve during local runs.
+- Link the Awareness client mocks into your unit tests to simulate baseline/drift/reflection responses before hitting live services.
 
 ## Specs to read
 - `openapi/baseline-awareness.yml`
@@ -24,9 +27,13 @@ A curses module that layers baseline CRUD, scrollable drift graphs, and a reflec
 - Exercise reflections pagination to confirm cursor persistence and keyboard shortcut routing across panes
 
 ## Runbook
-- Depend on corpus id from Module 02; reuse environment from **_includes/env.md**
-- Wire Awareness endpoints into the `swiftcurseskit` view models: `BaselineListViewModel`, `DriftViewModel`, and `ReflectionsTimelineViewModel` should orchestrate data pulls while delegating rendering to existing dashboard components.
-- Maintain curses UX constraints—non-blocking network calls, fixed-width columns, and shared status bar updates—by scheduling async refresh work on the dashboard's poll loop.
+1. Source your `.env` so Awareness endpoints are available (`source .env`) and ensure a corpus id exists from Module 02.
+2. Build the dashboard to confirm the new panes compile: `swift build`.
+3. Launch the curses UI: `swift run tutor-dashboard --panel awareness` (adjust the router argument to target your baseline/drift/reflections workspace).
+4. Hit `b`, `d`, and `r` to swap between Baseline, Drift, and Reflections panes; verify each refreshes on the shared poll loop without halting other panes.
+5. Create a new baseline via the UI and confirm the version list updates on the next tick; scroll with `j`/`k` to highlight the active version and inspect drift graphs.
+6. Page through reflections with `[` and `]`, ensuring cursor position persists and timestamps/authors render as expected.
+7. Quit with `q` and check logs for successful `/baselines`, `/drift`, and `/reflections` calls before handing off.
 
 ## Hand-off to Codex
 > Implement baseline CRUD, render drift/pattern insights, and extend the reflections timeline by wiring Awareness HTTP clients into `swiftcurseskit` view models while preserving the dashboard’s keyboard and refresh behaviors.

--- a/docs/tutor/modules/04-planner-and-llm-gateway-loop.md
+++ b/docs/tutor/modules/04-planner-and-llm-gateway-loop.md
@@ -5,6 +5,11 @@
 ## What you’ll ship
 A two-pane Swift `swiftcurseskit` dashboard module: the left pane hosts the planner step list (creation, navigation, status), the right pane renders execution details and tool outputs. Keyboard focus should move predictably between panes (e.g., `Tab` to toggle, arrow keys within a pane) and the screen should maintain a persistent header/footer for status and capability messaging.
 
+## Setup
+- Load Planner, Function Caller, and gateway URLs from **_includes/env.md** so local runs can reach each service.
+- Add the planner module target to `Package.swift` and wire dependencies on the Planner and Function Caller client libraries.
+- Register the planner workspace with the curses router (menu entry or hotkey) so it can be launched via `swift run` arguments during verification.
+
 ## Specs to read
 - `openapi/planner.yml`
 - `openapi/function-caller.yml`
@@ -21,9 +26,13 @@ A two-pane Swift `swiftcurseskit` dashboard module: the left pane hosts the plan
 - Curses interaction test pass: simulated key events traverse planner steps, trigger execute, and confirm status refresh behavior
 
 ## Runbook
-- Ensure Planner and Function Caller URLs are set; surface `NotSupported` if capabilities are missing
-- Map `/planner` responses into planner pane views and `/planner/execute` payloads into execution detail views via `swiftcurseskit`
-- Keep capability-aware messaging in the curses UI header/footer so missing planner/execute capabilities show actionable guidance
+1. Export Planner, Function Caller, and gateway environment variables (`source .env`) and confirm credentials resolve.
+2. Build the dashboard module: `swift build` (or target the specific planner executable if split out).
+3. Launch the planner workspace: `swift run tutor-dashboard --panel planner`.
+4. Trigger `POST /planner` from inside the curses pane and confirm the ordered steps appear in the left panel with focus on step 1.
+5. Execute the highlighted plan (`Enter`/designated key) and watch the right pane stream Function Caller outputs; manually press the refresh key to ensure live updates continue afterward.
+6. Toggle focus with `Tab`/arrow keys to confirm keyboard routing remains stable while the poller updates statuses.
+7. Quit (`q`) and verify logs show paired `/planner` and `/planner/execute` calls plus any surfaced `NotSupported` capabilities.
 
 ## Hand-off to Codex
 > Implement plan → execute controls wired to the documented endpoints only, rendering planner and execution panes with `swiftcurseskit` components and maintaining capability-aware status messaging in the curses UI.

--- a/docs/tutor/modules/05-tools-factory-to-function-caller.md
+++ b/docs/tutor/modules/05-tools-factory-to-function-caller.md
@@ -9,6 +9,11 @@ An end-to-end tool management workflow inside `swiftcurseskit`:
 - An invocation panel that calls Function Caller endpoints and streams output into a scrolling results history buffer.
 - Terminal UI rendering that surfaces past results inline (status, timestamp, payload excerpts) so operators can review history without leaving the curses session.
 
+## Setup
+- Import Tools Factory and Function Caller client libraries into the dashboard target; update `Package.swift` dependencies if missing.
+- Load service credentials via **_includes/env.md** so registration/invocation calls succeed in local runs.
+- Seed a test corpus/tool scenario (can reuse Module 02 data) to validate result persistence when you exercise the workflow.
+
 ## Specs to read
 - `openapi/tools-factory.yml`
 - `openapi/function-caller.yml`
@@ -29,9 +34,13 @@ An end-to-end tool management workflow inside `swiftcurseskit`:
 - Confirm results history refresh cadence matches the configured poll interval and reflects new corpus entries
 
 ## Runbook
-- Configure Tools Factory and Function Caller URLs, wiring them into the shared `swiftcurseskit` view models used by both panes
-- Ensure invocation responses append to the persistent results history buffer rendered in the curses interface
-- Monitor poll cadence to keep the results history synchronized without flicker; adjust timer intervals if rendering lags
+1. Export your `.env` file so Tools Factory, Function Caller, and FountainStore URLs are available.
+2. Build the dashboard target: `swift build` (or the executable name you registered for the workflow).
+3. Start the curses workflow: `swift run tutor-dashboard --panel tools`.
+4. Register a tool from the catalog pane (select by `operationId`, submit with `Enter`); confirm the registration success banner appears and the tool surfaces in the invocation list.
+5. Move focus to the invocation pane, press the rerun binding (`r` by default) to invoke the highlighted tool, and watch the streaming output buffer populate.
+6. Leave the dashboard open for two poll cycles to verify the results history refreshes automatically and persists the new record to the corpus.
+7. Exit (`q`) and inspect logs to ensure the Tools Factory registration, Function Caller invocation, and FountainStore persistence calls all completed.
 
 ## Hand-off to Codex
 > Wire Tools Factory and Function Caller endpoints into the shared `swiftcurseskit` view models, implement the curses panes for registration/invocation, and persist invocation outputs to the on-screen history and corpus.

--- a/docs/tutor/modules/06-teatro-gui-spec-only-integration.md
+++ b/docs/tutor/modules/06-teatro-gui-spec-only-integration.md
@@ -5,6 +5,11 @@
 ## What you’ll ship
 A curses workspace built with `swiftcurseskit` that renders corpora, baseline lineage, and planner execution history straight from the documented APIs.
 
+## Setup
+- Reuse the curses dashboard shell from prior modules and register a Teatro workspace entry in the router.
+- Load FountainStore, Awareness, Planner, and Function Caller URLs from **_includes/env.md** to keep the panes spec-only.
+- Prepare fixture JSON responses for each pane to validate parsing before pointing at live services.
+
 ## Specs to read
 - The same specs from Modules 02–05 (persist, awareness, planner, tools, function caller)
 
@@ -21,8 +26,13 @@ A curses workspace built with `swiftcurseskit` that renders corpora, baseline li
 - Snapshot the curses output against canned API fixtures to prevent regression drift
 
 ## Runbook
-- Wire FountainAI client responses directly into `swiftcurseskit` list/detail components for each pane
-- Ensure keyboard commands stay in sync with HTTP refresh loops instead of GUI affordances
+1. Source your `.env` so all service URLs are available in the shell.
+2. Build the dashboard: `swift build`.
+3. Launch the Teatro workspace: `swift run tutor-dashboard --panel teatro` (or the menu shortcut you registered).
+4. Cycle between the corpora, baseline lineage, and planner history panes using the documented hotkeys; confirm each pane fetches data exclusively via HTTP (watch logs for matching endpoints).
+5. Attempt to edit a record and verify the UI stays read-only—no extra requests should fire beyond the documented GET calls.
+6. Leave the dashboard running through two refresh intervals to observe the spec responses refreshing without hidden GUI shortcuts.
+7. Exit with `q` and review console output to confirm only documented endpoints were invoked.
 
 ## Hand-off to Codex
 > Surface the HTTP responses from the documented APIs in the `swiftcurseskit` panes and keep capability guidance visible inside the terminal experience. No direct file or DB access.

--- a/docs/tutor/modules/07-observability-and-guards.md
+++ b/docs/tutor/modules/07-observability-and-guards.md
@@ -5,6 +5,11 @@
 ## What you’ll ship
 Swift `swiftcurseskit` indicators that paint budget/rate-limit states, prompt overlays for destructive operations, and guard status banners that refresh alongside the terminal dashboard.
 
+## Setup
+- Add gateway client dependencies (budget breaker, rate limiter, guard) to the dashboard target.
+- Export gateway secrets and URLs using **_includes/env.md** before running locally.
+- Capture sample responses/headers for throttled and approved calls to drive automated tests.
+
 ## Specs to read
 - Gateway OpenAPIs: budget breaker, rate limiter, destructive operations guard, security sentinel
 
@@ -19,8 +24,13 @@ Swift `swiftcurseskit` indicators that paint budget/rate-limit states, prompt ov
 - Trigger guard rails to confirm keyboard confirmation flows mirror gateway decisions and that API contracts remain honored
 
 ## Runbook
-- Configure gateway base URLs and route response headers/metadata into `swiftcurseskit` data sources feeding the dashboard widgets
-- Persist and rehydrate operator prompts within the curses UI so guard dialogues survive screen refreshes and reconnects
+1. `source .env` to load gateway endpoints and API keys into your session.
+2. Build the dashboard target: `swift build`.
+3. Start the observability workspace: `swift run tutor-dashboard --panel guards` (or equivalent hotkey).
+4. Trigger API calls that return rate-limit headers and confirm the dashboard widgets update without flicker on the next poll tick.
+5. Initiate a destructive action and verify the curses prompt overlay appears, requires keyboard confirmation, and logs the guard decision.
+6. Simulate throttling/approval scenarios via fixtures or staging services to ensure banners and overlays react correctly.
+7. Exit with `q` and review logs for captured headers, guard prompts, and confirmation that the poll cadence stayed active.
 
 ## Hand-off to Codex
 > Wire gateway metadata into the Swift terminal UI via `swiftcurseskit` components and maintain operator prompts end-to-end in the curses experience.

--- a/docs/tutor/modules/08-reasoning-streams-midi2-optional.md
+++ b/docs/tutor/modules/08-reasoning-streams-midi2-optional.md
@@ -5,6 +5,11 @@
 ## What you’ll ship
 A Swift `swiftcurseskit` dashboard that renders the SSE-over-MIDI stream viewer in the left pane with event metadata on the right, anchored by a status bar showing transport state and connection health. The dashboard must map keyboard controls (`space` toggles play/pause, `r` rewinds to the first event, `n` steps to the next event) and surface on-screen hints so terminal users discover the bindings.
 
+## Setup
+- Ensure the MIDI2 client adapter target links against the platform MIDI libraries and is referenced from `Package.swift`.
+- Export planner/awareness streaming URLs plus `MIDI_CLIENT_NAME` as described in **_includes/env.md** prior to running.
+- Prepare fixture SSE event logs so you can replay deterministic sequences during tests.
+
 ## Specs to read
 - Planner/Awareness streaming endpoints
 - MIDI2 transport interfaces (consumer side)
@@ -20,10 +25,13 @@ A Swift `swiftcurseskit` dashboard that renders the SSE-over-MIDI stream viewer 
 - Integration test that exercises redraw cadence (e.g., 250 ms ticker) and verifies layout recovery after simulated `SIGWINCH`
 
 ## Runbook
-- Bind planner and awareness SSE endpoints to `swiftcurseskit` stream widgets via the MIDI2 client adapter; confirm the MIDI client identifier matches the terminal session and is discoverable to the OS MIDI stack.
-- Export `MIDI_CLIENT_NAME` (or platform equivalent) before launching the curses dashboard so the MIDI2 bridge registers correctly, then `swift run` the module with terminal colors enabled.
-- Validate the dashboard by connecting to staging endpoints first, watching the transport status bar for latency/backpressure indicators, and only then switch to production URLs.
-- Document the expected keyboard shortcuts in the deployment notes so on-call engineers can triage from an SSH session without a pointing device.
+1. `source .env` to load planner/awareness streaming URLs and ensure `MIDI_CLIENT_NAME` is set for the terminal session.
+2. Build the dashboard with MIDI support: `swift build`.
+3. Launch the MIDI workspace: `swift run tutor-dashboard --panel midi-stream --color` (append `--fixtures <path>` if you support replay files).
+4. Observe the connection banner to confirm the MIDI bridge announces the configured client name and the SSE stream begins populating the left pane.
+5. Exercise transport controls—`space` (play/pause), `r` (rewind), `n` (next event)—and ensure the status bar updates to reflect the current state while the right pane shows matching metadata.
+6. Resize the terminal to simulate `SIGWINCH` and verify the curses layout recovers without tearing or dropping events.
+7. Exit with `q` and capture logs that prove the stream consumed planner/awareness events successfully before switching to production endpoints.
 
 ## Hand-off to Codex
 > Implement a curses-native event stream viewer that wires planner/awareness SSE endpoints into `swiftcurseskit` components, includes keyboard transport controls, and configures the MIDI client for terminal execution.


### PR DESCRIPTION
## Summary
- add explicit setup sections for modules 03-08 so contributors can configure environments consistently
- expand every module runbook with step-by-step commands for building, launching, and validating the Swift curses dashboards
- highlight keyboard interactions and log checks to help operators confirm services respond correctly before hand-off

## Testing
- not run (documentation changes only)

------
https://chatgpt.com/codex/tasks/task_b_68cff7df6b808333b097fcc55bfd81e6